### PR TITLE
Update rpc-api.md: Fixed Typo

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -278,7 +278,7 @@ const encryptedMessage = ethUtil.bufferToHex(
       sigUtil.encrypt(
         {
           publicKey: encryptionPublicKey,
-          data: 'hello world!,
+          data: 'hello world!',
           version: 'x25519-xsalsa20-poly1305',
         }
       )

--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -275,13 +275,11 @@ const ethUtil = require('ethereumjs-util');
 const encryptedMessage = ethUtil.bufferToHex(
   Buffer.from(
     JSON.stringify(
-      sigUtil.encrypt(
-        {
-          publicKey: encryptionPublicKey,
-          data: 'hello world!',
-          version: 'x25519-xsalsa20-poly1305',
-        }
-      )
+      sigUtil.encrypt({
+        publicKey: encryptionPublicKey,
+        data: 'hello world!',
+        version: 'x25519-xsalsa20-poly1305',
+      })
     ),
     'utf8'
   )


### PR DESCRIPTION
Found typo error on line 281: `  data:  'hello world!, ` 
missing  ` ' ` at the end of ` 'hello world! `
added ` ' ` to rectify the error