### PR TITLE
Fix current provider docs

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -180,7 +180,7 @@ The provider supports listening for some events:
 
 - `accountsChanged`, returns the currently available account(s).
 - `networkChanged`, returns the current network ID as a decimal string.
-- `chainIdChanged`, returns the current chain ID string.
+- `chainIdChanged`, returns the current chain ID as a hexadecimal string.
 
 #### Example
 


### PR DESCRIPTION
Our current provider docs included a new API that has been cancelled. We have a PR for the new, new API, but we shouldn't merge that until the new API is in fact live.

This PR reverts our provider documentation to its old state, with some fixes.