### PR TITLE
Add cookie consent script to docusaurus.config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,8 +30,8 @@ const config = {
   trailingSlash: true,
 
   scripts: [
+    { src: "https://cmp.osano.com/AzZMxHTbQDOQD8c1J/a2e89f0e-f467-4542-bfea-30ea2c1a6648/osano.js" }, // cookie consent
     { src: "https://plausible.io/js/script.js", defer: true, "data-domain": "docs.metamask.io" }, // legacy analytics
-    { src: "https://cmp.osano.com/AzZMxHTbQDOQD8c1J/a2e89f0e-f467-4542-bfea-30ea2c1a6648/osano.js", defer: true }, // cookie consent
   ],
 
   presets: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,8 @@ const config = {
   trailingSlash: true,
 
   scripts: [
-    { src: "https://plausible.io/js/script.js", defer: true, "data-domain": "docs.metamask.io" },
+    { src: "https://plausible.io/js/script.js", defer: true, "data-domain": "docs.metamask.io" }, // legacy analytics
+    { src: "https://cmp.osano.com/AzZMxHTbQDOQD8c1J/a2e89f0e-f467-4542-bfea-30ea2c1a6648/osano.js", defer: true }, // cookie consent
   ],
 
   presets: [


### PR DESCRIPTION
**Webteam Ticket:** https://github.com/ConsenSys/dx-team/issues/1518

Adds a standard ConsenSys cookie consent script to all pages. It introduces a persistent icon in the lower right side of the docs site. Once this is merged, we may have some additional options to customize the behavior of this script, icon, menu appearance, etc.