### PR TITLE
Add snap permissions article

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -173,6 +173,7 @@ const guideSidebar = [
       'snaps',
       'snaps-development-guide',
       'snaps-rpc-api',
+      'snaps-permissions',
       'snaps-patching-dependencies',
     ],
   },

--- a/docs/guide/snaps-development-guide.md
+++ b/docs/guide/snaps-development-guide.md
@@ -191,7 +191,7 @@ You can find an example of how to do this in the [template snap's manifest](http
 
 Snaps do not get access to any sensitive APIs or features by default, and Internet access is no exception to that rule.
 To access the Internet, you must specify the permission `endowment:network-access` in the `initialPermissions` of your `snap.manifest.json` file.
-This will grant you access to the global `fetch` API.
+This will grant you access to the global `fetch` and `WebSocket` APIs.
 Other global network APIs may be made available in the future.
 
 ::: tip "Endowment"?

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -1,4 +1,4 @@
-#  Permissions
+# Permissions
 
 ::: tip Developer Preview Software
 Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://metamask.io/flask).
@@ -17,10 +17,13 @@ To access certain powerful JavaScript globals or JSON-RPC methods, your snap may
 ## Endowments
 
 ### `endowment:network-access`
+
 For snaps that need to access the internet, the snap can request the `endowment:network-access` permission. This permission will expose the global networking APIs `fetch` and `WebSocket` to the snap execution environment. Without this permission, these globals will not be available.
 
 ### `endowment:long-running`
+
 For snaps that are computationally heavy and can't finish execution within the current snap lifecycle requirements, the snap can request the `endowment:long-running` permission. This long-running permission will effectively allow snaps to run indefinitely.
 
 ## RPC Permissions
+
 To use any restricted RPC method, a snap will need to request permissions to access that method. For a list of available RPC methods and thus valid RPC permissions see [JSON-RPC API](./snaps-rpc-api.html)

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -8,7 +8,7 @@ Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://me
 Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
 :::
 
-To access certain powerful JavaScript globals or JSON-RPC methods, your snap may need to request permission from the user. Snaps follow the [EIP-2255 wallet permissions](https://eips.ethereum.org/EIPS/eip-2255), and your snaps required permissions must be specified in the `initialPermissions` field of your `snap.manifest.json` file.
+To access certain powerful JavaScript globals or JSON-RPC methods, your snap may need to request permission from the user. Snaps follow the [EIP-2255 wallet permissions specification](https://eips.ethereum.org/EIPS/eip-2255), and your snap's required permissions must be specified in the `initialPermissions` field of your `snap.manifest.json` file.
 
 ## Table of Contents
 

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -1,0 +1,26 @@
+#  Permissions
+
+::: tip Developer Preview Software
+Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://metamask.io/flask).
+:::
+
+::: tip Feature Requests
+Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
+:::
+
+To access certain powerful JavaScript globals or JSON-RPC methods, your snap may need to request permission from the user. Snaps follow the [EIP-2255 wallet permissions](https://eips.ethereum.org/EIPS/eip-2255), and your snaps required permissions must be specified in the `initialPermissions` field of your `snap.manifest.json` file.
+
+## Table of Contents
+
+[[toc]]
+
+## Endowments
+
+### `endowment:network-access`
+For snaps that need to access the internet, the snap can request the `endowment:network-access` permission. This permission will expose the global networking APIs `fetch` and `WebSocket` to the snap execution environment. Without this permission, these globals will not be available.
+
+### `endowment:long-running`
+For snaps that are computationally heavy and can't finish execution within the current snap lifecycle requirements, the snap can request the `endowment:long-running` permission. This long-running permission will effectively allow snaps to run indefinitely.
+
+## RPC Permissions
+To use any restricted RPC method, a snap will need to request permissions to access that method. For a list of available RPC methods and thus valid RPC permissions see [JSON-RPC API](./snaps-rpc-api.html)

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -8,7 +8,7 @@ Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://me
 Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
 :::
 
-To access certain powerful JavaScript globals or JSON-RPC methods, your snap may need to request permission from the user. Snaps follow the [EIP-2255 wallet permissions specification](https://eips.ethereum.org/EIPS/eip-2255), and your snap's required permissions must be specified in the `initialPermissions` field of your `snap.manifest.json` file.
+To access certain powerful JavaScript globals or JSON-RPC methods, your snap will need to ask the user for permission. Snaps follow the [EIP-2255 wallet permissions specification](https://eips.ethereum.org/EIPS/eip-2255), and your snap's required permissions must be specified in the `initialPermissions` field of your [`snap.manifest.json` file](./snaps-development-guide.md#the-snap-manifest).
 
 ## Table of Contents
 
@@ -16,14 +16,19 @@ To access certain powerful JavaScript globals or JSON-RPC methods, your snap may
 
 ## Endowments
 
+### `endowment:long-running`
+
+For snaps that are computationally heavy and can't finish execution within [the snap lifecycle requirements](./snaps-development-guide.md#the-snap-lifecycle), the snap can request the `endowment:long-running` permission.
+This permission will effectively allow snaps to run indefinitely while processing RPC requests.
+
 ### `endowment:network-access`
 
 For snaps that need to access the internet, the snap can request the `endowment:network-access` permission. This permission will expose the global networking APIs `fetch` and `WebSocket` to the snap execution environment. Without this permission, these globals will not be available.
 
-### `endowment:long-running`
-
-For snaps that are computationally heavy and can't finish execution within the current snap lifecycle requirements, the snap can request the `endowment:long-running` permission. This long-running permission will effectively allow snaps to run indefinitely.
+::: warning Avoid XMLHttpRequest
+`XMLHttpRequest` is never available in snaps, and you should replace it with `fetch`. If your dependencies are using `XMLHttpRequest`, you can learn how to patch it away [here](./snaps-patching-dependencies.md#patching-the-use-of-xmlhttprequest).
+:::
 
 ## RPC Permissions
 
-To use any restricted RPC method, a snap will need to request permissions to access that method. For a list of available RPC methods and thus valid RPC permissions see [JSON-RPC API](./snaps-rpc-api.html)
+To use any restricted RPC method, a snap will need to request permissions to access that method. For a list of available RPC methods and thus valid RPC permissions see [JSON-RPC API](./snaps-rpc-api.html#restricted-methods)


### PR DESCRIPTION
Fixes https://github.com/MetaMask/snaps-skunkworks/issues/473

Adds a snap permissions article that lists the current endowments and links to the RPC methods.