### PR TITLE
Update RPC methods documentation after refactoring

### DIFF
--- a/docs/guide/snaps-rpc-api.md
+++ b/docs/guide/snaps-rpc-api.md
@@ -295,10 +295,9 @@ interface SnapRequest {
 }
 ```
 
-- `Array`
-
-  0. `string` - The id of the snap to invoke.
-  1. `SnapRequest` - The JSON-RPC request object to send to the invoked snap.
+- `Object`
+  - `snapId` - `string` - The id of the snap to invoke.
+  - `request` - `SnapRequest` - The JSON-RPC request object to send to the invoked snap.
 
 #### Returns
 
@@ -316,12 +315,12 @@ Snaps are fully responsible for implementing their JSON-RPC API; consult the sna
 ```javascript
 const result = await ethereum.request({
   method: 'wallet_invokeSnap',
-  params: [
-    'npm:@metamask/example-snap',
-    {
+  params: {
+    snapId: 'npm:@metamask/example-snap',
+    request: {
       method: 'hello',
     },
-  ],
+  },
 });
 
 console.log(result); // We happen to know that this will be `true` or `false`
@@ -352,9 +351,8 @@ The `*` in the name will always be substituted for a string, in this case a snap
 
 #### Parameters
 
-- `Array`
-
-  0. `SnapRequest` - The JSON-RPC request object to send to the invoked snap.
+- `Object` (`SnapRequest`)
+  - The JSON-RPC request object to send to the invoked snap.
 
 #### Returns
 
@@ -372,11 +370,9 @@ Snaps are fully responsible for implementing their JSON-RPC API; consult the sna
 ```javascript
 const result = await ethereum.request({
   method: 'wallet_snap_npm:@metamask/example-snap',
-  params: [
-    {
+  params: {
       method: 'hello',
-    },
-  ],
+  },
 });
 
 console.log(result); // We happen to know that this will be `true` or `false`
@@ -784,10 +780,9 @@ console.log(dogecoinPublicKey);
 
 #### Parameters
 
-- `Array`
-
-  0. `'clear' | 'get' | 'update'` - The state operation to perform.
-  1. `Record<string, unknown> | void` - The value to update state with if the operation is `update`, and nothing otherwise.
+- `Object`
+  - `operation` - `'clear' | 'get' | 'update'` - The state operation to perform.
+  - `newState` - `Record<string, unknown> | void` - The value to update state with if the operation is `update`, and nothing otherwise.
 
 #### Returns
 
@@ -804,13 +799,13 @@ The data is automatically encrypted using a snap-specific key and automatically 
 // First, let's persist some data
 await wallet.request({
   method: 'snap_manageState',
-  params: ['update', { hello: 'world' }],
+  params: { operation: 'update', newState: { hello: 'world' } },
 });
 
 // Then, at some later time, let's get the data we stored
 const persistedData = await wallet.request({
   method: 'snap_manageState',
-  params: ['get'],
+  params: { operation: 'get' },
 });
 
 console.log(persistedData);
@@ -819,7 +814,7 @@ console.log(persistedData);
 // Finally, if there's no need to store data anymore, we can clear it out
 await wallet.request({
   method: 'snap_manageState',
-  params: ['clear'],
+  params: { operation: 'clear' },
 });
 ```
 
@@ -846,9 +841,9 @@ interface SnapNotifyParams {
 }
 ```
 
-- `Array`
-
-  0. `SnapNotifyParams` - An object containing the contents of the notification.
+- `Object` (`SnapNotifyParams`) - An object containing the contents of the notification.
+  - `type` - `'native' | 'inApp'` - Notification type to be used.
+  - `message` - Message to be displayed.
 
 #### Notification Type
 
@@ -883,11 +878,9 @@ See above for their meaning and format.
 ```javascript
 await wallet.request({
   method: 'snap_notify',
-  params: [
-    {
-      type: 'inApp',
-      message: `Hello, world!`,
-    },
-  ],
+  params: {
+    type: 'inApp', 
+    message: `Hello, world!`,
+  },
 });
 ```


### PR DESCRIPTION
This PR will update Snaps related documentation in the area of the RPC method API.

This version of RPC method API documentation will match the latest breaking changes introduced here: https://github.com/MetaMask/snaps-monorepo/pull/922

Fixes: https://github.com/MetaMask/metamask-docs/issues/585
