### PR TITLE
Add documentation about `allowTransactionOrigin` caveat

### DIFF
--- a/docs/guide/snaps-exports.md
+++ b/docs/guide/snaps-exports.md
@@ -101,7 +101,7 @@ interface OnTransactionArgs {
 ```
 
 ::: warning Getting the `transactionOrigin` parameter
-the `transactionOrigin` property is only passed to `onTransaction` if `allowTransactionOrigin` is set to `true` in the `endowment:transaction-insight` permission object. See [Permissions](./snaps-permissions.html#endowment-transaction-insight) for more information.
+The `transactionOrigin` property is only passed to `onTransaction` if `allowTransactionOrigin` is set to `true` in the `endowment:transaction-insight` permission object. See [Permissions](./snaps-permissions.html#endowment-transaction-insight) for more information.
 :::
 
 ### Returns

--- a/docs/guide/snaps-exports.md
+++ b/docs/guide/snaps-exports.md
@@ -85,19 +85,24 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 If the snap wants to provide transaction insights before a user signs a transaction, the snap must export a function called `onTransaction`. Whenever there is a contract interaction and a transaction is submitted via the extension, this function will be called. The raw unsigned transaction payload will be passed to the `onTransaction` handler function.
 
 ::: warning Requesting the transaction insight permission
-In order for the extension to call the `onTransaction` method of the snap, the `endowment:transaction-insight` permission must be requested. see [Permissions](./snaps-permissions.html#endowment-transaction-insight)
+In order for the extension to call the `onTransaction` method of the snap, the `endowment:transaction-insight` permission must be requested. See [Permissions](./snaps-permissions.html#endowment-transaction-insight) for more information.
 :::
 
 ### Parameters
 
-- `onTransactionArgs` - the raw transaction payload and the [CAIP-2 chain ID](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md). For more details on the transaction object see [SIP-3](https://metamask.github.io/SIPs/SIPS/sip-3#appendix-i-ethereum-transaction-objects).
+- `onTransactionArgs` - the raw transaction payload, the [CAIP-2 chain ID](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) and the transaction origin if [allowTransactionOrigin](./snaps-permissions.html#endowment-transaction-insight) is set to `true`. For more details on the transaction object see [SIP-3](https://metamask.github.io/SIPs/SIPS/sip-3#appendix-i-ethereum-transaction-objects).
 
 ```typescript
 interface OnTransactionArgs {
   transaction: Record<string, unknown>;
   chainId: string;
+  transactionOrigin?: string;
 }
 ```
+
+::: warning Getting the `transactionOrigin` parameter
+the `transactionOrigin` property is only passed to `onTransaction` if `allowTransactionOrigin` is set to `true` in the `endowment:transaction-insight` permission object. See [Permissions](./snaps-permissions.html#endowment-transaction-insight) for more information.
+:::
 
 ### Returns
 
@@ -119,6 +124,7 @@ interface OnTransactionResponse {
 import { OnTransactionHandler } from "@metamask/snap-types";
 
 export const onTransaction: OnTransactionHandler = async ({
+  transactionOrigin
   transaction,
   chainId,
 }) => {
@@ -131,6 +137,7 @@ export const onTransaction: OnTransactionHandler = async ({
 
 ```js
 module.exports.onTransaction = async ({
+  transactionOrigin
   transaction,
   chainId,
 }) => {

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -50,7 +50,7 @@ For snaps that need to access the internet, the snap can request the `endowment:
 
 For snaps that provide transaction insights, the snap can request the `endowment:transaction-insight` permission. This permission grants a snap read-only access to raw transaction payloads, before they are accepted for signing by the user, by exporting the `onTransaction` method. See [Exports](./snaps-exports.html#ontransaction) for more information.
 
-This permission requires an object with a `allowTransactionOrigin` property, to signal if the snap should pass the `origin` property to `onTransaction` parameters. This property represent the transaction initiator origin. Default to `false`.
+This permission requires an object with an `allowTransactionOrigin` property, to signal if the snap should pass the `origin` property to the `onTransaction` parameters. This property represents the transaction initiator origin. Default to `false`.
 
 ```json
 {

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -50,6 +50,16 @@ For snaps that need to access the internet, the snap can request the `endowment:
 
 For snaps that provide transaction insights, the snap can request the `endowment:transaction-insight` permission. This permission grants a snap read-only access to raw transaction payloads, before they are accepted for signing by the user, by exporting the `onTransaction` method. See [Exports](./snaps-exports.html#ontransaction) for more information.
 
+This permission requires an object with a `allowTransactionOrigin` property, to signal if the snap should pass the `origin` property to `onTransaction` parameters. This property represent the transaction initiator origin. Default to `false`.
+
+```json
+{
+  "endowment:transaction-insight": {
+    "allowTransactionOrigin": true
+  }
+}
+```
+
 ### `endowment:cronjob`
 
 For snaps that wants to run periodic actions for the user, the snap can request the `endowment:cronjob` permission. This permission allows a snap to specify periodic requests that will trigger the exported `onCronjob` method. see [Exports](./snaps-exports.html#oncronjob).

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -50,7 +50,7 @@ For snaps that need to access the internet, the snap can request the `endowment:
 
 For snaps that provide transaction insights, the snap can request the `endowment:transaction-insight` permission. This permission grants a snap read-only access to raw transaction payloads, before they are accepted for signing by the user, by exporting the `onTransaction` method. See [Exports](./snaps-exports.html#ontransaction) for more information.
 
-This permission requires an object with an `allowTransactionOrigin` property, to signal if the snap should pass the `origin` property to the `onTransaction` parameters. This property represents the transaction initiator origin. Default to `false`.
+This permission requires an object with an `allowTransactionOrigin` property to signal if the snap should pass the `transactionOrigin` property as part of the `onTransaction` parameters. This property represents the transaction initiator origin. Default to `false`.
 
 ```json
 {


### PR DESCRIPTION
This adds documentation for the `allowTransactionOrigin` caveat of `endowment:transaction-insight` permission.

Fixes: #597

Waiting on Flask `10.24.0`  release to merge.