### PR TITLE
Updated to move deprecated methods to later section

### DIFF
--- a/wallet/concepts/signing-methods.md
+++ b/wallet/concepts/signing-methods.md
@@ -1,72 +1,75 @@
 ---
-description: A brief history of the signing RPC methods.
+description: Available RPC methods for signing transactions in MetaMask.
 sidebar_position: 2
 ---
 
 # Signing methods
 
-This page describes a brief history of the signing RPC methods in MetaMask.
+This page describes the signing RPC methods in MetaMask.
 Learn how to [use the recommended signing methods](../how-to/sign-data.md).
 
-### eth_sign
+### eth_signTypedData_v4
 
-`eth_sign` is MetaMask's original signing method.
-It allows signing an arbitrary hash, which means it can be used to sign transactions, or any other
-data, making it a dangerous phishing risk.
-
-:::caution important
-`eth_sign` is deprecated.
-MetaMask disables this method by default and doesn't recommend using this method in production.
-However, some applications (usually internal administrator panels) use this method for its ease of
-use, or because of an inability to change the associated dapp.
-If a wallet user must interact with a dapp that still uses `eth_sign` and accepts the risks,
-they can still re-enable it through advanced settings.
-:::
-
-### personal_sign
-
-[`personal_sign`](https://metamask.github.io/api-playground/api-documentation/#personal_sign) is
-the next implemented signing method, which adds a prefix to the signed data so it can't impersonate
-transactions.
-This method also displays human-readable text when UTF-8 encoded, making it a popular choice for
-site logins.
-
-The text prefix of `personal_sign` makes signatures expensive to verify on-chain.
-If you don't need signatures to be efficiently processed on-chain, you can
-[use this method](../how-to/sign-data.md#use-personal_sign).
-
-### eth_signTypedData
-
-[EIP-712](https://eips.ethereum.org/EIPS/eip-712) introduced `eth_signTypedData`, which is:
+[`eth_signTypedData_v4`](https://metamask.github.io/api-playground/api-documentation/#eth_signTypedDatav4)
+is:
 
 - Cheap to verify on chain.
 - Human-readable.
 - Protected against phishing signatures.
 
-If on-chain verifiability cost is a high priority for you, we recommend
-[using this method](../how-to/sign-data.md#use-eth_signtypeddatav4).
+If onchain verifiability cost is a high priority,
+[use `eth_signTypedData_v4`](../how-to/sign-data.md#use-eth_signtypeddata_v4).
 
-The EIP-712 specification changed several times while retaining the same EIP, meaning that MetaMask
-originally implemented `eth_signTypedData` as the earliest proposed version, then implemented later
-versions with hard-versioned method names:
+To avoid compatibility issues between clients, use the hard-versioned method name.
 
+### personal_sign
+
+[`personal_sign`](https://metamask.github.io/api-playground/api-documentation/#personal_sign): 
+
+- Displays human-readable text when UTF-8 encoded, making it a popular choice for site logins. 
+- Protected against phishing signatures.
+
+The text prefix of `personal_sign` makes signatures expensive to verify on-chain.
+If onchain verifiability cost is not a priority, you can
+[use `personal_sign`](../how-to/sign-data.md#use-personal_sign).
+
+### Deprecated signing methods
+
+:::caution important
+`eth_signTypedData_v1`, `eth_signTypedData_v3`, and `eth_sign` are deprecated.
+Use `personal_sign` and `eth_signTypedData_v4`.
+:::
+
+#### eth_sign
+
+`eth_sign` allows signing an arbitrary hash, which means it can be used to sign transactions, or any other
+data. Using `eth_sign` is a dangerous phishing risk.
+
+:::caution important
+MetaMask disables `eth_sign` by default and does not recommend using `eth_sign` in production.
+Some applications (usually internal administrator panels) use `eth_sign` for ease of
+use, or due to an inability to change the associated dapp.
+If a wallet user must interact with a dapp that uses `eth_sign` and accepts the risks,
+the wallet user can re-enable `eth_sign` through advanced settings.
+:::
+
+### eth_signTypedData_v1 and eth_signTypedData_v3 
+
+`eth_signTypedData` was introduced by [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
+The EIP-712 specification changed several times resulting in multiple versions
+of `eth_signTypedData`. Use `eth_signTypedData_v4`.
+
+The earlier versions are: 
 - `eth_signTypedData_v1` – The same as `eth_signTypedData`.
   Read the
   [introductory blog post to this method](https://medium.com/metamask/scaling-web3-with-signtypeddata-91d6efc8b290).
 - `eth_signTypedData_v3` – A highly used version of the EIP-712 specification.
   Read the
   [introductory blog post to this method](https://medium.com/metamask/eip712-is-coming-what-to-expect-and-how-to-use-it-bb92fd1a7a26).
-- [`eth_signTypedData_v4`](https://metamask.github.io/api-playground/api-documentation/#eth_signTypedData_v4)
-  – The latest version of the EIP-712 specification, with added support for arrays and a breaking
-  fix for the way structs are encoded.
-  Read the
-  [introductory blog post to this method](https://medium.com/metamask/eip712-is-coming-what-to-expect-and-how-to-use-it-bb92fd1a7a26).
+
+The missing `v2` represents an intermediary design that the Cipher browser implemented. 
 
 :::caution important
 All early versions of this method lack later security improvements.
-We recommend using the latest version, `eth_signTypedData_v4`.
+Use the latest version, `eth_signTypedData_v4`.
 :::
-
-To avoid compatibility issues between clients, we recommend using the hard-versioned method names.
-The missing `v2` represents an intermediary design that the Cipher browser implemented –
-MetaMask has room to implement it if there's enough developer demand for it.

--- a/wallet/concepts/signing-methods.md
+++ b/wallet/concepts/signing-methods.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 This page describes the signing RPC methods in MetaMask.
 Learn how to [use the recommended signing methods](../how-to/sign-data.md).
 
-### eth_signTypedData_v4
+## eth_signTypedData_v4
 
 [`eth_signTypedData_v4`](https://metamask.github.io/api-playground/api-documentation/#eth_signTypedDatav4)
 is:
@@ -20,46 +20,44 @@ is:
 If onchain verifiability cost is a high priority,
 [use `eth_signTypedData_v4`](../how-to/sign-data.md#use-eth_signtypeddata_v4).
 
-To avoid compatibility issues between clients, use the hard-versioned method name.
-
-### personal_sign
+## personal_sign
 
 [`personal_sign`](https://metamask.github.io/api-playground/api-documentation/#personal_sign): 
 
-- Displays human-readable text when UTF-8 encoded, making it a popular choice for site logins. 
-- Protected against phishing signatures.
+- Displays human-readable text when UTF-8 encoded, making it a popular choice for site logins
+  (for example, [Sign-In with Ethereum](../how-to/use-siwe.md)). 
+- Is protected against phishing signatures.
 
 The text prefix of `personal_sign` makes signatures expensive to verify on-chain.
 If onchain verifiability cost is not a priority, you can
 [use `personal_sign`](../how-to/sign-data.md#use-personal_sign).
 
-### Deprecated signing methods
+## Deprecated signing methods
 
 :::caution important
-`eth_signTypedData_v1`, `eth_signTypedData_v3`, and `eth_sign` are deprecated.
-Use `personal_sign` and `eth_signTypedData_v4`.
+`eth_sign`, `eth_signTypedData_v1`, and `eth_signTypedData_v3` are deprecated.
+Use `eth_signTypedData_v4` or `personal_sign`.
 :::
 
-#### eth_sign
+### eth_sign
 
 `eth_sign` allows signing an arbitrary hash, which means it can be used to sign transactions, or any other
 data. Using `eth_sign` is a dangerous phishing risk.
 
-:::caution important
 MetaMask disables `eth_sign` by default and does not recommend using `eth_sign` in production.
 Some applications (usually internal administrator panels) use `eth_sign` for ease of
 use, or due to an inability to change the associated dapp.
 If a wallet user must interact with a dapp that uses `eth_sign` and accepts the risks,
 the wallet user can re-enable `eth_sign` through advanced settings.
-:::
 
 ### eth_signTypedData_v1 and eth_signTypedData_v3 
 
 `eth_signTypedData` was introduced by [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
 The EIP-712 specification changed several times resulting in multiple versions
-of `eth_signTypedData`. Use `eth_signTypedData_v4`.
+of `eth_signTypedData`.
 
-The earlier versions are: 
+The earlier versions are:
+
 - `eth_signTypedData_v1` – The same as `eth_signTypedData`.
   Read the
   [introductory blog post to this method](https://medium.com/metamask/scaling-web3-with-signtypeddata-91d6efc8b290).
@@ -69,7 +67,5 @@ The earlier versions are:
 
 The missing `v2` represents an intermediary design that the Cipher browser implemented. 
 
-:::caution important
 All early versions of this method lack later security improvements.
-Use the latest version, `eth_signTypedData_v4`.
-:::
+Use the latest version, [`eth_signTypedData_v4`](#eth_signtypeddata_v4).

--- a/wallet/how-to/sign-data.md
+++ b/wallet/how-to/sign-data.md
@@ -13,8 +13,6 @@ You can use the following RPC methods to request cryptographic signatures from u
 - [`personal_sign`](#use-personal_sign) - Use this method for the easiest way to request human-readable
   signatures that don't need to be efficiently processed on-chain.
 
-Read more about [the history of the signing methods](../concepts/signing-methods.md).
-
 :::caution
 [`eth_sign`](../concepts/signing-methods.md#eth_sign) is deprecated.
 :::


### PR DESCRIPTION
fixes #764 

As suggested in issue, moved current recommended methods to top of article and other methods to later section titled deprecated.  