### PR TITLE
Add signTypedData_v4 in history section

### DIFF
--- a/docs/guide/signing-data.md
+++ b/docs/guide/signing-data.md
@@ -15,13 +15,14 @@ Note that MetaMask supports signing transactions with Trezor and Ledger hardware
 
 ## A Brief History
 
-There are currently five signing methods in MetaMask, and you might wonder the history of these methods. Studying the history of these methods has some lessons in it for the emergent lessons of decentralized standards emergence. Our current five methods are:
+There are currently six signing methods in MetaMask, and you might wonder the history of these methods. Studying the history of these methods has some lessons in it for the emergent lessons of decentralized standards emergence. Our current five methods are:
 
 - `eth_sign`
 - `personal_sign`
 - `signTypedData` (currently identical to `signTypedData_v1`)
 - `signTypedData_v1`
 - `signTypedData_v3`
+- `signTypedData_v4`
 
 There are likely to be many more over time. When MetaMask first started, the Provider API wasn’t designed to be exposed to untrusted websites, and so some considerations weren’t taken as seriously as they were later.
 


### PR DESCRIPTION
Is this right? I thought it was weird that the v4 method has its own section but isn't mentioned in the list.