### PR TITLE
v8 Provider/web3 Migration Guide

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,7 +2,10 @@ module.exports = {
   singleQuote: true,
   overrides: [
     {
-      files: 'WatchAssetParams.ts',
+      files: [
+        'WatchAssetParams.ts',
+        'web3ToProvider.js',
+      ],
       options: {
         quoteProps: 'preserve',
       }

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -49,15 +49,16 @@ In the near future, we are introducing some breaking changes to this API, which 
 
 At that time, we will:
 
-- Ensure that chain IDs returned by `eth_chainId` are **not** 0-prefixed
+- Ensure that chain IDs returned by `eth_chainId` are **not** 0-padded
   - For example, instead of `0x01`, we will always return `0x1`, wherever the chain ID is returned or accessible.
+  - Note that this _only_ affects the [default Ethereum chains](#chain-ids), _except_ Kovan, whose chain ID is formatted correctly (`0x2a`).
 - Stop emitting `chainIdChanged`, and instead emit `chainChanged`
 - Remove the following experimental methods:
   - `ethereum._metamask.isEnabled`
   - `ethereum._metamask.isApproved`
 
 These changes _may_ break your website.
-Please read our [migration guide](./provider-migration.html) for more details.
+Please read our [Migration Guide](./provider-migration.html) for more details.
 
 ### `window.web3` Removal
 
@@ -94,7 +95,7 @@ If you are in need of higher-level abstractions than those provided by this API,
 At the moment, the [`ethereum.chainId`](#ethereum-chainid) property and the [`chainChanged`](#chainchanged) event should be preferred over the `eth_chainId` RPC method.
 Their chain ID values are correctly formatted, per the table below.
 
-`eth_chainId` returns an incorrectly formatted (0-prefixed) chain ID for the chains in the table below, e.g. `0x01` instead of `0x1`.
+`eth_chainId` returns an incorrectly formatted (0-padded) chain ID for the chains in the table below, e.g. `0x01` instead of `0x1`.
 See the [Upcoming Breaking Changes section](#upcoming-breaking-changes) for details on when the `eth_chainId` RPC method will be fixed.
 
 Custom RPC endpoints are not affected; they always return the chain ID specified by the user.
@@ -157,6 +158,13 @@ ethereum.autoRefreshOnNetworkChange = false;
 ## Methods
 
 ### ethereum.isConnected()
+
+::: tip
+Note that this method has nothing to do with the user's accounts.
+
+You may often encounter the word "connected" in reference to whether a web3 site can access the user's accounts.
+In the provider interface, however, "connected" and "disconnected" refer to whether the provider can make RPC requests to the current chain.
+:::
 
 ```typescript
 ethereum.isConnected(): boolean;

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -76,50 +76,7 @@ For many web3 sites, the API provided by `window.ethereum` is more than sufficie
 Much of the `web3` API simply maps to RPC methods, all of which can be requested using [`ethereum.request()`](./ethereum-provider.html#ethereum-request-args).
 For example, here are a couple of actions performed using first `window.web3`, and then their equivalents using `window.ethereum`.
 
-```javascript
-/**
- * Getting Accounts
- */
-
-// window.web3
-const accounts = web3.eth.accounts;
-
-// window.ethereum
-const accounts = await ethereum.request({ method: 'eth_accounts' });
-
-/**
- * Sending a Transaction
- */
-
-// window.web3
-web3.eth.sendTransaction(
-  {
-    to: '0x...',
-    amount: '0x...',
-    // And so on...
-  },
-  (result) => {
-    // Handle the result
-  }
-);
-
-// window.ethereum
-ethereum
-  .request({
-    method: 'eth_sendTransaction',
-    params: [
-      {
-        to: '0x...',
-        amount: '0x...',
-        // And so on...
-      },
-    ],
-  })
-  .then((transactionHash) => {
-    // Handle the result
-  })
-  .catch(console.error);
-```
+<<< @/docs/snippets/web3ToProvider.js
 
 ### Using an Updated Convenience library
 
@@ -127,8 +84,8 @@ If you decide that you need a convenience library, you will have to convert your
 We recommend one of the following options.
 
 - [`ethers`](https://npmjs.com/package/ethers)
-  - [Documentation](https://docs.ethers.io/v5)
-- [`web3@1.x`](https://npmjs.com/package/web3)
+  - [Documentation](https://docs.ethers.io/)
+- [`web3`](https://npmjs.com/package/web3)
   - [Documentation](https://web3js.readthedocs.io)
 
 ### Using `@metamask/legacy-web3`
@@ -139,9 +96,9 @@ It is not future-proof, and it is not guaranteed to work.
 :::
 
 Finally, if you just want your web3 site to continue to work, we created [`@metamask/legacy-web3`](https://npmjs.com/package/@metamask/legacy-web3).
-This package is a drop-in replacement for our `window.web3`, that you can add to your web3 site even before MetaMask stops injecting `window.web3`.
+This package is a drop-in replacement for our `window.web3` that you can add to your web3 site even before MetaMask stops injecting `window.web3`.
 
 `@metamask/legacy-web3` should work exactly like our injected `window.web3`, but _we cannot guarantee that it works perfectly_.
 We will not fix any future incompatibilities between `web3@0.20.7` and MetaMask itself, nor will we fix any bugs in `web3@0.20.7` itself.
 
-For installation and usage instructions, please see [NPM](https://npmjs.com/package/@metamask/legacy-web3).
+For installation and usage instructions, please see [npm](https://npmjs.com/package/@metamask/legacy-web3).

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -1,3 +1,147 @@
 # Provider Migration Guide
 
-TODO
+As noted in the [Ethereum Provider documentation](./ethereum-provider.html#upcoming-breaking-changes), we are going to make breaking changes to our provider API and remove our injected `window.web3`.
+This guide describes how to migrate to the new provider API, and how to replace our `window.web3` object.
+
+All replacement APIs are live, and you can migrate at any time.
+If you will be affected by the breaking changes, we recommend that you migrate as soon as possible.
+
+You can follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) to be notified of the dates of the breaking changes once we announce them.
+
+## Table of Contents
+
+[[toc]]
+
+## Migrating to the New Provider API
+
+### Handling `eth_chainId` Return Values
+
+Due to a long-standing bug, MetaMask's implementation of the `eth_chainId` RPC method has returned 0-padded values for the [default Ethereum chains](./ethereum-provider.html#chain-ids) _except_ Kovan.
+For example, instead of `0x1` and `0x2`, we currently return `0x01` and `0x02`.
+
+For the time being, instead of calling the `eth_chainId` RPC method, you should use the [`ethereum.chainId` property](./ethereum-provider.html#ethereum-chainid) and the [`chainChanged` event](./ethereum-provider.html#chainchanged).
+
+### Handling the Removal of `chainIdChanged`
+
+`chainIdChanged` is a typo of `chainChanged`.
+To migrate, simply listen for `chainChanged` instead:
+
+```javascript
+// Instead of this:
+ethereum.on('chainIdChanged', (chainId) => {
+  /* handle the chainId */
+});
+
+// Do this:
+ethereum.on('chainChanged', (chainId) => {
+  /* handle the chainId */
+});
+```
+
+### Handling the Removal of `isEnabled()` and `isApproved()`
+
+Before the new provider API shipped, we added
+[`_metamask.isEnabled`](./ethereum-provider.html#ethereum-metamask-isenabled-to-be-removed) and
+[`_metamask.isApproved`](./ethereum-provider.html#ethereum-metamask-isapproved-to-be-removed)
+to enable web3 sites to check if they have [access to the user's accounts](./rpc-api.html#eth-requestaccounts).
+`isEnabled` and `isApproved` are identical, except that `isApproved` is `async`.
+These methods were arguably never that useful, but they are completely redundant since the introduction of MetaMask's [permission system](./rpc-api.html#permissions).
+
+We recommend that you check for account access in the following ways:
+
+1. You can call the [`wallet_getPermissions` RPC method](./rpc-api.html#wallet-getpermissions) and check for the `eth_accounts` permission.
+
+2. You can call the `eth_accounts` RPC method and the [`ethereum._metamask.isUnlocked()` function](./ethereum-provider.html#ethereum-metamask-isunlocked).
+
+   - MetaMask has to be unlocked before you can access the user's accounts.
+     If the array returned by `eth_accounts` is empty, check if MetaMask is locked using `isUnlocked()`.
+
+   - If MetaMask is unlocked and you still aren't receiving any accounts, it's time to request accounts using the [`eth_requestAccounts` RPC method](./rpc-api.html#eth-requestaccounts).
+
+## Replacing `window.web3`
+
+For historical reasons, MetaMask injects [`web3@0.20.7`](https://github.com/ethereum/web3.js/tree/0.20.7) into all web pages.
+This version of `web3` is effectively deprecated, and new features are no longer added by the [web3.js](https://github.com/ethereum/web3.js/) team.
+
+If your website relies on our `window.web3` object, your Ethereum-related functionality will break when we stop injecting `window.web3`.
+Continue reading to learn more about the migration options.
+
+::: tip
+Regardless of how you choose to migrate, you will probably want to read the `web3@0.20.7` documentation, which you can find [here](https://github.com/ethereum/web3.js/blob/0.20.7/DOCUMENTATION.md).
+:::
+
+### Using `window.ethereum` Directly
+
+For many web3 sites, the API provided by `window.ethereum` is more than sufficient.
+Much of the `web3` API simply maps to RPC methods, all of which can be requested using [`ethereum.request()`](./ethereum-provider.html#ethereum-request-args).
+For example, here are a couple of actions performed using first `window.web3`, and then their equivalents using `window.ethereum`.
+
+```javascript
+/**
+ * Getting Accounts
+ */
+
+// window.web3
+const accounts = web3.eth.accounts;
+
+// window.ethereum
+const accounts = await ethereum.request({ method: 'eth_accounts' });
+
+/**
+ * Sending a Transaction
+ */
+
+// window.web3
+web3.eth.sendTransaction(
+  {
+    to: '0x...',
+    amount: '0x...',
+    // And so on...
+  },
+  (result) => {
+    // Handle the result
+  }
+);
+
+// window.ethereum
+ethereum
+  .request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        to: '0x...',
+        amount: '0x...',
+        // And so on...
+      },
+    ],
+  })
+  .then((transactionHash) => {
+    // Handle the result
+  })
+  .catch(console.error);
+```
+
+### Using an Updated Convenience library
+
+If you decide that you need a convenience library, you will have to convert your usage of `window.web3` to an updated convenience library.
+We recommend one of the following options.
+
+- [`ethers`](https://npmjs.com/package/ethers)
+  - [Documentation](https://docs.ethers.io/v5)
+- [`web3@1.x`](https://npmjs.com/package/web3)
+  - [Documentation](https://web3js.readthedocs.io)
+
+### Using `@metamask/legacy-web3`
+
+::: warning
+We strongly recommend that you consider one of the other two migration paths before resorting to this one.
+It is not future-proof, and it is not guaranteed to work.
+:::
+
+Finally, if you just want your web3 site to continue to work, we created [`@metamask/legacy-web3`](https://npmjs.com/package/@metamask/legacy-web3).
+This package is a drop-in replacement for our `window.web3`, that you can add to your web3 site even before MetaMask stops injecting `window.web3`.
+
+`@metamask/legacy-web3` should work exactly like our injected `window.web3`, but _we cannot guarantee that it works perfectly_.
+We will not fix any future incompatibilities between `web3@0.20.7` and MetaMask itself, nor will we fix any bugs in `web3@0.20.7` itself.
+
+For installation and usage instructions, please see [NPM](https://npmjs.com/package/@metamask/legacy-web3).

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -61,7 +61,7 @@ We recommend that you check for account access in the following ways:
 ## Replacing `window.web3`
 
 For historical reasons, MetaMask injects [`web3@0.20.7`](https://github.com/ethereum/web3.js/tree/0.20.7) into all web pages.
-This version of `web3` is effectively deprecated, and new features are no longer added by the [web3.js](https://github.com/ethereum/web3.js/) team.
+This version of `web3` is deprecated, and is no longer maintained by the [web3.js](https://github.com/ethereum/web3.js/) team.
 
 If your website relies on our `window.web3` object, your Ethereum-related functionality will break when we stop injecting `window.web3`.
 Continue reading to learn more about the migration options.

--- a/docs/snippets/handleProvider.js
+++ b/docs/snippets/handleProvider.js
@@ -34,7 +34,7 @@ ethereum.on('chainChanged', handleChainChanged);
 
 function handleChainChanged(_chainId) {
   // We recommend reloading the page, unless you must do otherwise
-  window.location.reload()
+  window.location.reload();
 }
 
 /***********************************************************/

--- a/docs/snippets/web3ToProvider.js
+++ b/docs/snippets/web3ToProvider.js
@@ -17,7 +17,7 @@ web3.eth.sendTransaction(
   {
     to: '0x...',
     'from': '0x...',
-    amount: '0x...',
+    value: '0x...',
     // And so on...
   },
   (result) => {
@@ -34,7 +34,7 @@ try {
       {
         to: '0x...',
         'from': '0x...',
-        amount: '0x...',
+        value: '0x...',
         // And so on...
       },
     ],

--- a/docs/snippets/web3ToProvider.js
+++ b/docs/snippets/web3ToProvider.js
@@ -20,7 +20,10 @@ web3.eth.sendTransaction(
     value: '0x...',
     // And so on...
   },
-  (result) => {
+  (error, result) => {
+    if (error) {
+      return console.error(error)
+    }
     // Handle the result
     console.log(result);
   }

--- a/docs/snippets/web3ToProvider.js
+++ b/docs/snippets/web3ToProvider.js
@@ -28,7 +28,7 @@ web3.eth.sendTransaction(
 
 // window.ethereum
 try {
-  const transactionHash = ethereum.request({
+  const transactionHash = await ethereum.request({
     method: 'eth_sendTransaction',
     params: [
       {

--- a/docs/snippets/web3ToProvider.js
+++ b/docs/snippets/web3ToProvider.js
@@ -22,7 +22,7 @@ web3.eth.sendTransaction(
   },
   (error, result) => {
     if (error) {
-      return console.error(error)
+      return console.error(error);
     }
     // Handle the result
     console.log(result);

--- a/docs/snippets/web3ToProvider.js
+++ b/docs/snippets/web3ToProvider.js
@@ -1,0 +1,46 @@
+/**
+ * Getting Accounts
+ */
+
+// window.web3
+const accounts = web3.eth.accounts;
+
+// window.ethereum
+const accounts = await ethereum.request({ method: 'eth_accounts' });
+
+/**
+ * Sending a Transaction
+ */
+
+// window.web3
+web3.eth.sendTransaction(
+  {
+    to: '0x...',
+    'from': '0x...',
+    amount: '0x...',
+    // And so on...
+  },
+  (result) => {
+    // Handle the result
+    console.log(result);
+  }
+);
+
+// window.ethereum
+try {
+  const transactionHash = ethereum.request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        to: '0x...',
+        'from': '0x...',
+        amount: '0x...',
+        // And so on...
+      },
+    ],
+  });
+  // Handle the result
+  console.log(transactionHash);
+} catch (error) {
+  console.error(error);
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "dev": "yarn start",
     "start": "vuepress dev docs",
     "build": "vuepress build docs",
-    "lint": "prettier docs/guide/*.md",
-    "lint:fix": "prettier docs/guide/*.md --write",
+    "lint": "prettier docs/guide/*.md docs/snippets/*",
+    "lint:fix": "yarn lint --write",
     "view-info": "vuepress view-info docs",
     "show-help": "vuepress --help"
   },


### PR DESCRIPTION
The provider/web3 migration guide for the v8 docs.

Relies on the readme of this: https://github.com/MetaMask/legacy-web3