### PR TITLE
Add deprecation warning for decryption methods

### DIFF
--- a/docs/guide/rpc-api.md
+++ b/docs/guide/rpc-api.md
@@ -179,10 +179,16 @@ function requestPermissions() {
 
 ## Unrestricted Methods
 
-### `eth_decrypt`
+### `eth_decrypt` (DEPRECATED)
+
+::: warning
+This method is deprecated and may be removed in the future.
+
+[See here for more information.](https://medium.com/metamask/metamask-api-method-deprecation-2b0564a84686)
+:::
 
 ::: tip Platform Availability
-This RPC method is not yet available in MetaMask Mobile.
+This RPC method is not available in MetaMask Mobile.
 :::
 
 #### Parameters
@@ -218,10 +224,16 @@ ethereum
   .catch((error) => console.log(error.message));
 ```
 
-### `eth_getEncryptionPublicKey`
+### `eth_getEncryptionPublicKey` (DEPRECATED)
+
+::: warning
+This method is deprecated and may be removed in the future.
+
+[See here for more information.](https://medium.com/metamask/metamask-api-method-deprecation-2b0564a84686)
+:::
 
 ::: tip Platform Availability
-This RPC method is not yet available in MetaMask Mobile.
+This RPC method is not available in MetaMask Mobile.
 :::
 
 #### Parameters


### PR DESCRIPTION
Both decryption-related methods (`eth_decrypt` and `eth_getPublicEncryptionKey`) have been deprecated. They are now labelled as deprecated, and have a deprecation warning that links our blog post with further information on why they were deprecated.

I considered making a new "deprecated methods" section, but I wasn't sure how to square that with our current categorization. This seems best for now, at least until we change how methods are organized overall.