### PR TITLE
Update RPC method anchor links to eth.wiki

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -21,8 +21,8 @@ Important methods from this API include:
 
 - [`eth_accounts`](https://eth.wiki/json-rpc/API#eth_accounts)
 - [`eth_call`](https://eth.wiki/json-rpc/API#eth_call)
-- [`eth_getBalance`](https://eth.wiki/json-rpc/API#eth_getBalance)
-- [`eth_sendTransaction`](https://eth.wiki/json-rpc/API#eth_sendTransaction)
+- [`eth_getBalance`](https://eth.wiki/json-rpc/API#eth_getbalance)
+- [`eth_sendTransaction`](https://eth.wiki/json-rpc/API#eth_sendtransaction)
 - [`eth_sign`](https://eth.wiki/json-rpc/API#eth_sign)
 
 ## Permissions


### PR DESCRIPTION
I haven't tested this in other browsers but in Brave, https://eth.wiki/json-rpc/API#eth_sendTransaction does not jump to the correct section on the eth.wiki page, whereas https://eth.wiki/json-rpc/API#eth_sendtransaction does. Therefore I updated some of the links to lowercase to fix that problem.