### PR TITLE
Document `snap_manageState` storage limit

### DIFF
--- a/docs/guide/snaps-rpc-api.md
+++ b/docs/guide/snaps-rpc-api.md
@@ -782,6 +782,10 @@ console.log(dogecoinPublicKey);
 - Snaps
   :::
 
+::: tip Storage Limit
+Snaps can currently use this RPC method to store up to 100MB of data.
+:::
+
 #### Parameters
 
 - `Array`


### PR DESCRIPTION
Adds a tip about the `snap_manageState` storage limit.

Fixes https://github.com/MetaMask/metamask-docs/issues/578