### PR TITLE
Fix casing of GitHub

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,3 +1,3 @@
 # FAQ
 
-For questions or issues visit our [Github](https://github.com/MetaMask)
+For questions or issues visit our [GitHub](https://github.com/MetaMask)

--- a/docs/guide/create-dapp.md
+++ b/docs/guide/create-dapp.md
@@ -12,7 +12,7 @@ Make sure you have:
 
 1. Have the [MetaMask Extension](https://metamask.io/download.html) downloaded.
 2. Have Node.js [Downloaded and Installed](https://nodejs.org/)
-3. Clone/Download the [Project Files](https://github.com/BboyAkers/simple-dapp-tutorial) from Github.
+3. Clone/Download the [Project Files](https://github.com/BboyAkers/simple-dapp-tutorial) from GitHub.
 4. Have your favorite Text Editor or IDE installed. I personally like [Visual Studio Code](https://code.visualstudio.com/)
 
 ### Open Project Folder


### PR DESCRIPTION
This tiny PR fixes the casing of GitHub throughout the docs.