### PR TITLE
Fix website description

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -5,7 +5,7 @@ module.exports = (_ctx) => ({
     '/': {
       lang: 'en-US',
       title: 'MetaMask Docs',
-      description: 'Developer documentation for the popular Ethereum wallet.'
+      description: 'Developer documentation for the MetaMask Ethereum wallet'
     }
   },
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -5,7 +5,7 @@ module.exports = (_ctx) => ({
     '/': {
       lang: 'en-US',
       title: 'MetaMask Docs',
-      description: 'Welcome'
+      description: 'Developer documentation for the popular Ethereum wallet.'
     }
   },
 


### PR DESCRIPTION
Currently, the description of our documentation website reads "Welcome":
![image](https://user-images.githubusercontent.com/25517051/91875848-e4d57080-ec30-11ea-8c4a-41f6cf05ce2d.png)

This PR `s/Welcome/Developer documentation for the popular Ethereum wallet.`