### PR TITLE
Add docs for removeListener in ethereum-provider.md

### DIFF
--- a/docs/guide/ethereum-provider.md
+++ b/docs/guide/ethereum-provider.md
@@ -166,6 +166,20 @@ ethereum.on('chainChanged', (chainId) => {
 });
 ```
 
+Also, don't forget to remove listeners once you are done listening to them (for example on component unmount in React):
+```javascript
+function handleAccountsChanged(accounts) {
+  // ...
+}
+
+ethereum.on('accountsChanged', handleAccountsChanged);
+
+// Later
+
+ethereum.removeListener('accountsChanged', handleAccountsChanged);
+```
+The first argument of the `ethereum.removeListener` is the event name and the second argument is the reference to the same function which has passed to `ethereum.on` for the event name mentioned in the first argument.
+
 ### connect
 
 ```typescript


### PR DESCRIPTION
Add documentation for `ethereum.removeListener` which is highly useful especially when developing with React.
I know `removeListener` can be derived from [NodeJS events](https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener); however, because of its importance, it's better to be mentioned inside docs explicitly.

Thanks!