### PR TITLE
Rename RPC API page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -96,7 +96,7 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
       collapsable: false,
       children: [
         'ethereum-provider',
-        'json-rpc-api',
+        'rpc-api',
         'experimental-apis',
         'signing-data',
       ]

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -13,7 +13,7 @@ MetaMask was created out of the needs of creating more secure and usable Ethereu
 
 - [Get started here](/guide/getting-started.html)
 - [Read the full docs of our injected provider](/guide/ethereum-provider.html)
-- [Read the full docs of the JSON RPC API](/guide/json-rpc-api.html)
+- [Read the full docs of the JSON RPC API](/guide/rpc-api.html)
 - [Read about other supported APIs](/guide/experimental-apis.html)
 
 ## Account Management

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -12,9 +12,9 @@ Welcome to MetaMask’s Developer Documentation. This documentation is for learn
 MetaMask was created out of the needs of creating more secure and usable Ethereum-based web sites. In particular, it handles account management and connecting the user to the blockchain.
 
 - [Get started here](/guide/getting-started.html)
-- [Read the full docs of our injected provider](/guide/ethereum-provider.html)
-- [Read the full docs of the JSON RPC API](/guide/rpc-api.html)
-- [Read about other supported APIs](/guide/experimental-apis.html)
+- [Learn more about our JavaScript Provider API](/guide/ethereum-provider.html)
+- [Learn more about our RPC API](/guide/rpc-api.html)
+- [Learn more about our experimental APIs](/guide/experimental-apis.html)
 
 ## Account Management
 
@@ -26,7 +26,7 @@ This security feature also comes with developer convenience: For developers, you
 
 MetaMask comes pre-loaded with nice and fast connections to the Ethereum blockchain and several test networks via our friends at [Infura](https://infura.io/). This allows users to get started without synchronizing a full node, while still providing the option to upgrade their security the blockchain provider of their choice over time.
 
-Today, MetaMask is compatible with any blockchain that exposes an [Ethereum Compatible JSON RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC), including custom and private blockchains. For development, we recommend running a test blockchain like [Ganache](https://www.trufflesuite.com/ganache).
+Today, MetaMask is compatible with any blockchain that exposes an [Ethereum-compatible JSON RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC), including custom and private blockchains. For development, we recommend running a test blockchain like [Ganache](https://www.trufflesuite.com/ganache).
 
 We’re aware that there are constantly more and more private blockchains that people are interested in connecting MetaMask to, and [we are continuously building towards easier and easier integration with these many options](https://medium.com/metamask/metamasks-vision-for-multiple-network-support-4ffbee9ec64d).
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -125,7 +125,7 @@ ethereum.sendAsync(
       // Handle the error
     } else {
       // This always returns a JSON RPC response object.
-      // The result varies by method, per the JSON RPC API.
+      // The result varies by method, per the RPC method specification
       // For example, this method will return a transaction hash on success.
       const result = response.result;
     }

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -11,7 +11,7 @@ if (typeof window.ethereum !== 'undefined') {
 }
 ```
 
-The provider API itself is very simple, and wraps [Ethereum JSON-RPC](./JSON-RPC-API) formatted messages, which is why developers usually use a convenience library for interacting with the provider,
+The provider API itself is very simple, and wraps [Ethereum JSON-RPC](./rpc-api) formatted messages, which is why developers usually use a convenience library for interacting with the provider,
 like [web3](https://www.npmjs.com/package/web3), [ethers](https://www.npmjs.com/package/ethers), [truffle](https://truffleframework.com/), [Embark](https://embark.status.im/), or others.
 From those tools, you can generally find sufficient documentation to interact with the provider, without reading this lower-level API.
 

--- a/docs/guide/json-rpc-api.md
+++ b/docs/guide/json-rpc-api.md
@@ -1,7 +1,0 @@
-# The Ethereum RPC API
-
-MetaMask uses the `ethereum.sendAsync()` (and soon, `ethereum.send()`) API to wrap an RPC API which is based on an interface exposed by all Ethereum clients, with some extra methods that are provided by MetaMask, as a key-holding signer. You can look up how to pass these methods to the `window.ethereum` object [here](./Ethereum-Provider).
-
-This document is a cross-post of [EIP 1474](https://github.com/ethereum/EIPs/pull/1474/), which aims to standardize the declaration of this interface.
-
-For the full API, please see [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md).

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -1,0 +1,5 @@
+# The Ethereum RPC API
+
+MetaMask uses the `ethereum.sendAsync()` (and soon, `ethereum.request()`) API to wrap an RPC API which is based on an interface exposed by all Ethereum clients, with some extra methods that are provided by MetaMask, as a key-holding signer. You can look up how to pass these methods to the `window.ethereum` object [here](./Ethereum-Provider).
+
+For the full API, please see [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md).


### PR DESCRIPTION
### Changes
- `json-rpc-api.md` -> `rpc-api.md`
  - It's supposed to be a transport-agnostic RPC API. JSON-RPC is our concern, not the consumer's.
- Minor content update of the RPC API page