### PR TITLE
Ethereum provider clarification - fixes #882

### DIFF
--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -82,7 +82,7 @@ Specify this permission in the manifest file as follows:
 ```
 
 :::note 
-The global `ethereum` API in Snaps has fewer capabilities than `window.ethereum`. 
+The global `ethereum` API in Snaps has fewer capabilities than `window.ethereum` for dapps. 
 You can only use it to make read requests from the RPC provider, not to write to the blockchain or initiate transactions. 
 You can also use it to access Ethereum accounts with `eth_requestAccounts` and then use `personal_sign` with 
 those connected accounts.

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -84,7 +84,7 @@ Specify this permission in the manifest file as follows:
 :::note 
 The global `ethereum` API in Snaps has fewer capabilities than `window.ethereum` for dapps. 
 You can only use it to make read requests from the RPC provider, not to write to the blockchain or initiate transactions. 
-You can also use it to access Ethereum accounts with `eth_requestAccounts` and then use `personal_sign` with 
+You can also use it to connect to Ethereum accounts with `eth_requestAccounts` and then use `personal_sign` with 
 those connected accounts.
 :::
 

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -81,6 +81,13 @@ Specify this permission in the manifest file as follows:
 },
 ```
 
+:::note 
+The global `ethereum` API in Snaps has fewer capabilities than `window.ethereum`. 
+You can only use it to make read requests from the RPC provider, not to write to the blockchain or initiate transactions. 
+You can also use it to access Ethereum accounts with `eth_requestAccounts` and then use `personal_sign` with 
+those connected accounts.
+:::
+
 ### endowment:long-running
 
 :::caution

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -428,9 +428,11 @@ derive an address for the relevant protocol or sign a transaction for the user.
 
 This method is only callable by snaps.
 
-:::danger important
-Coin type 60 is reserved for MetaMask accounts and is blocked for snaps. 
-If you wish to connect to MetaMask accounts in a snap, use `eth_accounts`.
+:::caution 
+Coin type 60 is reserved for MetaMask accounts and blocked for snaps. 
+If you wish to connect to MetaMask accounts in a snap, use 
+[`endowment:ethereum-provider`](../reference/permissions.md/#endowmentethereum-provider) and 
+`eth_requestAccounts`.
 :::
 
 #### Parameters


### PR DESCRIPTION
Clarifies what you can and cannot do with the ethereum provider in Snaps with the addition of a note section