### PR TITLE
Explicitly call out that coin type 60 is blocked

### DIFF
--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -428,6 +428,11 @@ derive an address for the relevant protocol or sign a transaction for the user.
 
 This method is only callable by snaps.
 
+:::danger important
+Coin type 60 is reserved for MetaMask accounts and is blocked for snaps. 
+If you wish to connect to MetaMask accounts in a snap, use `eth_accounts`.
+:::
+
 #### Parameters
 
 An object containing `coinType`, the BIP-44 coin type to get the entropy for.


### PR DESCRIPTION
We had not specified this in our documentation before and multiple developers only found out through an error in the API. This is finally calling out that it is blocked. 