### PR TITLE
fix: incorrect `docsDir` in `.vuepress/config.js`

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,7 +26,7 @@ module.exports = (_ctx) => ({
 
   themeConfig: {
     repo: 'MetaMask/metamask-docs',
-    docsDir: 'packages/docs/dist',
+    docsDir: 'docs',
     editLinks: true,
     logo: '/metamask-fox.svg',
     smoothScroll: true,


### PR DESCRIPTION
The `docsDir` of vuepress should be `docs` rather than `packages/docs/dist`.