### PR TITLE
Fix chain id snippet

### DIFF
--- a/docs/snippets/handleProvider.js
+++ b/docs/snippets/handleProvider.js
@@ -27,6 +27,7 @@ function startApp(provider) {
 /**********************************************************/
 
 const chainId = await ethereum.request({ method: 'eth_chainId' });
+// Do something with the chainId
 
 ethereum.on('chainChanged', handleChainChanged);
 

--- a/docs/snippets/handleProvider.js
+++ b/docs/snippets/handleProvider.js
@@ -27,7 +27,6 @@ function startApp(provider) {
 /**********************************************************/
 
 const chainId = await ethereum.request({ method: 'eth_chainId' });
-handleChainChanged(chainId);
 
 ethereum.on('chainChanged', handleChainChanged);
 


### PR DESCRIPTION
Our `chainId` snippet would cause an infinite reload loop if used. This PR fixes it.