### PR TITLE
Fix typo: `eth_personalSign` => `personal_sign`

### DIFF
--- a/docs/guide/accessing-accounts.md
+++ b/docs/guide/accessing-accounts.md
@@ -4,7 +4,7 @@ User accounts are used in a variety of contexts in Ethereum, including as identi
 
 - `eth_sendTransaction`
 - `eth_sign` (insecure and unadvised to use)
-- `eth_personalSign`
+- `personal_sign`
 - `eth_signTypedData`
 
 Once you've [connected to a user](./getting-started.html), you can always re-check the current account by checking `ethereum.selectedAddress`.


### PR DESCRIPTION
There is no such thing as `eth_personalSign`. It should be `personal_sign`
It seems to be a typo existing for 3 years.