### PR TITLE
v8 Provider Documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -96,6 +96,7 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
       collapsable: false,
       children: [
         'ethereum-provider',
+        'provider-migration',
         'rpc-api',
         'experimental-apis',
         'signing-data',

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -131,6 +131,29 @@ The value of this property can change at any time, and should not be exclusively
 
 A hexadecimal string representing the current chain ID.
 
+### ethereum.autoRefreshOnNetworkChange
+
+::: warning
+The value of this property will only affect MetaMask's behavior if `window.web3` is accessed during the page lifecycle.
+When `window.web3` [is removed](#window-web3-removal), either the effects of this property will change, or it will be removed.
+
+As the consumer of this API, it is your responsbility to handle chain changes using the [`chainChanged` event](#chainChanged).
+We recommend reloading the page on `chainChange` unless you have good reason not to.
+:::
+
+By default, this property is `true`.
+
+If this property is truthy, MetaMask will reload the page in the following cases:
+
+- When the connected chain (network) changes, if `window.web3` has been accessed during the page lifecycle
+- When `window.web3` is accessed, if the connected chain (network) has changed during the page lifecycle
+
+To disable this behavior, set this property to `false` immediately after detecting the provider:
+
+```javascript
+ethereum.autoRefreshOnNetworkChange = false;
+```
+
 ## Methods
 
 ### ethereum.isConnected()
@@ -395,29 +418,6 @@ MetaMask only supported this API before the provider API was standardized via [E
 Because of this, you may find web3 sites that use this API, or other providers that implement it.
 
 ## Legacy Properties
-
-### ethereum.autoRefreshOnNetworkChange (DEPRECATED)
-
-::: warning
-The value of this property will only affect MetaMask's behavior if `window.web3` is accessed during the page lifecycle.
-When `window.web3` [is removed](#window-web3-removal), either the effects of this property will change, or it will be removed.
-
-As the consumer of this API, it is your responsbility to handle chain changes using the [`chainChanged` event](#chainChanged).
-We recommend reloading the page on `chainChange` unless you have good reason not to.
-:::
-
-By default, this property is `true`.
-
-If this property is truthy, MetaMask will reload the page in the following cases:
-
-- When the connected chain (network) changes, if `window.web3` has been accessed during the page lifecycle
-- When `window.web3` is accessed, if the connected chain (network) has changed during the page lifecycle
-
-To disable this behavior, set this property to `false` immediately after detecting the provider:
-
-```javascript
-ethereum.autoRefreshOnNetworkChange = false;
-```
 
 ### ethereum.networkVersion (DEPRECATED)
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -35,9 +35,11 @@ We recommend that all web3 site developers read the [Basic Usage section](#basic
 ## Upcoming Breaking Changes
 
 ::: tip
-These changes are _upcoming._ Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for details.
+These changes are _upcoming._ Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for updates.
 
-If you are new to using the provider, or use [ethers](https://www.npmjs.com/package/ethers), you do not have to worry about these changes, and can skip ahead [to the next section](#api).
+All consumers of this API will be affected by the `eth_chainId` bug fix (see [next subsection](#window-ethereum-api-changes)).
+
+Otherwise, if you are new to using the provider or use [ethers](https://www.npmjs.com/package/ethers), you do not have to worry about these changes, and can skip ahead [to the next section](#api).
 :::
 
 ### `window.ethereum` API Changes
@@ -47,9 +49,9 @@ In **Q3 2020** (date TBD), we are introducing some breaking changes to this API,
 
 At that time, we will:
 
-- Stop emitting `chainIdChanged`, and instead emit `chainChanged`
 - Ensure that chain IDs returned by `eth_chainId` are **not** 0-prefixed
   - For example, instead of `0x01`, we will always return `0x1`, wherever the chain ID is returned or accessible.
+- Stop emitting `chainIdChanged`, and instead emit `chainChanged`
 - Remove the following experimental methods:
   - `ethereum._metamask.isEnabled`
   - `ethereum._metamask.isApproved`
@@ -371,8 +373,8 @@ ethereum._metamask.isUnlocked(): Promise<boolean>;
 ```
 
 This method returns a `Promise` that resolves to a `boolean` indicating if MetaMask is unlocked by the user.
-This is useful for knowing if MetaMask is unlocked in order to provide meaningful instructions to the user during onboarding.
-Note that this does not indicate if the user has exposed any accounts.
+MetaMask must be unlocked in order to perform any operation involving user accounts.
+Note that this method does not indicate if the user has exposed any accounts to the caller.
 
 ## Legacy API
 
@@ -380,8 +382,9 @@ Note that this does not indicate if the user has exposed any accounts.
 You should **never** rely on any of these methods, properties, or events in practice.
 :::
 
-Historically, the Ethereum provider API has been a mess.
-Here, we document the remains of this mess in case you see it used in the wild and wonder what's going on.
+This section documents our legacy provider API.
+MetaMask only supported this API before the provider API was standardized via [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) in 2020.
+Because of this, you may find web3 sites that use this API, or other providers that implement it.
 
 ## Legacy Properties
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -55,7 +55,7 @@ At that time, we will:
   - `ethereum._metamask.isApproved`
 
 These changes _may_ break your website.
-Please read our [migration guide](about:blank) for more details.
+Please read our [migration guide](./provider-migration.html) for more details.
 
 ### `window.web3` Removal
 
@@ -69,7 +69,7 @@ In **Q4 2020** (date TBD), we will:
 - Remove the `ethereum.autoRefreshOnNetworkChange` property
 
 If you rely on the `window.web3` object currently injected by MetaMask, these changes _will_ break your website.
-Please read our [migration guide](about:blank) for more details.
+Please read our [migration guide](./provider-migration.html) for more details.
 
 ## Basic Usage
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -283,7 +283,8 @@ ethereum.on('message', handler: (message: ProviderMessage) => void);
 The MetaMask provider emits this event when it receives some message that the consumer should be notified of.
 The kind of message is identified by the `type` string.
 
-One prominent example of such messages include updates from RPC subscriptions, such as `eth_subscribe`. For such messages, the message `type` will be `eth_subscription`.
+RPC subscription updates are a common use case for the `message` event.
+For example, if you create a subscription using `eth_subscribe`, each subscription update will be emitted as a `message` event with a `type` of `eth_subscription`.
 
 ## Errors
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -48,7 +48,7 @@ In **Q3 2020** (date TBD), we are introducing some breaking changes to this API,
 At that time, we will:
 
 - Stop emitting `chainIdChanged`, and instead emit `chainChanged`
-- Ensure that all `chainId` values are **not** 0-prefixed
+- Ensure that chain IDs returned by `eth_chainId` are **not** 0-prefixed
   - For example, instead of `0x01`, we will always return `0x1`, wherever the chain ID is returned or accessible.
 - Remove the following experimental methods:
   - `ethereum._metamask.isEnabled`

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -238,7 +238,9 @@ ethereum.on('accountsChanged', handler: (accounts: Array<string>) => void);
 ```
 
 The MetaMask provider emits this event whenever the return value of the `eth_accounts` RPC method changes.
-`eth_accounts` returns an array that is either empty or contains a single account address that the user decided to expose to the requesting domain (in the case of a website, identified by the _hostname_ of its URL).
+`eth_accounts` returns an array that is either empty or contains a single account address.
+The returned address, if any, is the address of the most recently used account that the caller is permitted to access.
+Callers are identified by their URL _origin_, which means that all sites with the same origin share the same permissions.
 
 This means that `accountsChanged` will be emitted whenever the user's exposed account address changes.
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -336,6 +336,8 @@ We expose some experimental, MetaMask-specific methods under the `ethereum._meta
 
 ::: danger DANGER
 This will be removed in **Q3 2020**.
+
+Please see the [Using the Provider section](#using-the-provider) for the recommended way of keeping track of user accounts.
 :::
 
 ```typescript
@@ -348,6 +350,8 @@ This method returns a `Promise` that resolves to a `boolean` indicating if the c
 
 ::: danger DANGER
 This will be removed in **Q3 2020**.
+
+Please see the [Using the Provider section](#using-the-provider) for the recommended way of keeping track of user accounts.
 :::
 
 ```typescript

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -121,7 +121,7 @@ Consult [chainid.network](https://chainid.network) for more.
 This property is not guaranteed to be correct for all providers. Non-MetaMask providers may also set this property to `true`.
 :::
 
-`true` if the user has MetaMask installed, some falsy value otherwise.
+`true` if the user has MetaMask installed.
 
 ### ethereum.chainId
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -84,13 +84,10 @@ For any non-trivial Ethereum web application — a.k.a. web3 site — to work, y
 The snippet at the top of this page is sufficient for detecting the provider.
 You can learn how to accomplish the other two by reviewing the snippet in the [Using the Provider section](#using-the-provider).
 
-Although any Ethereum operation can be performed via the provider API, most developers use a convenience library with higher-level abstractions.
-The most common such libraries are [ethers](https://www.npmjs.com/package/ethers) and [web3.js](https://www.npmjs.com/package/web3).
+The provider API is all you need to create a full-featured web3 application.
 
-Even if you use a convenience library, you will likely still need to detect the provider before initializing the library.
-Other than that, you can generally learn everything you need to know from the documentation of those libraries, without reading this lower-level API.
-
-However, for developers of convenience libraries, and for developers who would like to use features that are not yet supported by their favorite libraries, knowledge of the provider API is essential. Read on for more details.
+That said, many developers use a convenience library, such as [ethers](https://www.npmjs.com/package/ethers) and [web3.js](https://www.npmjs.com/package/web3), instead of using the provider directly.
+If you are in need of higher-level abstractions than those provided by this API, we recommend that you use a convenience library.
 
 ## Chain IDs
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -201,7 +201,8 @@ ethereum.on('accountsChanged', (accounts) => {
 
 ethereum.on('chainChanged', (chainId) => {
   // Handle the new chain.
-  // We recommend reloading the page.
+  // Correctly handling chain changes can be complicated.
+  // We recommend reloading the page unless you have a very good reason not to.
   window.location.reload();
 });
 ```

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -521,10 +521,10 @@ You can think of these signatures as follows:
 
 3. This signature enables you to call the following RPC methods synchronously:
 
-    - `eth_accounts`
-    - `eth_coinbase`
-    - `eth_uninstallFilter`
-    - `net_version`
+   - `eth_accounts`
+   - `eth_coinbase`
+   - `eth_uninstallFilter`
+   - `net_version`
 
 ## Deprecated Events
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -260,7 +260,7 @@ ethereum.on('chainChanged', handler: (chainId: string) => void);
 
 The MetaMask provider emits this event when the currently connected chain changes.
 
-All RPC requests are be submitted to the currently connected chain.
+All RPC requests are submitted to the currently connected chain.
 Therefore, it's critical to keep track of the current chain ID by listening for this event.
 
 We _strongly_ recommend reloading the page on chain changes, unless absolutely necessary not to.

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -147,7 +147,7 @@ ethereum.request(args: RequestArguments): Promise<unknown>;
 ```
 
 Use `request` to submit RPC requests to Ethereum via MetaMask.
-It method a `Promise` that resolves to the result of the RPC method call.
+It returns a `Promise` that resolves to the result of the RPC method call.
 
 The `params` and return value will vary by RPC method.
 In practice, if a method has any `params`, they are almost always of type `Array<any>`.

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -494,11 +494,37 @@ Use [`ethereum.request()`](#ethereum-request-args) instead.
 ethereum.send(
   methodOrPayload: string | JsonRpcRequest,
   paramsOrCallback: Array<unknown> | JsonRpcCallback,
-): Promise<JsonRpcResponse> | unknown;
+): Promise<JsonRpcResponse> | void;
 ```
 
-This method is mostly a Promise-based `sendAsync` with `method` and `params` instead of a payload as arguments.
-However, it behaves in unexpected ways and should be avoided at all costs.
+This method behaves unpredictably and should be avoided at all costs.
+It is essentially an overloaded version of [`ethereum.sendAsync()`](#ethereum-sendasync-deprecated).
+
+`ethereum.send()` can be called in three different ways:
+
+```typescript
+// 1.
+ethereum.send(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
+
+// 2.
+ethereum.send(method: string, params?: Array<unknown>): Promise<JsonRpcResponse>;
+
+// 3.
+ethereum.send(payload: JsonRpcRequest): unknown;
+```
+
+You can think of these signatures as follows:
+
+1. This signature is exactly like `ethereum.sendAsync()`
+
+2. This signature is like an async `ethereum.sendAsync()` with `method` and `params` as arguments, instead of a JSON-RPC payload and callback
+
+3. This signature enables you to call the following RPC methods synchronously:
+
+    - `eth_accounts`
+    - `eth_coinbase`
+    - `eth_uninstallFilter`
+    - `net_version`
 
 ## Deprecated Events
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -20,8 +20,9 @@ if (provider) {
 ```
 
 ::: warning
-In Q3 and Q4 of 2020, we are making changes to our provider API that will be breaking for some web3 sites.
+In the near future, we are making changes to our provider API that will be breaking for some web3 sites.
 
+You can prepare for these changes today.
 Please read the [Upcoming Breaking Changes section](#upcoming-breaking-changes) for details.
 :::
 
@@ -37,14 +38,13 @@ We recommend that all web3 site developers read the [Basic Usage section](#basic
 ::: tip
 These changes are _upcoming._ Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for updates.
 
-All consumers of this API will be affected by the `eth_chainId` bug fix (see [next subsection](#window-ethereum-api-changes)).
-
-Otherwise, if you are new to using the provider or use [ethers](https://www.npmjs.com/package/ethers), you do not have to worry about these changes, and can skip ahead [to the next section](#api).
+All consumers of MetaMask's provider may be affected by the `eth_chainId` bug (see [next subsection](#window-ethereum-api-changes)).
+Other than that, if you are new to using the provider, you do not have to worry about these changes, and can skip ahead [to the next section](#api).
 :::
 
 ### `window.ethereum` API Changes
 
-In **Q3 2020** (date TBD), we are introducing some breaking changes to this API, which we encourage you to
+In the near future, we are introducing some breaking changes to this API, which we encourage you to
 [read more about here](https://medium.com/metamask/breaking-changes-to-the-metamask-inpage-provider-b4dde069dd0a).
 
 At that time, we will:
@@ -65,10 +65,9 @@ Please read our [migration guide](./provider-migration.html) for more details.
 If you do not use the `window.web3` object injected by MetaMask, you will not be affected by these changes.
 :::
 
-In **Q4 2020** (date TBD), we will:
+In the near future, we will:
 
 - Stop injecting `window.web3` into web pages
-- Remove the `ethereum.autoRefreshOnNetworkChange` property
 
 If you rely on the `window.web3` object currently injected by MetaMask, these changes _will_ break your website.
 Please read our [migration guide](./provider-migration.html) for more details.
@@ -133,6 +132,17 @@ The value of this property can change at any time, and should not be exclusively
 A hexadecimal string representing the current chain ID.
 
 ## Methods
+
+### ethereum.isConnected()
+
+```typescript
+ethereum.isConnected(): boolean;
+```
+
+Returns `true` if the provider is connected to the current chain, and `false` otherwise.
+
+If the provider is not connected, the page will have to be reloaded in order for connection to be re-established.
+Please see the [`connect`](#connect) and [`disconnect`](#disconnect) events for more information.
 
 ### ethereum.request(args)
 
@@ -217,7 +227,7 @@ ethereum.on('connect', handler: (connectInfo: ConnectInfo) => void);
 ```
 
 The MetaMask provider emits this event when it first becomes able to submit RPC requests to a chain.
-In general, you can assume that the MetaMask provider is connected and has emitted this event by the time you are able to reference it.
+We recommend using a `connect` event handler and the [`ethereum.isConnected()` method](#ethereum-isconnected) in order to determine when/if the provider is connected.
 
 ### disconnect
 
@@ -228,7 +238,8 @@ ethereum.on('disconnect', handler: (error: ProviderRpcError) => void);
 The MetaMask provider emits this event if it becomes unable to submit RPC requests to any chain.
 In general, this will only happen due to network connectivity issues or some unforeseen error.
 
-Once `disconnect` has been emitted, MetaMask will not accept any new requests until until `connect` is emitted, which may require reloading the page.
+Once `disconnect` has been emitted, the provider will not accept any new requests until the connection to the chain has been re-restablished, which requires reloading the page.
+You can also use the [`ethereum.isConnected()` method](#ethereum-isconnected) to determine if the provider is disconnected.
 
 ### accountsChanged
 
@@ -338,7 +349,7 @@ We expose some experimental, MetaMask-specific methods under the `ethereum._meta
 ### ethereum.\_metamask.isApproved() (TO BE REMOVED)
 
 ::: danger DANGER
-This will be removed in **Q3 2020**.
+This will be removed in the future.
 
 Please see the [Using the Provider section](#using-the-provider) for the recommended way of keeping track of user accounts.
 :::
@@ -352,7 +363,7 @@ This method returns a `Promise` that resolves to a `boolean` indicating if the c
 ### ethereum.\_metamask.isEnabled() (TO BE REMOVED)
 
 ::: danger DANGER
-This will be removed in **Q3 2020**.
+This will be removed in the future.
 
 Please see the [Using the Provider section](#using-the-provider) for the recommended way of keeping track of user accounts.
 :::
@@ -385,15 +396,14 @@ Because of this, you may find web3 sites that use this API, or other providers t
 
 ## Legacy Properties
 
-### ethereum.autoRefreshOnNetworkChange (TO BE REMOVED)
+### ethereum.autoRefreshOnNetworkChange (DEPRECATED)
 
-::: danger DANGER
-When `window.web3` is removed in **Q4 2020**, this property will also be removed.
-
-If you don't access `window.web3`, the value of this property will not affect the behavior of your application or MetaMask.
+::: warning
+The value of this property will only affect MetaMask's behavior if `window.web3` is accessed during the page lifecycle.
+When `window.web3` [is removed](#window-web3-removal), either the effects of this property will change, or it will be removed.
 
 As the consumer of this API, it is your responsbility to handle chain changes using the [`chainChanged` event](#chainChanged).
-We recommend reloading the page on `chainChange` or using [ethers](https://www.npmjs.com/package/ethers), which will do so for you.
+We recommend reloading the page on `chainChange` unless you have good reason not to.
 :::
 
 By default, this property is `true`.
@@ -472,7 +482,7 @@ ethereum.sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
 
 This is the ancestor of `ethereum.request`. It only works for JSON-RPC methods, and takes a JSON-RPC request payload object and an error-first callback function as its arguments.
 
-See [the Ethereum JSON-RPC API](https://eips.ethereum.org/EIPS/eip-1474) for details.
+See the [Ethereum JSON-RPC API](https://eips.ethereum.org/EIPS/eip-1474) for details.
 
 ### ethereum.send() (DEPRECATED)
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -118,7 +118,7 @@ Consult [chainid.network](https://chainid.network) for more.
 ### ethereum.isMetaMask
 
 ::: tip
-This property is just a convention, and it may be `true` for non-MetaMask providers.
+This property is not guaranteed to be correct for all providers. Non-MetaMask providers may also set this property to `true`.
 :::
 
 `true` if the user has MetaMask installed, some falsy value otherwise.

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -1,103 +1,164 @@
 # Ethereum Provider API
 
 MetaMask injects a global API into websites visited by its users at `window.ethereum`.
-This API allows websites to request user login, load data from blockchains the user has a connection to, and suggest that the user sign messages and transactions.
-You can use this API to detect the user of an Ethereum browser.
+This API allows websites to request users' Ethereum accounts, read data from blockchains the user is connected to, and suggest that the user sign messages and transactions.
+The presence of the provider object indicates an Ethereum user.
 
 ```javascript
-if (typeof window.ethereum !== 'undefined') {
-  // Ethereum user detected. You can now use the provider.
-  const provider = window['ethereum'];
+// this function detects most providers injected at window.ethereum
+import detectEthereumProvider from '@metamask/detect-provider';
+
+const provider = await detectEthereumProvider();
+
+if (provider) {
+  // From now on, this should always be true:
+  // provider === window.ethereum
+  startApp(provider); // initialize your app
+} else {
+  console.log('Please install MetaMask!');
 }
 ```
 
-The provider API itself is very simple, and wraps [Ethereum JSON-RPC](./rpc-api) formatted messages, which is why developers usually use a convenience library for interacting with the provider,
-like [web3](https://www.npmjs.com/package/web3), [ethers](https://www.npmjs.com/package/ethers), [truffle](https://www.trufflesuite.com/), [Embark](https://framework.embarklabs.io/), or others.
-From those tools, you can generally find sufficient documentation to interact with the provider, without reading this lower-level API.
+::: warning
+In Q3 and Q4 of 2020, we are making changes to our provider API that will be breaking for some web3 sites.
 
-However, for developers of convenience libraries, and for developers who would like to use features that are not yet supported by their favorite libraries, knowledge of the provider API is essential.
+Please read the [Upcoming Breaking Changes section](#upcoming-breaking-changes) for details.
+:::
+
+The provider API is specified by [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193), and is designed to be minimal.
+We recommend that all web3 site developers read the [Basic Usage section](#basic-usage).
+
+## Table of Contents
 
 [[toc]]
 
-## Upcoming Provider Changes
-
-In **Q4 2020**, we will be making some breaking changes to the provider API. The biggest change is that we will stop injecting `window.web3`. We encourage you to
-[read more about this here](https://github.com/MetaMask/metamask-extension/issues/8077).
-
-## List of Chain and Network IDs
+## Upcoming Breaking Changes
 
 ::: tip
-The chain and network IDs of these chains are the same.
+These changes are _upcoming._ Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for details.
 
-Network IDs are decimal strings, while chain IDs are hexadecimal strings.
+If you are new to using the provider, or use [ethers](https://www.npmjs.com/package/ethers), you do not have to worry about these changes, and can skip ahead [to the next section](#api).
 :::
 
-```javascript
-'1': Ethereum Main Network
-'2': Morden Test network
-'3': Ropsten Test Network
-'4': Rinkeby Test Network
-'5': Goerli Test Network
-'42': Kovan Test Network
-```
+### `window.ethereum` API Changes
+
+In **Q3 2020** (date TBD), we are introducing some breaking changes to this API, which we encourage you to
+[read more about here](https://medium.com/metamask/breaking-changes-to-the-metamask-inpage-provider-b4dde069dd0a).
+
+At that time, we will:
+
+- Stop emitting `chainIdChanged`, and instead emit `chainChanged`
+- Ensure that all `chainId` values are **not** 0-prefixed
+  - For example, instead of `0x01`, we will always return `0x1`, wherever the chain ID is returned or accessible.
+- Remove the following experimental methods:
+  - `ethereum._metamask.isEnabled`
+  - `ethereum._metamask.isApproved`
+
+These changes _may_ break your website.
+Please read our [migration guide](about:blank) for more details.
+
+### `window.web3` Removal
+
+::: tip
+If you do not use the `window.web3` object injected by MetaMask, you will not be affected by these changes.
+:::
+
+In **Q4 2020** (date TBD), we will:
+
+- Stop injecting `window.web3` into web pages
+- Remove the `ethereum.autoRefreshOnNetworkChange` property
+
+If you rely on the `window.web3` object currently injected by MetaMask, these changes _will_ break your website.
+Please read our [migration guide](about:blank) for more details.
+
+## Basic Usage
+
+For any non-trivial Ethereum web application — a.k.a. web3 site — to work, you will have to:
+
+- Detect the Ethereum provider (`window.ethereum`)
+- Detect which Ethereum network the user is connected to
+- Get the user's Ethereum account(s)
+
+The snippet at the top of this page is sufficient for detecting the provider.
+You can learn how to accomplish the other two by reviewing the snippet in the [Using the Provider section](#using-the-provider).
+
+Although any Ethereum operation can be performed via the provider API, most developers use a convenience library with higher-level abstractions.
+The most common such libraries are [ethers](https://www.npmjs.com/package/ethers) and [web3.js](https://www.npmjs.com/package/web3).
+
+Even if you use a convenience library, you will likely still need to detect the provider before initializing the library.
+Other than that, you can generally learn everything you need to know from the documentation of those libraries, without reading this lower-level API.
+
+However, for developers of convenience libraries, and for developers who would like to use features that are not yet supported by their favorite libraries, knowledge of the provider API is essential. Read on for more details.
+
+## Chain IDs
+
+::: warning
+At the moment, the [`ethereum.chainId`](#ethereum-chainid) property and the [`chainChanged`](#chainchanged) event should be preferred over the `eth_chainId` RPC method.
+Their chain ID values are correctly formatted, per the table below.
+
+`eth_chainId` returns an incorrectly formatted (0-prefixed) chain ID for the chains in the table below, e.g. `0x01` instead of `0x1`.
+See the [Upcoming Breaking Changes section](#upcoming-breaking-changes) for details on when the `eth_chainId` RPC method will be fixed.
+
+Custom RPC endpoints are not affected; they always return the chain ID specified by the user.
+:::
+
+These are the IDs of the Ethereum chains that MetaMask supports by default.
+Consult [chainid.network](https://chainid.network) for more.
+
+| Hex  | Decimal | Network                         |
+| ---- | ------- | ------------------------------- |
+| 0x1  | 1       | Ethereum Main Network (MainNet) |
+| 0x3  | 3       | Ropsten Test Network            |
+| 0x4  | 4       | Rinkeby Test Network            |
+| 0x5  | 5       | Goerli Test Network             |
+| 0x2a | 42      | Kovan Test Network              |
 
 ## Properties
 
 ### ethereum.isMetaMask
 
-Returns `true` or `false`, representing whether the user has MetaMask installed.
-
-### ethereum.autoRefreshOnNetworkChange
-
-When the network is changed, MetaMask will reload any pages that have made requests to the provider.
-This automatic reload behavior will be removed in a future release of MetaMask, but in the meantime it can be disabled with this flag.
-
-To disable auto-refresh on a network change you can do:
-
-```javascript
-ethereum.autoRefreshOnNetworkChange = false;
-```
-
-This can be toggled on or off at any time.
-
-### ethereum.networkVersion (DEPRECATED)
-
-::: warning
-Use the `net_version` RPC method via `ethereum.sendAsync()` instead.
+::: tip
+This property is just a convention, and it may be `true` for non-MetaMask providers.
 :::
 
-Returns a numeric string representing the current blockchain's network ID.
+`true` if the user has MetaMask installed, some falsy value otherwise.
 
-### ethereum.selectedAddress (DEPRECATED)
+### ethereum.chainId
 
 ::: warning
-Use `ethereum.sendAsync({ method: 'eth_accounts' }, callback)` instead.
+The value of this property can change at any time, and should not be exclusively relied upon. See the [`chainChanged`](#chainchanged) event for details.
+
+**NOTE:** See the [Chain IDs section](#chain-ids) for important information about the MetaMask provider's chain IDs.
 :::
 
-Returns a hex-prefixed string representing the current user's selected address, ex: `"0xfdea65c8e26263f6d9a1b5de9555d2931a33b825"`.
+A hexadecimal string representing the current chain ID.
 
 ## Methods
 
-### ethereum.sendAsync(payload, callback)
+### ethereum.request(args)
 
 ```typescript
-interface JsonRpcResponse {
-  id: string | undefined,
-  jsonrpc: '2.0',
-  method: string,
-  result: any,
+interface RequestArguments {
+  method: string;
+  params?: unknown[] | object;
 }
 
-ethereum.sendAsync(payload: Object, callback: Function): JsonRpcResponse
+ethereum.request(args: RequestArguments): Promise<unknown>;
 ```
 
-_To be superseded by the Promise-returning `ethereum.send()` method in_
-_[EIP 1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md). (See also **[the new API](#new-api)**.)_
+Use `request` to submit RPC requests to Ethereum via MetaMask.
+It method a `Promise` that resolves to the result of the RPC method call.
 
-Sends a message to the web3 browser. Message format maps to the format of
-[the Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API#json-rpc-methods).
+The `params` and return value will vary by RPC method.
+In practice, if a method has any `params`, they are almost always of type `Array<any>`.
 
-Here's an example of everyone's favorite method, `eth_sendTransaction`, which is both how Ether is sent, and how smart contract methods are called:
+If the request fails for any reason, the Promise will reject with an [Ethereum RPC Error](#errors).
+
+MetaMask supports most standardized Ethereum RPC methods, in addition to a number of methods that may not be
+supported by other wallets.
+See the MetaMask [RPC API documentation](./rpc-api.html) for details.
+
+#### Example
 
 ```javascript
 params: [
@@ -112,83 +173,359 @@ params: [
   },
 ];
 
-ethereum.sendAsync(
-  {
+ethereum
+  .request({
     method: 'eth_sendTransaction',
-    params: params,
-    from: accounts[0], // Provide the user's account to use.
-  },
-  (err, response) => {
-    if (err) {
-      // Handle the error
-    } else {
-      // This always returns a JSON RPC response object.
-      // The result varies by method, per the RPC method specification
-      // For example, this method will return a transaction hash on success.
-      const result = response.result;
-    }
-  }
-);
+    params,
+  })
+  .then((result) => {
+    // The result varies by by RPC method.
+    // For example, this method will return a transaction hash hexadecimal string on success.
+  })
+  .catch((error) => {
+    // If the request fails, the Promise will reject with an error.
+  });
 ```
 
-### ethereum.sendAsync({ method: 'eth_requestAccounts'}, callback)
+## Events
 
-Requests to view the user's Ethereum address.
-
-#### Example
+The MetaMask provider implements the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) API.
+This sections details the events emitted via that API.
+There are innumerable `EventEmitter` guides elsewhere, but you can listen for events like this:
 
 ```javascript
-ethereum.sendAsync(
-  {
-    method: 'eth_requestAccounts',
-  },
-  (error, response) => {
-    if (error) {
-      // Handle error. Likely the user rejected the login
-      console.error(error);
-    } else {
-      const accounts = response.result;
-      // You now have an array of accounts!
-      // Currently only ever one, e.g.:
-      // ['0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825']
-    }
-  }
-);
+ethereum.on('accountsChanged', (accounts) => {
+  // Handle the new accounts, or lack thereof.
+  // "accounts" will always be an array, but it can be empty.
+});
+
+ethereum.on('chainChanged', (chainId) => {
+  // Handle the new chain.
+  // We recommend reloading the page.
+  window.location.reload();
+});
 ```
+
+### connect
+
+```typescript
+interface ConnectInfo {
+  chainId: string;
+}
+
+ethereum.on('connect', handler: (connectInfo: ConnectInfo) => void);
+```
+
+The MetaMask provider emits this event when it first becomes able to submit RPC requests to a chain.
+In general, you can assume that the MetaMask provider is connected and has emitted this event by the time you are able to reference it.
+
+### disconnect
+
+```typescript
+ethereum.on('disconnect', handler: (error: ProviderRpcError) => void);
+```
+
+The MetaMask provider emits this event if it becomes unable to submit RPC requests to any chain.
+In general, this will only happen due to network connectivity issues or some unforeseen error.
+
+Once `disconnect` has been emitted, MetaMask will not accept any new requests until until `connect` is emitted, which may require reloading the page.
+
+### accountsChanged
+
+```typescript
+ethereum.on('accountsChanged', handler: (accounts: Array<string>) => void);
+```
+
+The MetaMask provider emits this event whenever the return value of the `eth_accounts` RPC method changes.
+`eth_accounts` returns an array that is either empty or contains a single account address that the user decided to expose to the requesting domain (in the case of a website, identified by the _hostname_ of its URL).
+
+This means that `accountsChanged` will be emitted whenever the user's exposed account address changes.
+
+::: tip
+We plan to allow the `eth_accounts` array to be able to contain multiple addresses in the near future.
+:::
+
+### chainChanged
+
+::: warning
+**NOTE:** See the [Chain IDs section](#chain-ids) for important information about the MetaMask provider's chain IDs.
+:::
+
+```typescript
+ethereum.on('chainChanged', handler: (chainId: string) => void);
+```
+
+The MetaMask provider emits this event when the currently connected chain changes.
+
+All RPC requests are be submitted to the currently connected chain.
+Therefore, it's critical to keep track of the current chain ID by listening for this event.
+
+We _strongly_ recommend reloading the page on chain changes, unless absolutely necessary not to.
+
+```javascript
+ethereum.on('chainChanged', (_chainId) => window.location.reload());
+```
+
+### message
+
+```typescript
+interface ProviderMessage {
+  type: string;
+  data: unknown;
+}
+
+ethereum.on('message', handler: (message: ProviderMessage) => void);
+```
+
+The MetaMask provider emits this event when it receives some message that the consumer should be notified of.
+The kind of message is identified by the `type` string.
+
+One prominent example of such messages include updates from RPC subscriptions, such as `eth_subscribe`. For such messages, the message `type` will be `eth_subscription`.
+
+## Errors
+
+All errors thrown or returned by the MetaMask provider follow this interface:
+
+```typescript
+interface ProviderRpcError extends Error {
+  message: string;
+  code: number;
+  data?: unknown;
+}
+```
+
+The [`ethereum.request(args)` method](#ethereum-request-args) throws errors eagerly.
+You can often use the error `code` property to determine why the request failed.
+Common codes and their meaning include:
+
+- `4001`
+  - The request was rejected by the user
+- `-32602`
+  - The parameters were invalid
+- `-32603`
+  - Internal error
+
+For the complete list of errors, please see [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) and [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474#error-codes).
+
+::: tip
+The [`eth-rpc-errors`](https://npmjs.com/package/eth-rpc-errors) package implements all RPC errors thrown by the MetaMask provider, and can help you identify their meaning.
+:::
+
+## Using the Provider
+
+This snippet explains how to accomplish the three most common requirements for web3 sites:
+
+- Detect the Ethereum provider (`window.ethereum`)
+- Detect which Ethereum network the user is connected to
+- Get the user's Ethereum account(s)
+
+<<< @/docs/snippets/handleProvider.js
+
+## Experimental API
+
+::: warning
+There is no guarantee that the methods and properties defined in this section will remain stable.
+Use it at your own risk.
+:::
+
+We expose some experimental, MetaMask-specific methods under the `ethereum._metamask` property.
+
+## Experimental Methods
+
+### ethereum.\_metamask.isApproved() (TO BE REMOVED)
+
+::: danger DANGER
+This will be removed in **Q3 2020**.
+:::
+
+```typescript
+ethereum._metamask.isApproved(): Promise<boolean>;
+```
+
+This method returns a `Promise` that resolves to a `boolean` indicating if the caller has access to user accounts.
+
+### ethereum.\_metamask.isEnabled() (TO BE REMOVED)
+
+::: danger DANGER
+This will be removed in **Q3 2020**.
+:::
+
+```typescript
+ethereum._metamask.isEnabled(): boolean;
+```
+
+This method returns a `boolean` indicating if the caller has access to user accounts.
+
+### ethereum.\_metamask.isUnlocked()
+
+```typescript
+ethereum._metamask.isUnlocked(): Promise<boolean>;
+```
+
+This method returns a `Promise` that resolves to a `boolean` indicating if MetaMask is unlocked by the user.
+This is useful for knowing if MetaMask is unlocked in order to provide meaningful instructions to the user during onboarding.
+Note that this does not indicate if the user has exposed any accounts.
+
+## Legacy API
+
+::: warning
+You should **never** rely on any of these methods, properties, or events in practice.
+:::
+
+Historically, the Ethereum provider API has been a mess.
+Here, we document the remains of this mess in case you see it used in the wild and wonder what's going on.
+
+## Legacy Properties
+
+### ethereum.autoRefreshOnNetworkChange (TO BE REMOVED)
+
+::: danger DANGER
+When `window.web3` is removed in **Q4 2020**, this property will also be removed.
+
+If you don't access `window.web3`, the value of this property will not affect the behavior of your application or MetaMask.
+
+As the consumer of this API, it is your responsbility to handle chain changes using the [`chainChanged` event](#chainChanged).
+We recommend reloading the page on `chainChange` or using [ethers](https://www.npmjs.com/package/ethers), which will do so for you.
+:::
+
+By default, this property is `true`.
+
+If this property is truthy, MetaMask will reload the page in the following cases:
+
+- When the connected chain (network) changes, if `window.web3` has been accessed during the page lifecycle
+- When `window.web3` is accessed, if the connected chain (network) has changed during the page lifecycle
+
+To disable this behavior, set this property to `false` immediately after detecting the provider:
+
+```javascript
+ethereum.autoRefreshOnNetworkChange = false;
+```
+
+### ethereum.networkVersion (DEPRECATED)
+
+::: warning
+You should always prefer the chain ID over the network ID.
+
+If you must get the network ID, use [`ethereum.request({ method: 'net_version' })`](#ethereum-request-args).
+
+The value of this property can change at any time.
+:::
+
+A decimal string representing the current blockchain's network ID.
+
+### ethereum.selectedAddress (DEPRECATED)
+
+::: warning
+Use [`ethereum.request({ method: 'eth_accounts' })`](#ethereum-request-args) instead.
+
+The value of this property can change at any time.
+:::
+
+Returns a hexadecimal string representing the user's "currently selected" address.
+
+The "currently selected" address is the first item in the array returned by `eth_accounts`.
+
+## Legacy Methods
 
 ### ethereum.enable() (DEPRECATED)
 
 ::: warning
-Use `ethereum.sendAsync({ method: 'eth_requestAccounts' }, callback)` instead.
+Use [`ethereum.request({ method: 'eth_requestAccounts' })`](#ethereum-request-args) instead.
 :::
 
-Requests to view the user's Ethereum address.
-Returns a promise of an array of hex-prefixed ethereum address strings.
+Alias for `ethereum.request({ method: 'eth_requestAccounts' })`.
 
-### ethereum.send(payload, callback) (DEPRECATED)
+### ethereum.sendAsync() (DEPRECATED)
 
 ::: warning
-Use `ethereum.sendAsync()` instead.
+Use [`ethereum.request()`](#ethereum-request-args) instead.
 :::
 
-See `ethereum.sendAsync`, directly below.
+```typescript
+interface JsonRpcRequest {
+  id: string | undefined;
+  jsonrpc: '2.0';
+  method: string;
+  params?: Array<any>;
+}
 
-### ethereum.on(eventName, callback)
+interface JsonRpcResponse {
+  id: string | undefined;
+  jsonrpc: '2.0';
+  method: string;
+  result?: unknown;
+  error?: Error;
+}
 
-The provider supports listening for some events:
+type JsonRpcCallback = (error: Error, response: JsonRpcResponse) => unknown;
 
-- `accountsChanged`, returns the currently available account(s).
-- `networkChanged`, returns the current network ID as a decimal string.
-- `chainIdChanged`, returns the current chain ID as a hexadecimal string.
-
-#### Example
-
-```javascript
-ethereum.on('accountsChanged', function (accounts) {
-  // Time to reload your interface with accounts[0]!
-});
+ethereum.sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): void;
 ```
 
-**Note:** The `networkChanged` event is only useful if you disable auto-refresh on network
-change by setting [`ethereum.autoRefreshOnNetworkChange`](#ethereum-autorefreshonnetworkchange) to `false`.
-Otherwise, MetaMask will default to auto-reloading pages upon network change if they have made requests to the provider.
+This is the ancestor of `ethereum.request`. It only works for JSON-RPC methods, and takes a JSON-RPC request payload object and an error-first callback function as its arguments.
+
+See [the Ethereum JSON-RPC API](https://eips.ethereum.org/EIPS/eip-1474) for details.
+
+### ethereum.send() (DEPRECATED)
+
+::: warning
+Use [`ethereum.request()`](#ethereum-request-args) instead.
+:::
+
+```typescript
+ethereum.send(
+  methodOrPayload: string | JsonRpcRequest,
+  paramsOrCallback: Array<unknown> | JsonRpcCallback,
+): Promise<JsonRpcResponse> | unknown;
+```
+
+This method is mostly a Promise-based `sendAsync` with `method` and `params` instead of a payload as arguments.
+However, it behaves in unexpected ways and should be avoided at all costs.
+
+## Deprecated Events
+
+### close (DEPRECATED)
+
+::: warning
+Use [`disconnect`](#disconnect) instead.
+:::
+
+```typescript
+ethereum.on('close', handler: (error: Error) => void);
+```
+
+### chainIdChanged (DEPRECATED)
+
+::: warning
+Use [`chainChanged`](#chainchanged) instead.
+:::
+
+Misspelled alias of [`chainChanged`](#chainchanged).
+
+```typescript
+ethereum.on('chainChanged', handler: (chainId: string) => void);
+```
+
+### networkChanged (DEPRECATED)
+
+::: warning
+Use [`chainChanged`](#chainchanged) instead.
+:::
+
+Like [`chainChanged`](#chainchanged), but with the `networkId` instead.
+Network IDs are insecure, and were effectively deprecated in favor of chain IDs by [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+Avoid using them unless you know what you are doing.
+
+```typescript
+ethereum.on('networkChanged', handler: (networkId: string) => void);
+```
+
+### notification (DEPRECATED)
+
+::: warning
+Use [`message`](#message) instead.
+:::
+
+```typescript
+ethereum.on('notification', handler: (payload: any) => void);
+```

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -1,0 +1,3 @@
+# Provider Migration Guide
+
+TODO

--- a/docs/snippets/handleProvider.js
+++ b/docs/snippets/handleProvider.js
@@ -1,0 +1,95 @@
+/*****************************************/
+/* Detect the MetaMask Ethereum provider */
+/*****************************************/
+
+import detectEthereumProvider from '@metamask/detect-provider';
+
+// this returns the provider, or null if it wasn't detected
+const provider = await detectEthereumProvider();
+
+if (provider) {
+  startApp(provider); // Initialize your app
+} else {
+  console.log('Please install MetaMask!');
+}
+
+function startApp(provider) {
+  // If the provider returned by detectEthereumProvider is not the same as
+  // window.ethereum, something is overwriting it, perhaps another wallet.
+  if (provider === window.ethereum) {
+    console.error('Do you have multiple wallets installed?');
+  }
+  // Access the decentralized web!
+}
+
+/**********************************************************/
+/* Handle chain (network) and chainChanged (per EIP-1193) */
+/**********************************************************/
+
+// Normally, we would recommend the 'eth_chainId' RPC method, but it currently
+// returns incorrectly formatted chain ID values.
+let currentChainId = ethereum.chainId;
+
+ethereum.on('chainChanged', handleChainChanged);
+
+function handleChainChanged(_chainId) {
+  // We recommend reloading the page, unless you must do otherwise
+  window.location.reload()
+}
+
+/***********************************************************/
+/* Handle user accounts and accountsChanged (per EIP-1193) */
+/***********************************************************/
+
+let currentAccount = null;
+ethereum
+  .request({ method: 'eth_accounts' })
+  .then(handleAccountsChanged)
+  .catch((err) => {
+    // Some unexpected error.
+    // For backwards compatibility reasons, if no accounts are available,
+    // eth_accounts will return an empty array.
+    console.error(err);
+  });
+
+// Note that this event is emitted on page load.
+// If the array of accounts is non-empty, you're already
+// connected.
+ethereum.on('accountsChanged', handleAccountsChanged);
+
+// For now, 'eth_accounts' will continue to always return an array
+function handleAccountsChanged(accounts) {
+  if (accounts.length === 0) {
+    // MetaMask is locked or the user has not connected any accounts
+    console.log('Please connect to MetaMask.');
+  } else if (accounts[0] !== currentAccount) {
+    currentAccount = accounts[0];
+    // Do any other work!
+  }
+}
+
+/*********************************************/
+/* Access the user's accounts (per EIP-1102) */
+/*********************************************/
+
+// You should only attempt to request the user's accounts in response to user
+// interaction, such as a button click.
+// Otherwise, you popup-spam the user like it's 1999.
+// If you fail to retrieve the user's account(s), you should encourage the user
+// to initiate the attempt.
+document.getElementById('connectButton', connect);
+
+function connect() {
+  ethereum
+    .request({ method: 'eth_requestAccounts' })
+    .then(handleAccountsChanged)
+    .catch((err) => {
+      if (err.code === 4001) {
+        // EIP-1193 userRejectedRequest error
+        // If this happens, the user rejected the connection request.
+        console.log('Please connect to MetaMask.');
+      } else {
+        console.error(err);
+      }
+    });
+}


### PR DESCRIPTION
First of a number of v8 PRs using the `v8` branch as a base. Compare #104 for the finished product. We're splitting it up in order to make review more manageable.

### Assumptions
- This assumes that the "Experimental API" page will be removed, and its content moved into the Provider and RPC API pages.