### PR TITLE
Update CircleCI config to reflect branch rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - prep-deps
             - lint
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Build
           command: |
-            if [[ "$CIRCLE_BRANCH" == "master" ]]
+            if [[ "$CIRCLE_BRANCH" == "main" ]]
             then
               if [[ -z "$ALGOLIA_API_KEY" || -z "$ALGOLIA_INDEX_NAME" ]]
               then


### PR DESCRIPTION
The main branch was renamed but the CircleCI config was not updated accordingly, which broke the automated deployment. This has now been fixed.