### PR TITLE
Fix broken link to ConsenSys Developer Portal

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -41,4 +41,4 @@ We are aware that there are constantly new private blockchains being created. If
 - [Getting Started with Truffle](https://www.trufflesuite.com/docs/truffle/quickstart)
 - [Keeping up with Blockchain Development (from ConsenSys Academy)](https://github.com/ConsenSys-Academy/Blockchain-Developer-Bootcamp/blob/main/docs/S00-intro/L6-keeping-up/index.md)
 - Launch into the Web3 space with [ConsenSys Academy's Blockchain Developer Bootcamp](https://consensys.net/academy/bootcamp/)
-- Explore everything ConsenSys at the [ConsenSys Developer Portal](vhttps://consensys.net/developers/)
+- Explore everything ConsenSys at the [ConsenSys Developer Portal](https://consensys.net/developers/)


### PR DESCRIPTION
There was a typo in the URL, a `v` in front of it.