### PR TITLE
Typo fix

### DIFF
--- a/docs/guide/create-dapp.md
+++ b/docs/guide/create-dapp.md
@@ -188,7 +188,7 @@ Above your `MetaMaskClientCheck` function write/insert this code.
 
 ```javascript
 //We create a new MetaMask onboarding object to use in our app
-const onboarding = new MetaMaskOnboarding({ forwarderOrigin });
+const onboarding = new MetamaskOnboarding({ forwarderOrigin });
 
 //This will start the onboarding proccess
 const onClickInstall = () => {


### PR DESCRIPTION
Fixed typo of using MetaMaskOnboarding instead of MetamaskOnboarding. (Note the capital M)
Reference: https://github.com/BboyAkers/simple-dapp-tutorial/issues/26