### PR TITLE
Changed wallet_watchAsset symbol description to 11 characters

### DIFF
--- a/docs/snippets/WatchAssetParams.ts
+++ b/docs/snippets/WatchAssetParams.ts
@@ -2,7 +2,7 @@ interface WatchAssetParams {
   type: 'ERC20'; // In the future, other standards will be supported
   options: {
     address: string; // The address of the token contract
-    'symbol': string; // A ticker symbol or shorthand, up to 5 characters
+    'symbol': string; // A ticker symbol or shorthand, up to 11 characters
     decimals: number; // The number of token decimals
     image: string; // A string url of the token logo
   };


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/7567