### PR TITLE
Document publicConfigStore removal

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -58,7 +58,6 @@ At that time, we will:
 - Remove the `ethereum.publicConfigStore` object
   - This object was, despite its name, never intended for public consumption.
     Its removal _may_ affect those who do not use it directly, e.g. if another library you use relies on the object.
-  - Some users access this object via `web3.currentProvider.publicConfigStore`.
 
 These changes _may_ break your website.
 Please read our [Migration Guide](./provider-migration.html) for more details.

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -55,6 +55,10 @@ At that time, we will:
 - Remove the following experimental methods:
   - `ethereum._metamask.isEnabled`
   - `ethereum._metamask.isApproved`
+- Remove the `ethereum.publicConfigStore` object
+  - This object was, despite its name, never intended for public consumption.
+    Its removal _may_ affect those who do not use it directly, e.g. if another library you use relies on the object.
+  - Some users access this object via `web3.currentProvider.publicConfigStore`.
 
 These changes _may_ break your website.
 Please read our [Migration Guide](./provider-migration.html) for more details.

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -58,6 +58,19 @@ We recommend that you check for account access in the following ways:
 
    - If MetaMask is unlocked and you still aren't receiving any accounts, it's time to request accounts using the [`eth_requestAccounts` RPC method](./rpc-api.html#eth-requestaccounts).
 
+### Handling the Removal of `ethereum.publicConfigStore`
+
+How to handle this change depends on how you use it.
+We have seen examples of listening for provider state changes the `publicConfigStore` `data` event, and accessing the `publicConfigStore` internal state directly.
+
+We recommend that you search your code and its dependencies for references to `publicConfigStore`.
+If you find any references, you should understand what it's being used for, and migrate to [one of the recommended provider APIs](./ethereum-provider.html#using-the-provider) instead.
+
+Although it is possible that your dependencies use the `publicConfigStore`, we have confirmed that the latest versions of the following common libraries do not:
+
+- `ethers`
+- `web3` (a.k.a. web3.js)
+
 ## Replacing `window.web3`
 
 For historical reasons, MetaMask injects [`web3@0.20.7`](https://github.com/ethereum/web3.js/tree/0.20.7) into all web pages.

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -60,16 +60,17 @@ We recommend that you check for account access in the following ways:
 
 ### Handling the Removal of `ethereum.publicConfigStore`
 
-How to handle this change depends on how you use it.
+How to handle this change depends on if and how you use the `publicConfigStore`.
 We have seen examples of listening for provider state changes the `publicConfigStore` `data` event, and accessing the `publicConfigStore` internal state directly.
 
 We recommend that you search your code and its dependencies for references to `publicConfigStore`.
 If you find any references, you should understand what it's being used for, and migrate to [one of the recommended provider APIs](./ethereum-provider.html#using-the-provider) instead.
+If you don't find any references, you should not be affected by this change.
 
-Although it is possible that your dependencies use the `publicConfigStore`, we have confirmed that the latest versions of the following common libraries do not:
+Although it is possible that your dependencies use the `publicConfigStore`, we have confirmed that the latest versions of the following common libraries will not be affected by this change:
 
 - `ethers`
-- `web3` (a.k.a. web3.js)
+- `web3` (web3.js)
 
 ## Replacing `window.web3`
 


### PR DESCRIPTION
Note that we are removing the `publicConfigStore`, and add it to the migration guide.