### PR TITLE
Fix typo in wallet_switchEthereumChain documentation

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -378,7 +378,7 @@ This method is specified by [EIP-3326](https://ethereum-magicians.org/t/eip-3326
   0. `SwitchEthereumChainParameter` - Metadata about the chain that MetaMask will switch to.
 
 ```typescript
-interface AddEthereumChainParameter {
+interface SwitchEthereumChainParameter {
   chainId: string; // A 0x-prefixed hexadecimal string
 }
 ```


### PR DESCRIPTION
Fixes a typo in the `wallet_switchEthereumChain` documentation.