### PR TITLE
Specify React Native SDK version requirement

### DIFF
--- a/wallet/how-to/connect/set-up-sdk/javascript/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/index.md
@@ -19,10 +19,10 @@ You can also see instructions for the following JavaScript-based platforms:
 
 ## Prerequisites
 
-- An existing or [new project](../../../get-started-building/set-up-dev-environment.md) set up.
-- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above.
+- An existing or [new project](../../../get-started-building/set-up-dev-environment.md) set up
+- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) version 5.8.1 or above
 - [Yarn](https://yarnpkg.com/getting-started/install) or
-  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 ## Steps
 

--- a/wallet/how-to/connect/set-up-sdk/javascript/react-native.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react-native.md
@@ -10,8 +10,8 @@ users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 
 ## Prerequisites
 
-- A React Native project set up
-- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above
+- A [React Native](https://reactnative.dev/docs/0.71/getting-started) project set up with React Native version 0.71 or above
+- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) version 5.8.1 or above
 - [Yarn](https://yarnpkg.com/getting-started/install) or
   [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 


### PR DESCRIPTION
Update the React Native SDK prereqs to include version requirement.

Based on the following support email response:
> can you try to bump the react-native version you're using? The SDK works best in from version 0.71.0 onwards because of performance issues on cryptographic libraries.