### PR TITLE
Update instructions for creating a snap

### DIFF
--- a/snaps/get-started/install-snaps.md
+++ b/snaps/get-started/install-snaps.md
@@ -4,7 +4,7 @@ description: Install Snaps dependencies.
 
 # Install Snaps
 
-To use Snaps, you must install [MetaMask Flask](#install-metamask-flask) and the [Snaps CLI](#install-the-snaps-cli).
+To use Snaps, you must install [MetaMask Flask](#install-metamask-flask).
 
 You can then [get started quickly using the Snaps template](quickstart.md).
 
@@ -27,22 +27,3 @@ Flask.
 :::caution
 Running multiple instances of MetaMask in the same browser profile breaks dapp interactions.
 :::
-
-## Install the Snaps CLI
-
-The [Snaps CLI](../reference/cli/index.md) provides commands for initiating a snap project and building,
-executing, and serving your snap for local development.
-
-In a terminal window, install the CLI globally using npm or Yarn:
-
-```bash
-npm install -g @metamask/snaps-cli
-or
-yarn global add @metamask/snaps-cli
-```
-
-Verify the installation and display usage instructions:
-
-```bash
-mm-snap --help
-```

--- a/snaps/get-started/install-snaps.md
+++ b/snaps/get-started/install-snaps.md
@@ -6,7 +6,7 @@ description: Install Snaps dependencies.
 
 To use Snaps, you must install [MetaMask Flask](#install-metamask-flask).
 
-You can then [get started quickly using the Snaps template](quickstart.md).
+You can then [get started quickly using the Create Snap CLI](quickstart.md).
 
 ## Prerequisites
 

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -5,7 +5,7 @@ description: Get started quickly using the Snaps template.
 # Snaps quickstart
 
 Get started with Snaps using the
-[Snaps template](https://github.com/MetaMask/template-snap-monorepo) built with TypeScript and React.
+[Create Snap CLI](https://github.com/MetaMask/snaps-monorepo/packages/create-snap). With the CLI, you can initialize a snap monorepo project built with TypeScript and React.
 
 ## Prerequisites
 
@@ -22,21 +22,19 @@ Get started with Snaps using the
 
 ## Create the project
 
-Use the Snaps template by
-[creating a new repository from the template](https://github.com/MetaMask/template-snap-monorepo/generate).
-
-[Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
-using the command line:
+Create a new snap project by using the command line:
 
 ```bash
-git clone git@github.com:<your-username>/template-snap-monorepo.git
+yarn create @metamask/snap your-snap-name
+# or...
+npm create @metamask/snap your-snap-name
 ```
 
 You can learn about the [anatomy of your snap project files](../concepts/anatomy.md).
 
 ## Start the snap
 
-From the root of the repository, install the project dependencies using Yarn:
+From the root of the newly created project, install the project dependencies using Yarn:
 
 ```shell
 yarn

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -5,7 +5,8 @@ description: Get started quickly using the Snaps template.
 # Snaps quickstart
 
 Get started with Snaps using the
-[Create Snap CLI](https://github.com/MetaMask/snaps-monorepo/packages/create-snap). With the CLI, you can initialize a snap monorepo project built with TypeScript and React.
+[Create Snap CLI](https://github.com/MetaMask/snaps-monorepo/packages/create-snap).
+With the CLI, you can initialize a snap monorepo project built with TypeScript and React.
 
 ## Prerequisites
 
@@ -22,7 +23,7 @@ Get started with Snaps using the
 
 ## Create the project
 
-Create a new snap project by using the command line:
+Create a new snap project using the Create Snap CLI by running the following command:
 
 ```bash
 yarn create @metamask/snap your-snap-name

--- a/snaps/reference/cli/index.md
+++ b/snaps/reference/cli/index.md
@@ -6,8 +6,6 @@ description: Snaps CLI subcommands and options reference
 
 This reference describes the syntax of the Snaps command line interface (CLI) subcommands and options.
 
-Make sure to [install the Snaps CLI](../../get-started/install-snaps.md#install-the-snaps-cli).
-
 You can specify subcommands and options using the `mm-snap` command:
 
 ```bash

--- a/snaps/reference/cli/index.md
+++ b/snaps/reference/cli/index.md
@@ -6,6 +6,10 @@ description: Snaps CLI subcommands and options reference
 
 This reference describes the syntax of the Snaps command line interface (CLI) subcommands and options.
 
+:::note
+The CLI is installed when you [create a snap project](../../get-started/quickstart.md).
+:::
+
 You can specify subcommands and options using the `mm-snap` command:
 
 ```bash

--- a/snaps/tutorials/gas-estimation.md
+++ b/snaps/tutorials/gas-estimation.md
@@ -22,16 +22,12 @@ a confirmation dialog.
 
 ### 1. Set up the project
 
-Use the Snaps template by
-[creating a new repository from the template](https://github.com/MetaMask/template-snap-monorepo/generate).
-
-Give your project a new name, such as `gas-estimation-snap`.
-
-[Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
-using the command line:
+Create a new snap project by using the command line:
 
 ```bash
-git clone git@github.com:<your-username>/gas-estimation-snap.git
+yarn create @metamask/snap gas-estimation-snap
+# or...
+npm create @metamask/snap gas-estimation-snap
 ```
 
 To initialize your development environment with the required dependencies, in your project

--- a/snaps/tutorials/gas-estimation.md
+++ b/snaps/tutorials/gas-estimation.md
@@ -5,10 +5,8 @@ description: Create a snap that estimates gas fees.
 # Create a gas estimation snap
 
 This tutorial walks you through creating a snap that estimates gas fees.
-The snap is based on the
-[Snaps template](https://github.com/MetaMask/template-snap-monorepo).
-It uses the `fetch` API to request information from the internet, and displays custom information in
-a confirmation dialog.
+The snap uses the `fetch` API to request information from the internet, and displays custom
+information in a confirmation dialog.
 
 ## Prerequisites
 
@@ -22,7 +20,7 @@ a confirmation dialog.
 
 ### 1. Set up the project
 
-Create a new snap project by using the command line:
+Create a new snap project using the Create Snap CLI by running the following command:
 
 ```bash
 yarn create @metamask/snap gas-estimation-snap

--- a/snaps/tutorials/transaction-insights.md
+++ b/snaps/tutorials/transaction-insights.md
@@ -28,16 +28,12 @@ insights in the MetaMask transaction window.
 
 ### 1. Set up the project
 
-Use the Snaps template by
-[creating a new repository from the template](https://github.com/MetaMask/template-snap-monorepo/generate).
-
-Give your project a new name, such as `transaction-insights-snap`.
-
-[Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
-using the command line:
+Create a new snap project by using the command line:
 
 ```bash
-git clone git@github.com:<your-username>/transaction-insights-snap.git
+yarn create @metamask/snap transaction-insights-snap
+# or...
+npm create @metamask/snap transaction-insights-snap
 ```
 
 To initialize your development environment with the required dependencies, in your project

--- a/snaps/tutorials/transaction-insights.md
+++ b/snaps/tutorials/transaction-insights.md
@@ -6,9 +6,7 @@ description: Create a snap that provides transaction insights.
 
 This tutorial walks you through creating a snap that calculates the percentage of gas fees that
 a user would pay when creating a transaction.
-The snap is based on the
-[Snaps template](https://github.com/MetaMask/template-snap-monorepo), and it provides transaction
-insights in the MetaMask transaction window.
+The snap provides transaction insights in the MetaMask transaction window.
 
 ## Prerequisites
 
@@ -28,7 +26,7 @@ insights in the MetaMask transaction window.
 
 ### 1. Set up the project
 
-Create a new snap project by using the command line:
+Create a new snap project using the Create Snap CLI by running the following command:
 
 ```bash
 yarn create @metamask/snap transaction-insights-snap


### PR DESCRIPTION
Snaps should be created using the CLI rather than cloning the repo.

This should only be merged when the `@metamask/create-snap` package is published on NPM through this PR: https://github.com/MetaMask/snaps-monorepo/pull/1268

fixes #775 