### PR TITLE
Remove google analytics plugin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,9 +49,6 @@ module.exports = _ctx => ({
       updatePopup: true
     }],
     ['@vuepress/medium-zoom', true],
-    ['@vuepress/google-analytics', {
-      ga: 'UA-128189152-1'
-    }],
     ['container', {
       type: 'vue',
       before: '<pre class="vue-container"><code>',


### PR DESCRIPTION
We had some random-ass Google analytics plugin in our config. It's now removed.