### PR TITLE
Update breaking changes comms, lint

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -7,6 +7,14 @@ Welcome to MetaMask’s Developer Documentation. This documentation is for learn
 - For up to the minute news, follow our [Peepeth](https://peepeth.com/MetaMask/), [Twitter](https://twitter.com/metamask_io) or [Medium](https://medium.com/metamask) pages.
 - To learn how to contribute to the MetaMask project itself, visit our [Internal Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
 
+::: danger Upcoming Breaking Changes
+On **November 16, 2020** (or shortly thereafter), we are introducing changes that may break certain Ethereum web applications.
+Please read our [Migration Guide](./provider-migration.html) for more details.
+
+Action is required for Ethereum application developers only.
+MetaMask users do not need to do anything.
+:::
+
 ## Why MetaMask
 
 MetaMask was created to meet the needs of secure and usable Ethereum-based web sites. In particular, it handles account management and connecting the user to the blockchain.

--- a/docs/guide/contributors.md
+++ b/docs/guide/contributors.md
@@ -1,6 +1,7 @@
 # Contributors
 
 ## MetaMask Repositories
+
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab Extension
@@ -28,4 +29,3 @@
 :::
 
 ::::
-

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -6,6 +6,7 @@ We recommend that all web3 site developers read the [Basic Usage](#basic-usage) 
 
 ::: danger Upcoming Breaking Changes
 On **November 16, 2020** (or shortly thereafter), we are introducing changes that may break certain web3 sites.
+All future versions of MetaMask on all platforms will be affected.
 Please see the [Upcoming Breaking Changes](#upcoming-breaking-changes) section for details.
 
 Action is required for Ethereum application developers only.
@@ -42,6 +43,7 @@ if (provider) {
 
 ::: danger Important Information
 On **November 16, 2020** (or shortly thereafter), we are making changes to our provider API that will be breaking for some web3 sites.
+All future versions of MetaMask on all platforms will be affected.
 These changes are _upcoming_, but you can already handle them today.
 Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for updates.
 

--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -4,9 +4,12 @@
 We recommend that all web3 site developers read the [Basic Usage](#basic-usage) section.
 :::
 
-::: warning Upcoming Breaking Changes
-On **November 16, 2020**, we are introducing changes that may break certain web3 sites.
+::: danger Upcoming Breaking Changes
+On **November 16, 2020** (or shortly thereafter), we are introducing changes that may break certain web3 sites.
 Please see the [Upcoming Breaking Changes](#upcoming-breaking-changes) section for details.
+
+Action is required for Ethereum application developers only.
+MetaMask users do not need to do anything.
 :::
 
 MetaMask injects a global API into websites visited by its users at `window.ethereum`.
@@ -37,9 +40,9 @@ if (provider) {
 
 ## Upcoming Breaking Changes
 
-::: warning Important Information
-On **November 16, 2020**, we are making changes to our provider API that will be breaking for some web3 sites.
-These changes are _upcoming_, but you can prepare for them today.
+::: danger Important Information
+On **November 16, 2020** (or shortly thereafter), we are making changes to our provider API that will be breaking for some web3 sites.
+These changes are _upcoming_, but you can already handle them today.
 Follow [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/8077) for updates.
 
 All consumers of MetaMask's provider may be affected by the `eth_chainId` bug (see [next subsection](#window-ethereum-api-changes)).

--- a/docs/guide/metamask-extension-provider.md
+++ b/docs/guide/metamask-extension-provider.md
@@ -7,30 +7,36 @@ The account provided by this provider will be the user's MetaMask account.
 When sending signing requests to this provider, MetaMask will prompt the user to sign with their accounts.
 
 Works in:
+
 - Chrome
 - Firefox
 
 ## Installation
 
 Using npm as a package manager:
+
 ```bash
 npm install metamask-extension-provider -s
 ```
-## Usage
-Using a bundler like browserify:
-```javascript
-const createMetaMaskProvider = require('metamask-extension-provider')
 
-const provider = createMetaMaskProvider()
+## Usage
+
+Using a bundler like browserify:
+
+```javascript
+const createMetaMaskProvider = require('metamask-extension-provider');
+
+const provider = createMetaMaskProvider();
 
 provider.on('error', (error) => {
   // Failed to connect to MetaMask, fallback logic.
-})
+});
 
 // Enjoy!
 ```
 
 ## Adding additional browser support
+
 Add MetaMask's extension ID for that browser's store to the config file.
 
 ```javascript
@@ -41,15 +47,19 @@ Add MetaMask's extension ID for that browser's store to the config file.
 ```
 
 ## Running the example
+
 Use the `./sample-extension` folder as an WebExtension. You can easily add it to Chrome or Firefox Developer Edition.
 
 ## Editing the example
+
 You must have `browserify` installed (`npm i -g browserify`).
 
 You can edit the sample file `sample-extension/index.js` and then rebuild the file with `npm run buildSample`.
 
 ## Using with a local Development copy of MetaMask
+
 You'll need to edit the method `getMetaMaskId()` to return your local development MetaMask's id. You can get that from your MetaMask console with `chrome.runtime.id`.
 
 ## Current Limitations
+
 In order to identify when there is a problem (like MetaMask was not connected), some kind of proper error handling must be added to [metamask-inpage-provider](https://github.com/MetaMask/metamask-inpage-provider) that exposes the errors to the consumer of the provider. Maybe making it an event-emitter, so it can emit its errors, instead of just logging them.

--- a/docs/guide/mobile-best-practices.md
+++ b/docs/guide/mobile-best-practices.md
@@ -106,7 +106,7 @@ When debugging on a physical device, you must enable Web Inspector in your devic
 
 1. Open MetaMask Mobile in an Android emulator or Android device
 2. Open Google Chrome's DevTools -> menu (3 dots) -> **More tools** -> **Remote devices**
-You may also navigate to `chrome://inspect` from Chrome to display the list of available devices for debugging
+   You may also navigate to `chrome://inspect` from Chrome to display the list of available devices for debugging
 3. Select your device on the left and click **Inspect** on the browser contents you'd like to inspect.
 
 ::: tip Tip

--- a/docs/guide/mobile-best-practices.md
+++ b/docs/guide/mobile-best-practices.md
@@ -4,6 +4,11 @@ If this page doesn't answer your question, please feel free to open an issue [in
 
 ## The Provider (window.ethereum)
 
+::: danger Upcoming Breaking Changes
+MetaMask Mobile is also affected by the **November 16, 2020** breaking changes.
+Please read our [Migration Guide](./provider-migration.html) for more details.
+:::
+
 The [provider API](./ethereum-provider.html) is the same for both MetaMask Mobile and the desktop extension.
 However, the providers become available (i.e., are injected into the page) at different points in the page lifecycle.
 

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -7,6 +7,7 @@ As a MetaMask user, you don't need to do anything!
 
 ::: danger Deadline
 All of these changes are shipping on (or shortly after) **November 16, 2020**.
+All future versions of MetaMask on all platforms will be affected.
 
 If your web3 site relies on any of these features, it may break when these changes are made unless you migrate.
 :::

--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -1,7 +1,12 @@
 # Provider Migration Guide
 
+::: tip Attention MetaMask Users
+This documentation is for Ethereum application developers.
+As a MetaMask user, you don't need to do anything!
+:::
+
 ::: danger Deadline
-All of these changes are shipping on **November 16, 2020**.
+All of these changes are shipping on (or shortly after) **November 16, 2020**.
 
 If your web3 site relies on any of these features, it may break when these changes are made unless you migrate.
 :::

--- a/docs/guide/signing-data.md
+++ b/docs/guide/signing-data.md
@@ -95,7 +95,6 @@ Hopefully soon we will also have good examples for parsing method input into str
 
 - For example, as a user, you're using an Ether Mail app and a dialog comes up for cryptokitties exchange, this would arouse suspicion due to what the name is on the signature.
 
-
 `verifyingContract`: This is an extra layer of assurance. Even if two developers end up creating an app with the same name, they will never have the same contract address.(You can add another field `salt` but it's complete overkill and unnecessary)
 
 - If you are unsure of the name this will show the contract responsible for message verification.


### PR DESCRIPTION
- Update breaking changes warnings to `danger`
- Ensure that MetaMask users understand that they have no action required
- Clarify that mobile is also affected
- Lint (apparently we'd made some commits without linting that didn't get caught by CI?)