### PR TITLE
improve Snaps documentation

### DIFF
--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -30,11 +30,11 @@ Endowments are a type of permission.
 See the [Snaps permissions reference](../reference/permissions.md) for the full list of endowments
 you can specify in the manifest file.
 
-For example, to request the [`endowment:long-running`](../reference/permissions.md#endowmentlong-running)
+For example, to request the [`endowment:network-access`](../reference/permissions.md#endowmentnetwork-access)
 permission, add the following to the manifest file:
 
 ```json
 "initialPermissions": {
-  "endowment:long-running": {}
+  "endowment:network-access": {}
 },
 ```

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -60,44 +60,6 @@ console.log(result);
 
 <!--/tabs-->
 
-### wallet_invokeSnap
-
-Invokes the specified JSON-RPC method of the specified snap.
-The snap must be installed and the caller must have the permission to communicate with the snap, or
-the request is rejected.
-
-Snaps are fully responsible for implementing their JSON-RPC API.
-Consult the snap's documentation for available methods, their parameters, and return values.
-
-This method is only callable by websites.
-
-#### Parameters
-
-An object containing:
-
-- `snapId` - The ID of the snap to invoke.
-- `request` - The JSON-RPC request object to send to the invoked snap.
-
-#### Returns
-
-Result of the snap method call.
-
-#### Example
-
-```javascript
-const result = await ethereum.request({
-  method: 'wallet_invokeSnap',
-  params: {
-    snapId: 'npm:@metamask/example-snap',
-    request: {
-      method: 'hello',
-    },
-  },
-});
-
-console.log(result); // In this example, the result is a boolean.
-```
-
 ### wallet_requestSnaps
 
 Requests permission for a website to communicate with the specified snaps and attempts to install
@@ -747,3 +709,41 @@ console.log(result); // In this example, the result is a boolean.
 ```
 
 <!--/tabs-->
+
+### wallet_invokeSnap
+
+Invokes the specified JSON-RPC method of the specified snap.
+The snap must be installed and the caller must have the permission to communicate with the snap, or
+the request is rejected.
+
+Snaps are fully responsible for implementing their JSON-RPC API.
+Consult the snap's documentation for available methods, their parameters, and return values.
+
+This method is only callable by websites.
+
+#### Parameters
+
+An object containing:
+
+- `snapId` - The ID of the snap to invoke.
+- `request` - The JSON-RPC request object to send to the invoked snap.
+
+#### Returns
+
+Result of the snap method call.
+
+#### Example
+
+```javascript
+const result = await ethereum.request({
+  method: 'wallet_invokeSnap',
+  params: {
+    snapId: 'npm:@metamask/example-snap',
+    request: {
+      method: 'hello',
+    },
+  },
+});
+
+console.log(result); // In this example, the result is a boolean.
+```


### PR DESCRIPTION
- change endowment example from `long-running` (deprecated) to `network-access`. fixes #757 .
- move `wallet_invokeSnap` to a restricted method. fixes #647 .