### PR TITLE
use correct example repo

### DIFF
--- a/docs/guide/create-dapp.md
+++ b/docs/guide/create-dapp.md
@@ -12,7 +12,7 @@ Make sure you have:
 
 1. Have the [MetaMask Extension](https://metamask.io/download.html) downloaded.
 2. Have Node.js [Downloaded and Installed](https://nodejs.org/)
-3. Clone/Download the [Project Files](https://github.com/BboyAkers/simple-dapp-tutorial) from GitHub.
+3. Clone/Download the [Project Files](https://github.com/MetaMask/test-dapp) from GitHub.
 4. Have your favorite Text Editor or IDE installed. I personally like [Visual Studio Code](https://code.visualstudio.com/)
 
 ### Open Project Folder


### PR DESCRIPTION
The BboyAkers for repo appears out of date. it wont connect and giving the error. ```We noticed that the current website tried to use the removed window.web3 API. If the site appears to be broken, please click here for more information.``` https://metamask.zendesk.com/hc/en-us/articles/360053147012

I believe this repo is what was intended