### PR TITLE
Expand `prettier` coverage

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,13 +2,10 @@ module.exports = {
   singleQuote: true,
   overrides: [
     {
-      files: [
-        'WatchAssetParams.ts',
-        'web3ToProvider.js',
-      ],
+      files: ['WatchAssetParams.ts', 'web3ToProvider.js'],
       options: {
         quoteProps: 'preserve',
-      }
+      },
     },
-  ]
-}
+  ],
+};

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,8 +6,8 @@ module.exports = (_ctx) => ({
     '/': {
       lang: 'en-US',
       title: 'MetaMask Docs',
-      description: 'Developer documentation for the MetaMask Ethereum wallet'
-    }
+      description: 'Developer documentation for the MetaMask Ethereum wallet',
+    },
   },
 
   head: [
@@ -15,11 +15,30 @@ module.exports = (_ctx) => ({
     ['link', { rel: 'manifest', href: '/manifest.json' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
-    ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
-    ['link', { rel: 'apple-touch-icon', href: `/icons/apple-touch-icon-152x152.png` }],
-    ['link', { rel: 'mask-icon', href: '/icons/safari-pinned-tab.svg', color: '#3eaf7c' }],
-    ['meta', { name: 'msapplication-TileImage', content: '/icons/msapplication-icon-144x144.png' }],
-    ['meta', { name: 'msapplication-TileColor', content: '#000000' }]
+    [
+      'meta',
+      { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },
+    ],
+    [
+      'link',
+      { rel: 'apple-touch-icon', href: `/icons/apple-touch-icon-152x152.png` },
+    ],
+    [
+      'link',
+      {
+        rel: 'mask-icon',
+        href: '/icons/safari-pinned-tab.svg',
+        color: '#3eaf7c',
+      },
+    ],
+    [
+      'meta',
+      {
+        name: 'msapplication-TileImage',
+        content: '/icons/msapplication-icon-144x144.png',
+      },
+    ],
+    ['meta', { name: 'msapplication-TileColor', content: '#000000' }],
   ],
 
   theme: '@vuepress/theme-default',
@@ -42,46 +61,65 @@ module.exports = (_ctx) => ({
         lastUpdated: 'Last Updated',
         nav: require('./nav/en'),
         sidebar: {
-          '/guide/': getGuideSidebar('Guide', 'API Reference', 'Best Practices', 'Mobile', 'Resources'),
-        }
-      }
-    }
+          '/guide/': getGuideSidebar(
+            'Guide',
+            'API Reference',
+            'Best Practices',
+            'Mobile',
+            'Resources'
+          ),
+        },
+      },
+    },
   },
 
   plugins: [
     ['@vuepress/back-to-top', true],
-    ['@vuepress/pwa', {
-      serviceWorker: true,
-      updatePopup: true
-    }],
+    [
+      '@vuepress/pwa',
+      {
+        serviceWorker: true,
+        updatePopup: true,
+      },
+    ],
     ['@vuepress/medium-zoom', true],
-    ['container', {
-      type: 'vue',
-      before: '<pre class="vue-container"><code>',
-      after: '</code></pre>',
-    }],
-    ['container', {
-      type: 'upgrade',
-      before: info => `<UpgradePath title="${info}">`,
-      after: '</UpgradePath>',
-    }],
-    ['vuepress-plugin-redirect', {
-      redirectors: [
-        {
-          base: '/',
-          alternative: '/guide/'
-        },
-      ],
-    }],
-    ['tabs', {
-      useUrlFragment: false
-    }]
+    [
+      'container',
+      {
+        type: 'vue',
+        before: '<pre class="vue-container"><code>',
+        after: '</code></pre>',
+      },
+    ],
+    [
+      'container',
+      {
+        type: 'upgrade',
+        before: (info) => `<UpgradePath title="${info}">`,
+        after: '</UpgradePath>',
+      },
+    ],
+    [
+      'vuepress-plugin-redirect',
+      {
+        redirectors: [
+          {
+            base: '/',
+            alternative: '/guide/',
+          },
+        ],
+      },
+    ],
+    [
+      'tabs',
+      {
+        useUrlFragment: false,
+      },
+    ],
   ],
 
-  extraWatchFiles: [
-    '.vuepress/nav/en.js',
-  ]
-})
+  extraWatchFiles: ['.vuepress/nav/en.js'],
+});
 
 function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
   return [
@@ -95,7 +133,7 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
         'initializing-dapps',
         'accessing-accounts',
         'sending-transactions',
-      ]
+      ],
     },
     {
       title: api,
@@ -105,7 +143,7 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
         'provider-migration',
         'rpc-api',
         'signing-data',
-      ]
+      ],
     },
     {
       title: bestPractices,
@@ -116,7 +154,7 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
         'defining-your-icon',
         'onboarding-library',
         'metamask-extension-provider',
-      ]
+      ],
     },
     {
       title: mobile,
@@ -125,16 +163,12 @@ function getGuideSidebar(guide, api, bestPractices, mobile, resources) {
         'mobile-getting-started',
         'site-compatibility-checklist',
         'mobile-best-practices',
-      ]
+      ],
     },
     {
       title: resources,
       collapsable: false,
-      children: [
-        'create-dapp',
-        'contributors'
-      ]
-    }
-  ]
+      children: ['create-dapp', 'contributors'],
+    },
+  ];
 }
-

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,5 +1,3 @@
-
-
 import EthConnectButton from './components/EthConnectButton';
 import EthAsyncConnectButton from './components/EthAsyncConnectButton';
 import ChangeAccount from './components/ChangeAccount';
@@ -7,13 +5,15 @@ import SendTransaction from './components/SendTransaction';
 
 export default ({ Vue, isServer }) => {
   if (!isServer) {
-    import('vue-toasted' /* webpackChunkName: "notification" */).then((module) => {
-      Vue.use(module.default)
-    })
+    import('vue-toasted' /* webpackChunkName: "notification" */).then(
+      (module) => {
+        Vue.use(module.default);
+      }
+    );
   }
 
   Vue.component('EthConnectButton', EthConnectButton);
   Vue.component('EthAsyncConnectButton', EthAsyncConnectButton);
   Vue.component('ChangeAccount', ChangeAccount);
   Vue.component('SendTransaction', SendTransaction);
-}
+};

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -3,4 +3,4 @@ module.exports = [
     text: 'Guide',
     link: '/guide/',
   },
-]
+];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "yarn start",
     "start": "node scripts/build.js dev",
     "build": "node scripts/build.js build",
-    "lint": "prettier docs/guide/*.md docs/snippets/* --check",
+    "lint": "prettier '!docs/dist' **/*.{js,json,md,ts} --check",
     "lint:fix": "yarn lint --write",
     "view-info": "vuepress view-info docs",
     "show-help": "vuepress --help"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,19 +1,19 @@
-require('dotenv').config()
+require('dotenv').config();
 
-const { dev, build } = require('vuepress')
-const config = require('../docs/.vuepress/config')()
+const { dev, build } = require('vuepress');
+const config = require('../docs/.vuepress/config')();
 
-const command = process.argv[2]
+const command = process.argv[2];
 
 switch (command) {
   case 'build':
-    build(config)
-    return
+    build(config);
+    return;
 
   case 'dev':
-    dev(config)
-    return
+    dev(config);
+    return;
 
   default:
-    throw new Error(`Unrecognized command "${command}".`)
+    throw new Error(`Unrecognized command "${command}".`);
 }


### PR DESCRIPTION
All Markdown, JavaScript, and TypeScript files are now covered by `prettier` in the `lint` script, excluding build files.

Aside from the adjustment to the npm `lint` script, all other changes are the output of `yarn lint:fix`.