### PR TITLE
Fix broken link in Snaps Dev Guide

### DIFF
--- a/docs/guide/snaps-development-guide.md
+++ b/docs/guide/snaps-development-guide.md
@@ -246,7 +246,7 @@ Via the MetaMask settings page, the user can see their installed snaps. For each
 - see its execution status (running, stopped, or crashed)
 - enable and disable the snap
 
-Other than the settings page, the only way a snap can modify the MetaMask UI is by creating a confirmation using the [`snap_confirm`](./snaps-rpc.html#snap-confirm) RPC method.
+Other than the settings page, the only way a snap can modify the MetaMask UI is by creating a confirmation using the [`snap_confirm`](./snaps-rpc-api.html#snap-confirm) RPC method.
 This means that many snaps will have to rely on web pages (i.e., dapps) and their own RPC methods to present their data to the user.
 
 Providing more ways for snaps to modify the MetaMask UI is an important goal of the snaps system, and over time more and more snaps will be able to contain their user interfaces entirely within MetaMask itself.


### PR DESCRIPTION
Fixes a broken link in the Snaps Development Guide.