### PR TITLE
Add docs for `endowment:webassembly`

### DIFF
--- a/docs/guide/snaps-development-guide.md
+++ b/docs/guide/snaps-development-guide.md
@@ -310,7 +310,7 @@ In addition, the following globals are available:
 - `setTimeout` / `clearTimeout`
 - `setInterval` / `clearInterval`
 - `SubtleCrypto`
-- `WebAssembly`
+- `WebAssembly` (with the `endowment:webassembly` permission)
 - `TextEncoder` / `TextDecoder`
 - `atob` / `btoa`
 - `URL`

--- a/docs/guide/snaps-permissions.md
+++ b/docs/guide/snaps-permissions.md
@@ -105,6 +105,10 @@ Cronjobs are specified as follows:
 
 For snaps that wish to communicate with a node via MetaMask, the snap can request the `endowment:ethereum-provider` permission. This permission will expose the global API `ethereum` to the snap execution environment. Without this permission, this global will not be available. This global is a EIP-1193 provider.
 
+### `endowment:webassembly`
+
+For snaps that wish to leverage `WebAssembly`, the snap can request the `endowment:webassembly` permission. This permission will expose the global `WebAssembly` API to the snap execution environment.
+
 ## RPC Permissions
 
 To use any restricted RPC method, a snap will need to request permissions to access that method. For a list of available RPC methods and thus valid RPC permissions see [JSON-RPC API](./snaps-rpc-api.html#restricted-methods).


### PR DESCRIPTION
Adds docs for `endowment:webassembly`. To be merged when Flask `10.28.1` goes out.

Fixes #683