### PR TITLE
Update snaps examples linked from docs

### DIFF
--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -105,7 +105,7 @@ can always build, publish, and use snaps without MetaMask's permission.
 
 ## Resources and tools
 
-You can review the growing number of [example snaps](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source snaps: 
+You can review the growing number of [example snaps](https://github.com/MetaMask/snaps/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source snaps: 
 
 - [Dogecoin](https://github.com/ziad-saab/dogecoin-snap)
 - [StarkNet](https://github.com/Consensys/starknet-snap)

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -105,13 +105,11 @@ can always build, publish, and use snaps without MetaMask's permission.
 
 ## Resources and tools
 
-You can review the growing number of
-[example snaps](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples) maintained
-by MetaMask, as well as the following fully functional and open source snaps:
+The following fully functional and open source snaps can be used as a reference for your projects: 
 
+- [Dogecoin](https://github.com/ziad-saab/dogecoin-snap)
 - [StarkNet](https://github.com/Consensys/starknet-snap)
-- [FilSnap for Filecoin](https://github.com/Chainsafe/filsnap/)
-- [Password Manager Snap](https://github.com/ritave/snap-passwordManager)
+- [MobyMask Phishing Warning](https://github.com/Montoya/mobymask-snap)
 - [Transaction Simulation with Ganache](https://github.com/Montoya/tx-simulation-with-ganache-snap)
   (uses Truffle for local testing)
 

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -105,7 +105,7 @@ can always build, publish, and use snaps without MetaMask's permission.
 
 ## Resources and tools
 
-The following fully functional and open source snaps can be used as a reference for your projects: 
+You can review the growing number of [example snaps](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source snaps: 
 
 - [Dogecoin](https://github.com/ziad-saab/dogecoin-snap)
 - [StarkNet](https://github.com/Consensys/starknet-snap)


### PR DESCRIPTION
Had to update some outdated links in the development guide. Sticking to only the snaps that have been developed internally and are still relevant to our current API. 