### PR TITLE
Replace instances of snaps-skunkworks URL with snaps-monorepo

### DIFF
--- a/docs/guide/snaps-development-guide.md
+++ b/docs/guide/snaps-development-guide.md
@@ -342,7 +342,7 @@ Don't forget to run `mm-snap manifest --fix` if you modified your snap bundle af
 Otherwise your manifest `shasum` value won't be correct, and attempting to install your snap will fail.
 :::
 
-If you run into a build or eval issue that you can't solve on your own, please create an issue on the [MetaMask/snaps-skunkworks](https://github.com/MetaMask/snaps-skunkworks) repository.
+If you run into a build or eval issue that you can't solve on your own, please create an issue on the [MetaMask/snaps-monorepo](https://github.com/MetaMask/snaps-monorepo) repository.
 
 #### Using Other Build Tools
 
@@ -352,7 +352,7 @@ If you prefer building your snap with a build system you are more comfortable wi
 - [Rollup](https://www.npmjs.com/package/@metamask/rollup-plugin-snaps)
 - [Browserify](https://www.npmjs.com/package/@metamask/snaps-browserify-plugin)
 
-For examples on how to set up these build systems yourself, please visit our [examples](https://github.com/MetaMask/snaps-skunkworks/tree/main/packages/examples/examples).
+For examples on how to set up these build systems yourself, please visit our [examples](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples/examples).
 
 We still recommend using our CLI `mm-snap` to make sure your manifest `shasum` value is correct by running `mm-snap manifest --fix` after creating your bundle. You may also benefit from running `mm-snap eval` to detect any SES issues up front.
 
@@ -401,7 +401,7 @@ In the future, MetaMask will create some way for users to more easily discover s
 
 ## Resources and Tools
 
-You can review the growing number of [example snaps](https://github.com/MetaMask/snaps-skunkworks/tree/main/packages/examples) maintained by MetaMask, as well as the following reference Snaps. Each one is fully-functional and open-source:
+You can review the growing number of [example snaps](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples) maintained by MetaMask, as well as the following reference Snaps. Each one is fully-functional and open-source:
 
 - [StarkNet](https://github.com/ConsenSys/starknet-snap)
 - [FilSnap for Filecoin](https://github.com/Chainsafe/filsnap/)
@@ -417,4 +417,4 @@ MetaMask also maintains tools to help developers debug, build and maintain Snaps
 - [Snaps Inspector](https://inspector.open-rpc.org/?request[jsonrpc]=2.0&request[method]=confirm&request[params][0]=hello&request[params][1]=more&request[params][2]=lorem%20ipsum&request[id]=0&url=npm:@metamask/test-snap-confirm&customTransport[type]=plugin&customTransport[name]=Snaps&customTransport[transport][type]=postmessageiframe&customTransport[transport][name]=PostMessageIframe&customTransport[uri]=https://xops.github.io/inspector-snaps-transport/) - An API tool to make JSON-RPC requests directly to Snaps.
 - [Snaps OpenRPC Generator](https://github.com/xops/snaps-openrpc-generator) - A project skeleton generator that creates a Snap and documentation from your [OpenRPC document](https://spec.open-rpc.org/#openrpc-document)
 
-Finally, if you need help, you can ask for help on our [discussion board](https://github.com/MetaMask/snaps-skunkworks/discussions), and if you encounter any issues, please open an issue in our [issue tracker](https://github.com/MetaMask/snaps-skunkworks/issues).
+Finally, if you need help, you can ask for help on our [discussion board](https://github.com/MetaMask/snaps-monorepo/discussions), and if you encounter any issues, please open an issue in our [issue tracker](https://github.com/MetaMask/snaps-monorepo/issues).

--- a/docs/guide/snaps-exports.md
+++ b/docs/guide/snaps-exports.md
@@ -5,7 +5,7 @@ Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://me
 :::
 
 ::: tip Feature Requests
-Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
+Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-monorepo/discussions) to join the discussion.
 :::
 
 ## Table of Contents

--- a/docs/guide/snaps-patching-dependencies.md
+++ b/docs/guide/snaps-patching-dependencies.md
@@ -24,7 +24,7 @@ Then add a postinstall script to your `package.json`.
 
 Now you can make changes to your dependencies inside `node_modules` and run `yarn patch-package package-name` to save the changes as a patch. This will create a `.patch` file containing your dependency patch. These patches can be committed to your Git repository and will be replayed when you re-install your dependencies.
 
-**If you need guidance in how you can patch your dependencies or otherwise need help troubleshooting dependency problems, please create an issue on the [MetaMask/snaps-skunkworks](https://github.com/MetaMask/snaps-skunkworks) repository.**
+**If you need guidance in how you can patch your dependencies or otherwise need help troubleshooting dependency problems, please create an issue on the [MetaMask/snaps-monorepo](https://github.com/MetaMask/snaps-monorepo) repository.**
 
 ## Patching the use of XMLHttpRequest
 

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -5,7 +5,7 @@ Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://me
 :::
 
 ::: tip Feature Requests
-Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
+Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-monorepo/discussions) to join the discussion.
 :::
 
 To access certain powerful JavaScript globals or JSON-RPC methods, your snap will need to ask the user for permission. Snaps follow the [EIP-2255 wallet permissions specification](https://eips.ethereum.org/EIPS/eip-2255), and your snap's required permissions must be specified in the `initialPermissions` field of your [`snap.manifest.json` file](./snaps-development-guide.md#the-snap-manifest).

--- a/docs/guide/snaps-rpc-api.md
+++ b/docs/guide/snaps-rpc-api.md
@@ -5,7 +5,7 @@ Snaps is pre-release software. To try Snaps, install [MetaMask Flask](https://me
 :::
 
 ::: tip Feature Requests
-Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-skunkworks/discussions) to join the discussion.
+Do you have feature requests? Other ideas? We'd love to hear about them! [Click here](https://github.com/MetaMask/snaps-monorepo/discussions) to join the discussion.
 :::
 
 ## Table of Contents

--- a/docs/guide/snaps.md
+++ b/docs/guide/snaps.md
@@ -73,7 +73,7 @@ Perform actions that run periodically at fixed times, dates, or intervals.
 
 ### Propose a feature
 
-Create a feature proposal with your ideas in our [GitHub discussion board](https://github.com/MetaMask/snaps-skunkworks/discussions).
+Create a feature proposal with your ideas in our [GitHub discussion board](https://github.com/MetaMask/snaps-monorepo/discussions).
 
 ## Getting started
 
@@ -173,4 +173,4 @@ You can also look at some of the existing snaps being developed right now. Each 
 
 ## GitHub discussion board
 
-If you have questions, proposals, or need help with anything related to Snaps, you're always welcome to ask our team and community on [GitHub discussions](https://github.com/MetaMask/snaps-skunkworks/discussions).
+If you have questions, proposals, or need help with anything related to Snaps, you're always welcome to ask our team and community on [GitHub discussions](https://github.com/MetaMask/snaps-monorepo/discussions).


### PR DESCRIPTION
This repository URL has been updated from snaps-skunkworks to snaps-monorepo: 

https://github.com/MetaMask/snaps-monorepo

Instances of the old URL are updated in this PR