### PR TITLE
Update permission system documentation

### DIFF
--- a/docs/guide/provider-migration.md
+++ b/docs/guide/provider-migration.md
@@ -136,7 +136,7 @@ ethereum.on('chainChanged', (chainId) => {
 Before the new provider API shipped, we added the `_metamask.isEnabled` and `_metamask.isApproved` methods
 to enable web3 sites to check if they have [access to the user's accounts](./rpc-api.html#eth-requestaccounts).
 `isEnabled` and `isApproved` functioned identically, except that `isApproved` was `async`.
-These methods were arguably never that useful, and they became completely redundant with the introduction of MetaMask's [permission system](./rpc-api.html#permissions).
+These methods were arguably never that useful, and they became completely redundant with the introduction of MetaMask's [permission system](./rpc-api.html#restricted-methods).
 
 We recommend that you check for account access in the following ways:
 

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -34,7 +34,7 @@ Important methods from this API include:
 MetaMask introduced Web3 Wallet Permissions via [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
 In this permissions system, each RPC method is either _restricted_ or _unrestricted_.
 If a method is restricted, the caller must have the corresponding permission in order to call it.
-Unrestricted methods, meanwhile, do not require permissions to call, but may require confirmation by the user in order to succeed (e.g. `wallet_addEthereumChain`).
+Unrestricted methods, meanwhile, have no corresponding permission. Some of them still rely upon permissions to succeed though (e.g. the signing methods require that you have the `eth_accounts` permission for the signer account), and some require confirmation by the user (e.g. `wallet_addEthereumChain`).
 
 Currently, the only permission is `eth_accounts`, which allows you to access the user's Ethereum address(es).
 More permissions will be added in the future.
@@ -177,6 +177,8 @@ function requestPermissions() {
 }
 ```
 
+## Unrestricted Methods
+
 ### `eth_decrypt`
 
 ::: tip Platform Availability
@@ -283,8 +285,6 @@ const encryptedMessage = ethUtil.bufferToHex(
   )
 );
 ```
-
-## Unrestricted Methods
 
 ### `wallet_addEthereumChain`
 

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -29,12 +29,12 @@ Important methods from this API include:
 - [`eth_sendTransaction`](https://eth.wiki/json-rpc/API#eth_sendtransaction)
 - [`eth_sign`](https://eth.wiki/json-rpc/API#eth_sign)
 
-## Permissions
+## Restricted Methods
 
 MetaMask introduced Web3 Wallet Permissions via [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
-In this permissions system, each RPC method is either _restricted_ or _open_.
-If a method is restricted, an external _domain_ (like a web3 site) must have the corresponding permission in order to call it.
-Open methods, meanwhile, do not require permissions to call, but may require confirmation by the user in order to succeed (e.g. `wallet_addEthereumChain`).
+In this permissions system, each RPC method is either _restricted_ or _unrestricted_.
+If a method is restricted, the caller must have the corresponding permission in order to call it.
+Unrestricted methods, meanwhile, do not require permissions to call, but may require confirmation by the user in order to succeed (e.g. `wallet_addEthereumChain`).
 
 Currently, the only permission is `eth_accounts`, which allows you to access the user's Ethereum address(es).
 More permissions will be added in the future.
@@ -52,7 +52,6 @@ interface Web3WalletPermission {
 }
 ```
 
-The permissions system is implemented in the [`rpc-cap` package](https://github.com/MetaMask/rpc-cap).
 If you're interested in learning more about the theory behind this _capability_-inspired permissions system, we encourage you to take a look at [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
 
 ### `eth_requestAccounts`
@@ -178,8 +177,6 @@ function requestPermissions() {
 }
 ```
 
-## Other RPC Methods
-
 ### `eth_decrypt`
 
 ::: tip Platform Availability
@@ -286,6 +283,8 @@ const encryptedMessage = ethUtil.bufferToHex(
   )
 );
 ```
+
+## Unrestricted Methods
 
 ### `wallet_addEthereumChain`
 


### PR DESCRIPTION
The RPC API documentation about the permission system has been updated to reflect the current terminology we use, and to reflect recent changes.

The term "open methods" has been dropped in favor of "unrestricted methods", which is more in-line with "restricted methods" and is what we have been calling them in practice.

The wording was updated to no longer imply that a _domain_ is the permission subject. Now it just says "caller" instead, which is just as clear but leaves open the possibility that the caller is not a website. This was done in preparation for Snaps, since snaps can also call RPC methods.

The definition for "Unrestricted methods" was updated to clarify that sometimes they do depend upon permissions indirectly. The unrestricted methods just don't have permissions that directly correspond with the method name.

The note on the implementation was removed, since the permission system no longer uses `rpc-cap`. I removed it rather than linking the new implementation because it's not really in a state where it would be easy to understand or re-use.

The "Other RPC Methods" header has been renamed to "Unrestricted Methods". The old title was silly; this section was alongside the header "Restricted Methods" so it always meant to refer to unrestricted methods.