### PR TITLE
Fix `metamask_watchAsset` example

### DIFF
--- a/docs/guide/registering-your-token.md
+++ b/docs/guide/registering-your-token.md
@@ -27,17 +27,15 @@ const tokenImage = 'http://placekitten.com/200/300';
 try {
   const wasAdded = await ethereum.request({
     method: 'metamask_watchAsset',
-    params: [
-      {
-        type: 'ERC20', // Initially only supports ERC20, but eventually more!
-        options: {
-          address: tokenAddress, // The address that the token is at.
-          symbol: tokenSymbol, // A ticker symbol or shorthand, up to 5 chars.
-          decimals: tokenDecimals, // The number of decimals in the token
-          image: tokenImage, // A string url of the token logo
-        },
+    params: {
+      type: 'ERC20', // Initially only supports ERC20, but eventually more!
+      options: {
+        address: tokenAddress, // The address that the token is at.
+        symbol: tokenSymbol, // A ticker symbol or shorthand, up to 5 chars.
+        decimals: tokenDecimals, // The number of decimals in the token
+        image: tokenImage, // A string url of the token logo
       },
-    ],
+    },
   });
 } catch (error) {
   console.log(error);


### PR DESCRIPTION
The example passed an array as the `params` property, which does not work. `params` must be passed as an object.