### PR TITLE
Use better example of "open" method

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -34,7 +34,7 @@ Important methods from this API include:
 MetaMask introduced Web3 Wallet Permissions via [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
 In this permissions system, each RPC method is either _restricted_ or _open_.
 If a method is restricted, an external _domain_ (like a web3 site) must have the corresponding permission in order to call it.
-Open methods, meanwhile, do not require permissions to call, but may require confirmation by the user in order to succeed (e.g. `eth_sendTransaction`).
+Open methods, meanwhile, do not require permissions to call, but may require confirmation by the user in order to succeed (e.g. `wallet_addEthereumChain`).
 
 Currently, the only permission is `eth_accounts`, which allows you to access the user's Ethereum address(es).
 More permissions will be added in the future.


### PR DESCRIPTION
The listed example of an "open" (i.e. unrestricted) RPC method was `eth_sendTransaction`, which is a poor example because it is a restricted method. It cannot be called without the `eth_accounts` permission.

The example has been updated to `wallet_addEthereumChain`, which is actually an unrestricted method.