### PR TITLE
Remove NPM from Snaps Install & Quick Start

### DIFF
--- a/snaps/get-started/install-snaps.md
+++ b/snaps/get-started/install-snaps.md
@@ -13,7 +13,7 @@ You can then [get started quickly using the Create Snap CLI](quickstart.md).
 
 - Up-to-date Chromium or Firefox browser
 - [Node.js](https://nodejs.org/) version 16 or later
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://yarnpkg.com/) version 3
 
 ## Install MetaMask Flask
 

--- a/snaps/get-started/install-snaps.md
+++ b/snaps/get-started/install-snaps.md
@@ -13,7 +13,7 @@ You can then [get started quickly using the Create Snap CLI](quickstart.md).
 
 - Up-to-date Chromium or Firefox browser
 - [Node.js](https://nodejs.org/) version 16 or later
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or [Yarn](https://yarnpkg.com/)
+- [Yarn](https://yarnpkg.com/)
 
 ## Install MetaMask Flask
 

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -28,8 +28,6 @@ Create a new snap project using the Create Snap CLI by running the following com
 
 ```bash
 yarn create @metamask/snap your-snap-name
-# or...
-npm create @metamask/snap your-snap-name
 ```
 
 You can learn about the [anatomy of your snap project files](../concepts/anatomy.md).

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -28,6 +28,8 @@ Create a new snap project using the Create Snap CLI by running the following com
 
 ```bash
 yarn create @metamask/snap your-snap-name
+# or...
+npm create @metamask/snap your-snap-name
 ```
 
 You can learn about the [anatomy of your snap project files](../concepts/anatomy.md).


### PR DESCRIPTION
because it requires Yarn anyway?!

Fixes https://github.com/MetaMask/snaps/issues/1477.