### PR TITLE
Remove v8 rollout notices

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -1,14 +1,5 @@
 # Ethereum Provider API
 
-::: warning Rollout in Progress
-We are currently rolling out the version of MetaMask that includes the new provider API.
-Some users will only have access to the legacy API until the rollout is complete.
-
-The rollout is complete on Firefox.
-We are waiting on the Google Chrome review process, which will hopefully have completed by July 10, 2020.
-[Follow us on Twitter](https://twitter.com/metamask_io) for updates.
-:::
-
 ::: tip Recommended Reading
 We recommend that all web3 site developers read the [Upcoming Breaking Changes](#upcoming-breaking-changes) and [Basic Usage](#basic-usage) sections.
 :::

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -1,14 +1,5 @@
 # RPC API
 
-::: warning Rollout in Progress
-We are currently rolling out the version of MetaMask that supports some of the new RPC methods on this page.
-Some users will not have access to the updated RPC API until the rollout is complete.
-
-The rollout is complete on Firefox.
-We are waiting on the Google Chrome review process, which will hopefully have completed by July 10, 2020.
-[Follow us on Twitter](https://twitter.com/metamask_io) for updates.
-:::
-
 MetaMask uses the [`ethereum.request(args)` method](./ethereum-provider.html#ethereum-request-args) to wrap an RPC API.
 
 The API is based on an interface exposed by all Ethereum clients, along with a growing number of methods that may or may not be supported by other wallets.


### PR DESCRIPTION
Since v8 is at 100% on Chrome and Firefox, it's time to remove the rollout notices.