### PR TITLE
Update eth_accounts return behavior

### DIFF
--- a/wallet/get-started/access-accounts.md
+++ b/wallet/get-started/access-accounts.md
@@ -127,8 +127,8 @@ function handleAccountsChanged(accounts) {
 }
 ```
 
-:::note
-MetaMask currently returns at most one account in the `accounts` array.
-The array may contain more than one account in the future.
+:::caution
+MetaMask now returns the full list of accounts for which the user has permitted access to.
+Previously, MetaMask returned at most one account in the `accounts` array.
 The first account in the array will always be considered the user's "selected" account.
 :::

--- a/wallet/reference/provider-api.md
+++ b/wallet/reference/provider-api.md
@@ -140,8 +140,8 @@ window.ethereum.on('accountsChanged', handler: (accounts: Array<string>) => void
 The provider emits this event when the return value of the
 [`eth_accounts`](https://metamask.github.io/api-playground/api-documentation/#eth_accounts) RPC
 method changes.
-`eth_accounts` returns either an empty array, or an array that contains the address of the most
-recently used account the caller is permitted to access.
+`eth_accounts` returns either an empty array, or an array that contains the addresses of the accounts
+the caller is permitted to access with most recently used accounts first.
 Callers are identified by their URL origin, which means that all sites with the same origin share
 the same permissions.
 


### PR DESCRIPTION
* Update `eth_accounts` behavior description for return of all permitted accounts with most recently used first.

[Ticket: mme-18515](https://github.com/MetaMask/metamask-extension/issues/18515)
