### PR TITLE
Update Snap Publishing specification link

### DIFF
--- a/docs/guide/snaps-development-guide.md
+++ b/docs/guide/snaps-development-guide.md
@@ -149,7 +149,7 @@ For the time being, snaps can only be [published to the official npm registry](h
 Over time, developers will be able to distribute snaps in a variety of different ways, and the manifest will expand to support different publishing solutions.
 
 ::: tip The Snaps Publishing Specification
-The [snaps publishing specification](https://github.com/MetaMask/specifications/blob/main/snaps/publishing.md) details the requirements of both `snap.manifest.json` and its relationship to `package.json`.
+The [snaps publishing specification](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-9.md) details the requirements of both `snap.manifest.json` and its relationship to `package.json`.
 :::
 
 In the course of developing your snap, you will have to modify some of the manifest fields manually.


### PR DESCRIPTION
Snap publishing specification has been superseded by the Snaps Improvements Proposals specifications and so it has been moved there as a SIP-9