### PR TITLE
Update links

### DIFF
--- a/00_Examples/00_Low_Level_Ether_Transfer.md
+++ b/00_Examples/00_Low_Level_Ether_Transfer.md
@@ -136,7 +136,7 @@ Now that was all very low level, but should show you how MetaMask works at its s
 Now you can read more about this [ethereum API](./API_Reference), or maybe get acquainted with a convenience library so you don't have to interact with it directly:
 
 - [ethjs](https://www.npmjs.com/package/ethjs)
-- [truffle](https://truffleframework.com/)
-- [Embark](https://embark.status.im/)
+- [truffle](https://www.trufflesuite.com/)
+- [Embark](https://framework.embarklabs.io/)
 - [web3](https://www.npmjs.com/package/web3)
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -3,7 +3,7 @@
 Welcome to MetaMask’s Developer Documentation. This documentation is for learning to develop applications for MetaMask.
 
 - You can find the latest version of MetaMask on our [official website](https://metamask.io/).
-- For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).
+- For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/).
 - For up to the minute news, follow our [Peepeth](https://peepeth.com/MetaMask/), [Twitter](https://twitter.com/metamask_io) or [Medium](https://medium.com/metamask) pages.
 - To learn how to contribute to the MetaMask project itself, visit our [Internal Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
 
@@ -26,7 +26,7 @@ This security feature also comes with developer convenience: For developers, you
 
 MetaMask comes pre-loaded with fast connections to the Ethereum blockchain and several test networks via our friends at [Infura](https://infura.io/). This allows you to get started without synchronizing a full node, while still providing the option to upgrade your security and use the blockchain provider of your choice.
 
-Today, MetaMask is compatible with any blockchain that exposes an [Ethereum-compatible JSON RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC), including custom and private blockchains. For development, we recommend running a test blockchain like [Ganache](https://www.trufflesuite.com/ganache).
+Today, MetaMask is compatible with any blockchain that exposes an [Ethereum-compatible JSON RPC API](https://eth.wiki/json-rpc/API), including custom and private blockchains. For development, we recommend running a test blockchain like [Ganache](https://www.trufflesuite.com/ganache).
 
 We’re aware that there are constantly new private blockchains that people are interested in connecting MetaMask to, and [we are building towards easier integration with these many options](https://medium.com/metamask/metamasks-vision-for-multiple-network-support-4ffbee9ec64d).
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -12,7 +12,7 @@ if (typeof window.ethereum !== 'undefined') {
 ```
 
 The provider API itself is very simple, and wraps [Ethereum JSON-RPC](./rpc-api) formatted messages, which is why developers usually use a convenience library for interacting with the provider,
-like [web3](https://www.npmjs.com/package/web3), [ethers](https://www.npmjs.com/package/ethers), [truffle](https://truffleframework.com/), [Embark](https://embark.status.im/), or others.
+like [web3](https://www.npmjs.com/package/web3), [ethers](https://www.npmjs.com/package/ethers), [truffle](https://www.trufflesuite.com/), [Embark](https://framework.embarklabs.io/), or others.
 From those tools, you can generally find sufficient documentation to interact with the provider, without reading this lower-level API.
 
 However, for developers of convenience libraries, and for developers who would like to use features that are not yet supported by their favorite libraries, knowledge of the provider API is essential.
@@ -97,7 +97,7 @@ _To be superseded by the Promise-returning `ethereum.send()` method in_
 _[EIP 1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md). (See also **[the new API](#new-api)**.)_
 
 Sends a message to the web3 browser. Message format maps to the format of
-[the Ethereum JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods).
+[the Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API#json-rpc-methods).
 
 Here's an example of everyone's favorite method, `eth_sendTransaction`, which is both how Ether is sent, and how smart contract methods are called:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,7 +23,7 @@ Note that in **early 2020**, we are introducing significant changes to this API,
 
 ### Running a Test Network
 
-In the top right menu of MetaMask, select the network that you are currently connected to. Among several popular defaults, you'll find `Custom RPC` and `Localhost 8545`. These are both useful for connecting to a test blockchain, like [ganache](https://truffleframework.com/ganache). You can quickly install and start Ganache if you have `npm` installed with `npm i -g ganache-cli && ganache-cli`.
+In the top right menu of MetaMask, select the network that you are currently connected to. Among several popular defaults, you'll find `Custom RPC` and `Localhost 8545`. These are both useful for connecting to a test blockchain, like [ganache](https://www.trufflesuite.com/ganache). You can quickly install and start Ganache if you have `npm` installed with `npm i -g ganache-cli && ganache-cli`.
 
 Ganache has some great features for starting your application with different states. If your application starts with the `-m` flag, you can feed it the same seed phrase you have in your MetaMask, and the test network will give each of your first 10 accounts 100 test ether, which makes it easier to start work.
 
@@ -149,8 +149,8 @@ Convenience libraries exist for a variety of reasons.
 Some of them simplify the creation of specific user interface elements, some entirely manage the user account onboarding, and others give you a variety of methods of interacting with smart contracts, for a variety of API preferences, from promises, to callbacks, to strong types, and on.
 
 The provider API itself is very simple, and wraps
-[Ethereum JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods)
+[Ethereum JSON-RPC](https://eth.wiki/json-rpc/API#json-rpc-methods)
 formatted messages, which is why developers usually use a convenience library for interacting
 with the provider, like [ethers](https://www.npmjs.com/package/ethers), [web3](https://www.npmjs.com/package/web3),
-[truffle](https://truffleframework.com/), [Embark](https://embark.status.im/), or others. From those tools,
+[truffle](https://www.trufflesuite.com/), [Embark](https://framework.embarklabs.io/), or others. From those tools,
 you can generally find sufficient documentation to interact with the provider, without reading this lower-level API.

--- a/docs/guide/initializing-dapps.md
+++ b/docs/guide/initializing-dapps.md
@@ -14,7 +14,7 @@ Every account in Ethereum has an address, whether it's an external key-pair acco
 
 ## The Contract ABI
 
-In Ethereum, [The ABI Specification](https://solidity.readthedocs.io/en/develop/abi-spec.html) is a way to encode the interface of a smart contract in a way that your user interface can make sense of. It is an array of method-describing objects, and when you feed this and the address into a contract-abstraction library like [web3](https://www.npmjs.com/package/web3), [truffle](https://truffleframework.com/), [ethjs](https://www.npmjs.com/package/ethjs), [Embark](https://embark.status.im/), or others, this `ABI` tells those libraries about what methods to provide, and how to compose transactions to call those methods.
+In Ethereum, [The ABI Specification](https://solidity.readthedocs.io/en/develop/abi-spec.html) is a way to encode the interface of a smart contract in a way that your user interface can make sense of. It is an array of method-describing objects, and when you feed this and the address into a contract-abstraction library like [web3](https://www.npmjs.com/package/web3), [truffle](https://www.trufflesuite.com/), [ethjs](https://www.npmjs.com/package/ethjs), [Embark](https://framework.embarklabs.io/), or others, this `ABI` tells those libraries about what methods to provide, and how to compose transactions to call those methods.
 
 ## The Contract Bytecode
 

--- a/docs/guide/registering-function-names.md
+++ b/docs/guide/registering-function-names.md
@@ -41,6 +41,6 @@ You can look at the FUNCTIONHASHES section on remix.ethereum.org by loading the 
 
 You can also use the [signature registry](https://rinkeby.etherscan.io/address/0x0c0831fb1ec7442485fb41a033ba188389a990b4) deployed on rinkeby but should note that **MetaMask reads from the mainnet eth-method-registry endpoint, regardless of user's network**
 
-[eth-method-registry](https://github.com/danfinlay/eth-method-registry) is used to lookup methods in MetaMask.
+[eth-method-registry](https://github.com/MetaMask/eth-method-registry) is used to lookup methods in MetaMask.
 
 This [stack exchange](https://ethereum.stackexchange.com/questions/59678/metamask-shows-unknown-function-when-calling-method-send-function) answer is a good **tldr**.

--- a/docs/guide/registering-your-token.md
+++ b/docs/guide/registering-your-token.md
@@ -4,7 +4,7 @@ When a user opens their MetaMask, they are shown a variety of assets, including 
 
 While this is possible using our UI with the `Add Token` button, that process can be cumbersome, and involves the user interacting with contract addresses, and is very error prone.
 
-You can greatly improve the security and experience of users adding your token to their MetaMask by taking advantage of the `wallet_watchAsset` API as defined in [EIP 747](https://github.com/estebanmino/EIPs/blob/master/EIPS/eip-747.md).
+You can greatly improve the security and experience of users adding your token to their MetaMask by taking advantage of the `wallet_watchAsset` API as defined in [EIP 747](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-747.md).
 
 ## Code-free Example
 

--- a/docs/guide/sending-transactions.md
+++ b/docs/guide/sending-transactions.md
@@ -123,7 +123,7 @@ Contract creation occurs when there is no `to` value but there is a `data` value
 
 ### Value [optional]
 
-Hex-encoded value of the network's native currency to send. On the Main Ethereum network, this is [ether](https://www.ethereum.org/ether), which is denominated in _wei_, which is `1e-18` ether.
+Hex-encoded value of the network's native currency to send. On the Main Ethereum network, this is [ether](https://www.ethereum.org/eth), which is denominated in _wei_, which is `1e-18` ether.
 
 Please note that these numbers often used in Ethereum are far higher precision than native JavaScript numbers, and can cause unpredictable behavior if not anticipated. For this reason, we highly recommend using [BN.js](https://github.com/indutny/bn.js/) when manipulating values intended for the blockchain.
 

--- a/docs/guide/signing-data.md
+++ b/docs/guide/signing-data.md
@@ -3,7 +3,7 @@
 Since MetaMask makes cryptographic keys available to each user, websites can use these signatures for a variety of uses. Here are a few guides related to specific use cases:
 
 - [Authenticating websites](https://medium.com/hackernoon/writing-for-blockchain-wallet-signature-request-messages-6ede721160d5)
-- Some examples of signing off-chain messages for an on-chain protocol from our [MetaTransaction Hackathon](https://medium.com/metamask/our-metatransaction-hackathon-winner-a620551ccb9b?source=collection_home---4------2-----------------------)
+- Some examples of signing off-chain messages for an on-chain protocol from our [MetaTransaction Hackathon](https://medium.com/metamask/our-metatransaction-hackathon-winner-a620551ccb9b)
 
 ## Signing Data with MetaMask
 


### PR DESCRIPTION
All links have been updated to reference the correct address.

* `truffleframework.com` now redirects to `www.trufflesuite.com`, so links have been updated accordingly.
* `embark.status.im` now redirects to `framework.embarklabs.io`, so links have been updated accordingly.
* The JSON-RPC API docs have been moved from the `ethereum` project wiki to `eth.wiki/json-rpc/API`. Any references have been updated to refer to the new location. Links pertaining to the JSON RPC methods specifically link to the `#json-rpc-methods` section.
* The path was removed from the link to our Zendesk support site, so that the browser can negotiate the correct locale. Though in practice I'm not sure whether it supports more than `en-us`.
* The link to the `eth-method-registry` GitHub repository has been updated to reflect the change in ownership
* The "official" version of EIP-747 is now linked, rather than a fork
* The `ethereum.org` page explaining what Ether is has moved from `/ether` to `/eth`, so the link has been updated accordingly.
  `/ether` was redirecting to `/dapps` instead.
* Remove unnecessary query string from the link to our blog post about hackathon winners.