### PR TITLE
Remove extraneous fields from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "private": true,
-  "version": "1.0.3",
-  "name": "docs",
   "description": "MetaMask documentation.",
   "scripts": {
     "dev": "yarn start",


### PR DESCRIPTION
This PR removes the `name` and `version` fields from the `package.json` file since the package is marked as private.