### PR TITLE
Update notices about the timeline of API changes

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -21,10 +21,8 @@ However, for developers of convenience libraries, and for developers who would l
 
 ## Upcoming Provider Changes
 
-In **Q3 2020**, we are introducing a new version of this API. The existing API will mostly remain in place, however, in **late Q3/early Q4 2020**, we will break parts of the existing API. We encourage you to
+In **Q4 2020**, we will be making some breaking changes to the provider API. The biggest change is that we will stop injecting `window.web3`. We encourage you to
 [read more about this here](https://github.com/MetaMask/metamask-extension/issues/8077).
-
-Documentation for the new API will be released as soon as it's in production.
 
 ## List of Chain and Network IDs
 

--- a/docs/guide/experimental-apis.md
+++ b/docs/guide/experimental-apis.md
@@ -45,13 +45,9 @@ Each method and its intended use is described below.
 
 ### `ethereum._metamask.isEnabled: () => boolean` (To Be Removed)
 
-**Note:** This will be removed in **early 2020**.
-
 This method returns a `boolean` indicating if the current domain has access to user accounts. This is useful for determining if a user has approved account access for the current session.
 
 ### `ethereum._metamask.isApproved: () => Promise<boolean>` (To Be Removed)
-
-**Note:** This will be removed in **early 2020**.
 
 This method returns a `Promise` that resolves to a `Boolean` indicating if the current domain has a cached approval. This is useful for determining if an approval popup will show when `ethereum.enable()` is called, since it indicates if a past approval exists.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,6 @@ if (typeof window.ethereum !== 'undefined') {
 ```
 
 You can review the full API for the `windows.ethereum` object [here](./ethereum-provider.html).
-Note that in **early 2020**, we are introducing significant changes to this API, and we recommend that you refer to its documentation.
 
 ### Running a Test Network
 


### PR DESCRIPTION
There were a few notices about upcoming API changes that were no longer accurate. The notices have been removed for the time being, until we can announce something more precise.

The notice about upcoming provider changes was preserved, so that users could still be directed to the tracking issue. The notice was re-worded to be more accurate though. We should add more detail here when we know more.