### PR TITLE
Fix typo in gas-estimation.md

### DIFF
--- a/snaps/tutorials/gas-estimation.md
+++ b/snaps/tutorials/gas-estimation.md
@@ -112,7 +112,7 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
         return snap.request({
           method: 'snap_dialog',
           params: {
-            type: 'Alert',
+            type: 'alert',
             content: panel([
               text(`Hello, **${origin}**!`),
               text(`Current gas fee estimates: ${fees}`),


### PR DESCRIPTION
Alert -> alert

An error happened: The "type" property must be one of: alert, confirmation, prompt.