### PR TITLE
Fix broken links in README

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -9,16 +9,16 @@ Welcome to MetaMask’s Developer Documentation. This documentation is for learn
 
 ::: tip Recent Breaking Provider Changes
 If you are an Ethereum application developer and are looking for information about our January 2021 provider API changes,
-please see our [Migration Guide](./guide/provider-migration.html) for more details.
+please see our [Migration Guide](./provider-migration.html) for more details.
 :::
 
 ## Why MetaMask
 
 MetaMask was created to meet the needs of secure and usable Ethereum-based web sites. In particular, it handles account management and connecting the user to the blockchain.
 
-- [Get started here](./guide/getting-started.html)
-- [Learn more about our JavaScript Provider API](./guide/ethereum-provider.html)
-- [Learn more about our RPC API](./guide/rpc-api.html)
+- [Get started here](./getting-started.html)
+- [Learn more about our JavaScript Provider API](./ethereum-provider.html)
+- [Learn more about our RPC API](./rpc-api.html)
 
 ## Account Management
 


### PR DESCRIPTION
Currently at https://docs.metamask.io/guide/ links 404 because it is linking to ./guide/guide/foobar.html instead of ./guide/foobar.html. The README is at the same top level as the other guide docs.