### PR TITLE
Update SDK docs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -88,3 +88,19 @@ h4 {
 .navbar__title {
   font-weight: 500;
 }
+
+table {
+  display: table;
+  width: 100%;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-auto-rows: auto;
+  grid-gap: 2rem;
+  padding: 1rem 2rem 3rem;
+}
+
+.card {
+}

--- a/wallet-sidebar.js
+++ b/wallet-sidebar.js
@@ -25,16 +25,51 @@ const sidebar = {
         {
           type: "category",
           label: "Use MetaMask SDK",
-          collapsed: true,
           link: {
             type: "doc",
             id: "how-to/use-sdk/index",
           },
           items: [
-            "how-to/use-sdk/react-native",
-            "how-to/use-sdk/pure-js",
-            "how-to/use-sdk/ios",
-            "how-to/use-sdk/unity",
+            {
+              type: "category",
+              label: "JavaScript",
+              link: {
+                type: "doc",
+                id: "how-to/use-sdk/javascript/index",
+              },
+              items: [
+                "how-to/use-sdk/javascript/react",
+                "how-to/use-sdk/javascript/pure-js",
+                "how-to/use-sdk/javascript/other-web-frameworks",
+                "how-to/use-sdk/javascript/react-native",
+                "how-to/use-sdk/javascript/nodejs",
+                "how-to/use-sdk/javascript/electron",
+              ],
+            },
+            {
+              type: "category",
+              label: "Mobile",
+              link: {
+                type: "doc",
+                id: "how-to/use-sdk/mobile/index",
+              },
+              items: [
+                "how-to/use-sdk/mobile/ios",
+                "how-to/use-sdk/mobile/android",
+              ],
+            },
+            {
+              type: "category",
+              label: "Gaming",
+              link: {
+                type: "doc",
+                id: "how-to/use-sdk/gaming/index",
+              },
+              items: [
+                "how-to/use-sdk/gaming/unity",
+                "how-to/use-sdk/gaming/unreal-engine",
+              ],
+            },
           ],
         },
         "how-to/use-mobile",

--- a/wallet/concepts/sdk-connections.md
+++ b/wallet/concepts/sdk-connections.md
@@ -24,6 +24,14 @@ paused and resumes when the user opens it again.
 
 Because of this, polling data from MetaMask Mobile may not work for long periods of time.
 
+:::info known issue
+Sometimes the connection pauses when MetaMask Mobile is in background and doesn't resume properly
+when the user opens MetaMask Mobile again.
+The user must return to your dapp so the request is re-sent.
+The SDK team is working on this issue, and is researching decentralized communication solutions that
+hold state such as [Waku](https://waku.org/).
+:::
+
 ### Cleared connections
 
 Connections clear if the user closes or refreshes your dapp, since MetaMask doesn't persist

--- a/wallet/how-to/use-sdk/gaming/index.md
+++ b/wallet/how-to/use-sdk/gaming/index.md
@@ -1,0 +1,8 @@
+# Use MetaMask SDK with gaming dapps
+
+You can import MetaMask SDK into your gaming dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+See the instructions for the following gaming platforms:
+
+- [Unity](unity.md)
+- [Unreal Engine](unreal-engine.md) (coming soon)

--- a/wallet/how-to/use-sdk/gaming/unity.md
+++ b/wallet/how-to/use-sdk/gaming/unity.md
@@ -1,5 +1,5 @@
 ---
-title: Unity gaming
+title: Unity
 ---
 
 # Use MetaMask SDK with Unity
@@ -10,10 +10,10 @@ The MetaMask Unity SDK supports macOS, Windows, Linux, iOS, Android, and WebGL.
 
 ## How it works
 
-The SDK renders a QR code in the UI using a dedicated prefab which players can scan with their
-MetaMask Mobile app.
+The SDK renders a QR code in the Unity game UI using a dedicated prefab which players can scan with
+their MetaMask Mobile app.
 It also supports deeplinking on mobile platforms.
-You can use all the [provider API methods](../../reference/provider-api.md) right from your game.
+You can use all the [provider API methods](../../../reference/provider-api.md) right from your game.
 
 ## Video demo
 
@@ -78,7 +78,7 @@ You first must initialize by doing one of the following:
 - Check **Initialize On Start** on the component within the editor.
 
 This initializes the wallet instance, making it accessible from `MetaMaskUnity.Instance.Wallet`.
-You can now make calls to the user's wallet using [provider API methods](../../reference/provider-api.md).
+You can now make calls to the user's wallet using [provider API methods](../../../reference/provider-api.md).
 
 ### 4. Connect to MetaMask
 
@@ -231,7 +231,7 @@ This method disconnects the user that is connected from the MetaMask app session
 #### `Request`
 
 This method sends a request to MetaMask.
-You can use it to call any [provider API method](../../reference/provider-api.md).
+You can use it to call any [provider API method](../../../reference/provider-api.md).
 
 ## Package structure
 

--- a/wallet/how-to/use-sdk/gaming/unreal-engine.md
+++ b/wallet/how-to/use-sdk/gaming/unreal-engine.md
@@ -1,0 +1,9 @@
+---
+title: Unreal Engine (coming soon)
+---
+
+# Use MetaMask SDK with Unreal Engine
+
+MetaMask SDK support for Unreal Engine games is coming soon.
+The SDK currently supports [Unity](unity.md) gaming dapps,
+[JavaScript-based](../javascript/index.md) dapps, and [mobile](../mobile/index.md) dapps.

--- a/wallet/how-to/use-sdk/index.md
+++ b/wallet/how-to/use-sdk/index.md
@@ -1,17 +1,49 @@
 # Use MetaMask SDK
 
-MetaMask SDK currently supports all JavaScript-based, native iOS, and Unity gaming dapps.
-It provides a reliable, secure, and seamless [connection](../../concepts/sdk-connections.md) from
-your dapp to a MetaMask wallet client.
+MetaMask SDK provides a reliable, secure, and seamless [connection](../../concepts/sdk-connections.md)
+from your dapp to a MetaMask wallet client.
+It supports the following dapp platforms:
 
-The following instructions work for dapps based on standard JavaScript, React, Node.js, Electron,
-and other web frameworks.
-You can also see instructions for [React Native](react-native.md), [pure JavaScript](pure-js.md),
-[native iOS](ios.md), and [Unity gaming](unity.md) dapps.
-
-:::tip Coming soon
-SDK support for Android and Unreal Engine dapps is coming soon.
-:::
+<div class="cards">
+  <div class="card">
+    <div class="card__header">
+      <h3><a href="javascript">JavaScript</a></h3>
+    </div>
+    <div class="card__body">
+      <ul>
+        <li><a href="javascript/react">React</a></li>
+        <li><a href="javascript/pure-js">Pure JavaScript</a></li>
+        <li><a href="javascript/other-web-frameworks">Other web frameworks</a></li>
+        <li><a href="javascript/react-native">React Native</a></li>
+        <li><a href="javascript/nodejs">Node.js</a></li>
+        <li><a href="javascript/electron">Electron</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card__header">
+      <h3><a href="mobile">Mobile</a></h3>
+    </div>
+    <div class="card__body">
+      <ul>
+        <li><a href="javascript/react-native">React Native</a></li>
+        <li><a href="mobile/ios">Native iOS</a></li>
+        <li><a href="mobile/android">Native Android</a> (coming soon)</li>
+      </ul>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card__header">
+      <h3><a href="gaming">Gaming</a></h3>
+    </div>
+    <div class="card__body">
+      <ul>
+        <li><a href="gaming/unity">Unity</a></li>
+        <li><a href="gaming/unreal-engine">Unreal Engine</a> (coming soon)</li>
+      </ul>
+    </div>
+  </div>
+</div>
 
 :::note
 MetaMask SDK uses the [Ethereum provider](../../reference/provider-api.md) that developers are
@@ -20,11 +52,13 @@ already used to, so existing dapps work out of the box with the SDK.
 
 ## How it works
 
+The following are examples of how a user experiences a dapp with the SDK installed, on various platforms.
+
 <!--tabs-->
 
-# Desktop browser
+# Desktop
 
-If a user accesses your web dapp on a desktop browser and doesn't have the MetaMask extension
+When a user accesses your web dapp on a desktop browser and doesn't have the MetaMask extension
 installed, a popup appears that prompts the user to either install the MetaMask extension or connect
 to MetaMask Mobile using a QR code.
 
@@ -32,13 +66,14 @@ to MetaMask Mobile using a QR code.
 
 You can try the
 [hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
-You can also see this
+You can also download the
 [React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
+Install the example using `yarn` and run it using `yarn start`.
 
-# Mobile browser
+# Mobile
 
-If a user accesses your web dapp on a mobile browser, the SDK automatically deeplinks to MetaMask
-Mobile (or if the user doesn't already have it, prompts them to install it).
+When a user accesses your mobile dapp, or web dapp on a mobile browser, the SDK automatically
+deeplinks to MetaMask Mobile (or if the user doesn't already have it, prompts them to install it).
 Once the user accepts the connection, they're automatically redirected back to your dapp.
 This happens for all actions that need user approval.
 
@@ -50,8 +85,9 @@ This happens for all actions that need user approval.
 
 You can try the
 [hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
-You can also see this
+You can also download the
 [React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
+Install the example using `yarn` and run it using `yarn start`.
 
 # Node.js
 
@@ -64,52 +100,25 @@ scan with their MetaMask Mobile app.
 
 </p>
 
+You can download the
+[Node.js example](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/downloads/nodejs_v0.0.1_beta5.zip).
+Install the example using `yarn` and run it using `node .`.
+
+# React Native
+
+When a user accesses your mobile React Native dapp, the SDK automatically deeplinks to MetaMask
+Mobile (or if the user doesn't already have it, prompts them to install it).
+Once the user accepts the connection, they're automatically redirected back to your dapp.
+This happens for all actions that need user approval.
+
+<p align="center">
+
+![SDK React Native example](../../assets/sdk-react-native.gif)
+
+</p>
+
+You can download the
+[React Native example](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/downloads/reactNativeApp_v0.1.0.zip).
+Install the example using `yarn setup` and run it using `yarn ios` or `yarn android`.
+
 <!--/tabs-->
-
-## Prerequisites
-
-- An existing or [new project](../../get-started/set-up-dev-environment.md) set up.
-- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above.
-- [Yarn](https://yarnpkg.com/getting-started/install) or
-  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
-
-## Steps
-
-### 1. Install the SDK
-
-In your project directory, install the SDK using Yarn or npm:
-
-```bash
-yarn add @metamask/sdk
-or
-npm i @metamask/sdk
-```
-
-### 2. Import the SDK
-
-In your project script, add the following to import the SDK:
-
-```javascript
-import MetaMaskSDK from '@metamask/sdk';
-```
-
-### 3. Instantiate the SDK
-
-Instantiate the SDK using any [options](../../reference/sdk-js-options.md):
-
-```javascript
-const MMSDK = new MetaMaskSDK(options);
-
-const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
-```
-
-### 4. Use the SDK
-
-Use the SDK by calling any [provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#eth_requestaccounts) using
-[`ethereum.request(args)`](../../reference/provider-api.md#windowethereumrequestargs)
-first, since it prompts the installation or connection popup to appear.
-
-```javascript
-ethereum.request({ method: 'eth_requestAccounts', params: [] });
-```

--- a/wallet/how-to/use-sdk/javascript/electron.md
+++ b/wallet/how-to/use-sdk/javascript/electron.md
@@ -1,0 +1,11 @@
+---
+title: Electron
+---
+
+# Use MetaMask SDK with Electron
+
+You can import MetaMask SDK into your Electron dapp to enable your users to easily connect with
+their MetaMask Mobile wallet.
+
+On the frontend, see the instructions to use the SDK with [React](react.md).
+On the backend, see the instructions to use the SDK with [Node.js](nodejs.md).

--- a/wallet/how-to/use-sdk/javascript/index.md
+++ b/wallet/how-to/use-sdk/javascript/index.md
@@ -1,0 +1,94 @@
+# Use MetaMask SDK with JavaScript
+
+You can import MetaMask SDK into your JavaScript dapp to enable your users to easily connect
+with a MetaMask wallet client.
+The following instructions work for web dapps based on standard JavaScript.
+You can also see instructions for the following JavaScript-based platforms:
+
+- [React](react.md)
+- [Pure JavaScript](pure-js.md)
+- [Other web frameworks](other-web-frameworks.md)
+- [React Native](react-native.md)
+- [Node.js](nodejs.md)
+- [Electron](electron.md)
+
+## How it works
+
+<!--tabs-->
+
+# Desktop browser
+
+When a user accesses your JavaScript web dapp on a desktop browser and doesn't have the MetaMask
+extension installed, a popup appears that prompts the user to either install the MetaMask extension or connect
+to MetaMask Mobile using a QR code.
+
+![SDK desktop browser example](../../../assets/sdk-desktop-browser.gif)
+
+# Mobile browser
+
+When a user accesses your JavaScript web dapp on a mobile browser, the SDK automatically deeplinks
+to MetaMask Mobile (or if the user doesn't already have it, prompts them to install it).
+Once the user accepts the connection, they're automatically redirected back to your dapp.
+This happens for all actions that need user approval.
+
+<p align="center">
+
+![SDK mobile browser example](../../../assets/sdk-mobile-browser.gif)
+
+</p>
+
+<!--/tabs-->
+
+You can try the
+[hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
+You can also download the
+[React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
+Install the example using `yarn` and run it using `yarn start`.
+
+## Prerequisites
+
+- An existing or [new project](../../../get-started/set-up-dev-environment.md) set up.
+- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above.
+- [Yarn](https://yarnpkg.com/getting-started/install) or
+  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/nodejs.md
+++ b/wallet/how-to/use-sdk/javascript/nodejs.md
@@ -1,0 +1,65 @@
+---
+title: Node.js
+---
+
+# Use MetaMask SDK with Node.js
+
+You can import MetaMask SDK into your Node.js dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for Node.js has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## How it works
+
+When a user accesses your Node.js dapp, the SDK renders a QR code on the console which users can
+scan with their MetaMask Mobile app.
+
+<p align="center">
+
+![SDK Node.js example](../../../assets/sdk-nodejs.gif)
+
+</p>
+
+You can download the
+[Node.js example](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/downloads/nodejs_v0.0.1_beta5.zip).
+Install the example using `yarn` and run it using `node .`.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
+++ b/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
@@ -1,0 +1,51 @@
+---
+title: Other web frameworks
+---
+
+# Use MetaMask SDK with other web frameworks
+
+You can import MetaMask SDK into your web dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for other web frameworks [works the same way](index.md#how-it-works) and has the
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/pure-js.md
+++ b/wallet/how-to/use-sdk/javascript/pure-js.md
@@ -7,7 +7,7 @@ title: Pure JavaScript
 You can import MetaMask SDK into your pure JavaScript dapp to enable your users to easily connect
 with a MetaMask wallet client.
 The SDK for pure JavaScript [works the same way](index.md#how-it-works) and has the
-[same prerequisites](index.md#prerequisites) as for standard JavaScript and other web frameworks.
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
 To import, instantiate, and use the SDK, you can insert a script in the head section of your website:
 
@@ -31,8 +31,8 @@ To import, instantiate, and use the SDK, you can insert a script in the head sec
 </head>
 ```
 
-You can configure the SDK using any [options](../../reference/sdk-js-options.md) and call any
-[provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#eth_requestaccounts) using
-[`ethereum.request(args)`](../../reference/provider-api.md#windowethereumrequestargs) first, since
-it prompts the installation or connection popup to appear.
+You can configure the SDK using any [options](../../../reference/sdk-js-options.md) and call any
+[provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request(args)`](../../../reference/provider-api.md#windowethereumrequestargs) first,
+since it prompts the installation or connection popup to appear.

--- a/wallet/how-to/use-sdk/javascript/react-native.md
+++ b/wallet/how-to/use-sdk/javascript/react-native.md
@@ -9,14 +9,14 @@ with their MetaMask Mobile wallet.
 
 ## How it works
 
-When a user accesses your mobile React Native dapp, the SDK automatically deeplinks to MetaMask
+When a user accesses your React Native mobile dapp, the SDK automatically deeplinks to MetaMask
 Mobile (or if the user doesn't already have it, prompts them to install it).
 Once the user accepts the connection, they're automatically redirected back to your dapp.
 This happens for all actions that need user approval.
 
 <p align="center">
 
-![SDK React Native example](../../assets/sdk-react-native.gif)
+![SDK React Native example](../../../assets/sdk-react-native.gif)
 
 </p>
 
@@ -125,11 +125,11 @@ const ethereum = MMSDK.getProvider();
 const accounts = await ethereum.request({ method: 'eth_requestAccounts' });
 ```
 
-You can configure the SDK using any [options](../../reference/sdk-js-options.md) and call any
-[provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#eth_requestaccounts) using
-[`ethereum.request()`](../../reference/provider-api.md#windowethereumrequestargs) first, since it
-prompts the installation or connection popup to appear.
+You can configure the SDK using any [options](../../../reference/sdk-js-options.md) and call any
+[provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request(args)`](../../../reference/provider-api.md#windowethereumrequestargs) first,
+since it prompts the installation or connection popup to appear.
 
 You can use [EthersJS](https://docs.ethers.io/v5/getting-started/) with your React Native app:
 

--- a/wallet/how-to/use-sdk/javascript/react.md
+++ b/wallet/how-to/use-sdk/javascript/react.md
@@ -1,0 +1,51 @@
+---
+title: React
+---
+
+# Use MetaMask SDK with React
+
+You can import MetaMask SDK into your React dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for React [works the same way](index.md#how-it-works) and has the
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/mobile/android.md
+++ b/wallet/how-to/use-sdk/mobile/android.md
@@ -1,0 +1,10 @@
+---
+title: Native Android (coming soon)
+---
+
+# Use MetaMask SDK with Android
+
+MetaMask SDK support for native Android dapps is coming soon.
+The SDK currently supports [React Native](../javascript/react-native.md) and [native iOS](ios.md)
+mobile dapps, [JavaScript-based](../javascript/index.md) dapps, and [Unity](../gaming/unity.md)
+gaming dapps.

--- a/wallet/how-to/use-sdk/mobile/index.md
+++ b/wallet/how-to/use-sdk/mobile/index.md
@@ -1,0 +1,22 @@
+# Use MetaMask SDK with mobile dapps
+
+You can import MetaMask SDK into your mobile dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+See the instructions for the following mobile platforms:
+
+- [React Native](../javascript/react-native.md)
+- [Native iOS](ios.md)
+- [Native Android](android.md) (coming soon)
+
+## How it works
+
+When a user accesses your mobile dapp, the SDK automatically deeplinks to MetaMask Mobile (or if the
+user doesn't already have it, prompts them to install it).
+Once the user accepts the connection, they're automatically redirected back to your dapp.
+This happens for all actions that need user approval.
+
+<p align="center">
+
+![SDK mobile browser example](../../../assets/sdk-mobile-browser.gif)
+
+</p>

--- a/wallet/how-to/use-sdk/mobile/ios.md
+++ b/wallet/how-to/use-sdk/mobile/ios.md
@@ -62,7 +62,7 @@ To disable this, set `MetaMaskSDK.shared.enableDebug = false` or `ethereum.enabl
 
 ### 4. Call provider methods
 
-You can now call any [provider API method](../../reference/provider-api.md).
+You can now call any [provider API method](../../../reference/provider-api.md).
 
 The SDK uses [Combine](https://developer.apple.com/documentation/combine) to publish Ethereum
 events, so you need to define an `AnyCancellable` storage by adding the following line to your
@@ -73,8 +73,8 @@ project file:
 ```
 
 The following examples use the
-[`window.ethereum.request(args)`](../../reference/provider-api.md#windowethereumrequestargs)
-provider API method to call various [RPC API](../../reference/rpc-api.md) methods.
+[`window.ethereum.request(args)`](../../../reference/provider-api.md#windowethereumrequestargs)
+provider API method to call various [RPC API](../../../reference/rpc-api.md) methods.
 
 #### Example: Get chain ID
 


### PR DESCRIPTION
Update SDK docs:

- Restructure SDK docs to have separate how-to page for each platform and category.
- Implement cards on main SDK page to better display supported platforms.
- On main SDK page, mention that the screen recordings show the user experience.
- Add a known issue note to the SDK connections page.