### PR TITLE
Fix docs: Change port from `3000` to `8000`

### DIFF
--- a/docs/guide/snaps.md
+++ b/docs/guide/snaps.md
@@ -102,7 +102,7 @@ Start the development server:
 yarn start
 ```
 
-You should now be serving both (1) the front-end and (2) the snap locally. Time to check it out in action at [`http://localhost:3000/`](http://localhost:3000/).
+You should now be serving both (1) the front-end and (2) the snap locally. Time to check it out in action at [`http://localhost:8000/`](http://localhost:8000/).
 
 Next step is to [install MetaMask Flask](https://metamask.io/flask/).
 


### PR DESCRIPTION
When running `yarn start` the port is `8000` instead of `3000`