### PR TITLE
Fix Legacy Events heading name

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -533,7 +533,7 @@ You can think of these signatures as follows:
    - `eth_uninstallFilter`
    - `net_version`
 
-## Deprecated Events
+## Legacy Events
 
 ### close (DEPRECATED)
 


### PR DESCRIPTION
`Deprecated Events` -> `Legacy Events`, in line with other headings in that section.