### PR TITLE
Fix `metamask_watchAsset` syntax error

### DIFF
--- a/docs/guide/registering-your-token.md
+++ b/docs/guide/registering-your-token.md
@@ -23,8 +23,8 @@ const tokenSymbol = 'TUT';
 const tokenDecimals = 18;
 const tokenImage = 'http://placekitten.com/200/300';
 
-// wasAdded is a boolean. Like any RPC method, an error may be thrown.
 try {
+  // wasAdded is a boolean. Like any RPC method, an error may be thrown.
   const wasAdded = await ethereum.request({
     method: 'metamask_watchAsset',
     params: {
@@ -37,14 +37,14 @@ try {
       },
     },
   });
+
+  if (wasAdded) {
+    console.log('Thanks for your interest!');
+  } else {
+    console.log('Your loss!');
+  }
 } catch (error) {
   console.log(error);
-}
-
-if (added) {
-  console.log('Thanks for your interest!');
-} else {
-  console.log('Your loss!');
 }
 ```
 

--- a/docs/guide/registering-your-token.md
+++ b/docs/guide/registering-your-token.md
@@ -26,7 +26,7 @@ const tokenImage = 'http://placekitten.com/200/300';
 try {
   // wasAdded is a boolean. Like any RPC method, an error may be thrown.
   const wasAdded = await ethereum.request({
-    method: 'metamask_watchAsset',
+    method: 'wallet_watchAsset',
     params: {
       type: 'ERC20', // Initially only supports ERC20, but eventually more!
       options: {


### PR DESCRIPTION
The `wasAdded` variable was referenced by the wrong name (`added`) and from the wrong scope. It now checks the result correctly.