### PR TITLE
Note which RPC methods are unavailable in MetaMask Mobile

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -106,6 +106,10 @@ function connect() {
 
 ### wallet_requestPermissions
 
+::: tip
+This RPC method is not yet available in MetaMask Mobile.
+:::
+
 #### Parameters
 
 - `Array`
@@ -162,6 +166,10 @@ function requestPermissions() {
 ```
 
 ### wallet_getPermissions
+
+::: tip
+This RPC method is not yet available in MetaMask Mobile.
+:::
 
 #### Returns
 
@@ -253,6 +261,10 @@ ethereum.request({
 
 ### eth_getEncryptionPublicKey
 
+::: tip
+This RPC method is not yet available in MetaMask Mobile.
+:::
+
 #### Parameters
 
 - `Array`
@@ -316,6 +328,10 @@ const encryptedMessage = ethUtil.bufferToHex(
 ```
 
 ### eth_decrypt
+
+::: tip
+This RPC method is not yet available in MetaMask Mobile.
+:::
 
 #### Parameters
 

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -106,7 +106,7 @@ function connect() {
 
 ### wallet_requestPermissions
 
-::: tip
+::: tip Platform Availability
 This RPC method is not yet available in MetaMask Mobile.
 :::
 
@@ -167,7 +167,7 @@ function requestPermissions() {
 
 ### wallet_getPermissions
 
-::: tip
+::: tip Platform Availability
 This RPC method is not yet available in MetaMask Mobile.
 :::
 
@@ -261,7 +261,7 @@ ethereum.request({
 
 ### eth_getEncryptionPublicKey
 
-::: tip
+::: tip Platform Availability
 This RPC method is not yet available in MetaMask Mobile.
 :::
 
@@ -329,7 +329,7 @@ const encryptedMessage = ethUtil.bufferToHex(
 
 ### eth_decrypt
 
-::: tip
+::: tip Platform Availability
 This RPC method is not yet available in MetaMask Mobile.
 :::
 


### PR DESCRIPTION
Add `::: tip` components noting which RPC methods are unavailable in MetaMask Mobile.