### PR TITLE
Fix lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "yarn start",
     "start": "node scripts/build.js dev",
     "build": "node scripts/build.js build",
-    "lint": "prettier docs/guide/*.md docs/snippets/*",
+    "lint": "prettier docs/guide/*.md docs/snippets/* --check",
     "lint:fix": "yarn lint --write",
     "view-info": "vuepress view-info docs",
     "show-help": "vuepress --help"


### PR DESCRIPTION
Ensure that `yarn lint` exits with a non-zero code if linting fails. Just running `prettier` without the `--check` flag is pretty much useless. This will prevent unlinted files from being merged to `main`.

The `lint:fix` script still works because the `--write` flag appears to effectively override the `--check` behavior.