### PR TITLE
Added plausible analytics to the head of the document

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,7 +15,13 @@ module.exports = (_ctx) => ({
     ['link', { rel: 'manifest', href: '/manifest.json' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
-    ['script', { 'data-domain': 'docs.metamask.io', src: 'https://plausible.io/js/plausible.js' }],
+    [
+      'script',
+      {
+        'data-domain': 'docs.metamask.io',
+        src: 'https://plausible.io/js/plausible.js',
+      },
+    ],
     [
       'meta',
       { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,6 +15,7 @@ module.exports = (_ctx) => ({
     ['link', { rel: 'manifest', href: '/manifest.json' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+    ['script', { 'data-domain': 'docs.metamask.io', src: 'https://plausible.io/js/plausible.js' }],
     [
       'meta',
       { name: 'apple-mobile-web-app-status-bar-style', content: 'black' },


### PR DESCRIPTION
Updates the documentation to use the plausible.io's analytics functionality

Tag should display like this in the head:

```html
<script defer data-domain="docs.metamask.io" src="https://plausible.io/js/plausible.js"></script>
```