### PR TITLE
Amend readme example for encrypting with `eth-sig-utils`

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -277,7 +277,7 @@ const encryptedMessage = ethUtil.bufferToHex(
     JSON.stringify(
       sigUtil.encrypt(
         {
-          pubKey: encryptionPublicKey,
+          publicKey: encryptionPublicKey,
           data: 'hello world!,
           version: 'x25519-xsalsa20-poly1305',
         }

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -277,9 +277,11 @@ const encryptedMessage = ethUtil.bufferToHex(
   Buffer.from(
     JSON.stringify(
       sigUtil.encrypt(
-        encryptionPublicKey,
-        { data: 'Hello world!' },
-        'x25519-xsalsa20-poly1305'
+        {
+          pubKey: encryptionPublicKey,
+          data: 'hello world!,
+          version: 'x25519-xsalsa20-poly1305',
+        }
       )
     ),
     'utf8'


### PR DESCRIPTION
The current example utilizing  [`eth-sig-util`](https://github.com/MetaMask/eth-sig-util) doesn't use name parameters and currently has the publicKey in the [wrong argument position](https://github.com/MetaMask/eth-sig-util/blob/main/src/encryption.ts#L22). 

This PR converts to named parameters to avoid this issue. 
