### PR TITLE
Fix twitter URL to the current account being used

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -4,7 +4,7 @@ Welcome to MetaMask’s Developer Documentation. This documentation is for learn
 
 - You can find the latest version of MetaMask on our [official website](https://metamask.io/).
 - For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/).
-- For up to the minute news, follow our [Peepeth](https://peepeth.com/MetaMask/), [Twitter](https://twitter.com/metamask_io) or [Medium](https://medium.com/metamask) pages.
+- For up to the minute news, follow our [Peepeth](https://peepeth.com/MetaMask/), [Twitter](https://twitter.com/MetaMask) or [Medium](https://medium.com/metamask) pages.
 - To learn how to contribute to the MetaMask project itself, visit our [Internal Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
 
 ::: tip Recent Breaking Provider Changes


### PR DESCRIPTION
I have updated the twitter URL as https://twitter.com/MetaMask seems to be in use now. I don't know why, but old one (https://twitter.com/metamask_io) seems to be suspended.