### PR TITLE
docs: update `snap_manageState` documentation

### DIFF
--- a/docs/guide/snaps-rpc-api.md
+++ b/docs/guide/snaps-rpc-api.md
@@ -574,8 +574,8 @@ const addressKey1 = await deriveDogecoinAddress(1);
 
 #### Description
 
-This method allows the snap to persist some data to disk in encrypted form and retrieve it at will.
-The data is automatically encrypted when `update`d using a snap-specific key, and automatically decrypted when retrieved using `get`.
+This method allows the snap to persist some data to disk and retrieve it at will.
+The data is automatically encrypted using a snap-specific key and automatically decrypted when retrieved.
 
 #### Example
 

--- a/docs/guide/snaps-rpc-api.md
+++ b/docs/guide/snaps-rpc-api.md
@@ -556,11 +556,6 @@ const addressKey1 = await deriveDogecoinAddress(1);
 
 ### `snap_manageState`
 
-::: danger Plaintext Data Storage
-The data stored by this method is persisted to disk in unencrypted / plaintext form.
-**Never** store any secrets using this method.
-:::
-
 ::: warning Only Callable By
 
 - Snaps
@@ -579,8 +574,8 @@ The data stored by this method is persisted to disk in unencrypted / plaintext f
 
 #### Description
 
-This method allows the snap to persist some data to disk in plaintext form and retrieve it at will.
-Since the data is in plaintext, the method should **never** be used to store secrets of any kind.
+This method allows the snap to persist some data to disk in encrypted form and retrieve it at will.
+The data is automatically encrypted when `update`d using a snap-specific key, and automatically decrypted when retrieved using `get`.
 
 #### Example
 


### PR DESCRIPTION
The `snap_manageState` documentation still warns about storing unencrypted data.

https://github.com/MetaMask/snaps-skunkworks/pull/369 makes all Snaps data automatically encrypted.

The password manager snap example has even been updated to stop doing manual encryption of the data: https://github.com/ritave/snap-passwordManager/blob/main/src/index.js#L33