### PR TITLE
upd: removed rimble ui

### DIFF
--- a/docs/guide/site-compatibility-checklist.md
+++ b/docs/guide/site-compatibility-checklist.md
@@ -12,5 +12,4 @@ Please direct your users to either the relevant app store listing or to [the Met
 
 Instead of creating your own `Connect With MetaMask` button here are a couple of options:
 
-- [Rimble UI](https://rimble.consensys.design/)
 - [Decentraland UI](https://ui.decentraland.org/?path=/story/atlas--uncontrolled)


### PR DESCRIPTION
It appears that the domain consensys.design is no longer operational as it was and is now put up for sale. Better to get it out of the official documentation.