### PR TITLE
Add documentation for `wallet_registerOnboarding` method

### DIFF
--- a/03_API_Reference/03_Experimental_APIs.md
+++ b/03_API_Reference/03_Experimental_APIs.md
@@ -1,6 +1,8 @@
 # Experimental APIs
 
-## wallet_watchAsset
+## `wallet_` RPC methods
+
+### wallet_watchAsset
 
 Most all Ethereum wallets display some set of tokens, usually from a centrally curated registry of tokens.
 
@@ -29,6 +31,11 @@ ethereum.sendAsync({
 ```
 
 We even created a sample Dapp so developers could suggest their tokens to users with a simple hyperlink, without a line of code. [Visit it here](https://github.com/MetaMask/Add-Token).
+
+### wallet_registerOnboarding
+
+This method is in support of a new onboarding process that helps users find their way back to the site that requested MetaMask be installed. This RPC method is used by the `@metamask/onboarding` library to tell MetaMask which site initiated onboarding. It should be send directly from the site doing the onboarding; there are no parameters. We recommend using our `@metamask/onboarding` library instead of using this method directly.
+
 
 ## `ethereum._metamask`
 


### PR DESCRIPTION
This method is used by our `@metamask/onboarding` library to facilitate onboarding. It has been documented as an experimental API because it is a public-facing method, though we have no immediate plans to standardize this method, and we don't encourage its use directly.

A new section was created called "`wallet_` RPC methods" to differentiate the two experimental RPC methods from the JavaScript experimental provider API.