### PR TITLE
Less onerous callout for coin type 60 in Snaps

### DIFF
--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -428,8 +428,8 @@ derive an address for the relevant protocol or sign a transaction for the user.
 
 This method is only callable by snaps.
 
-:::danger important
-Coin type 60 is reserved for MetaMask accounts and is blocked for snaps. 
+:::caution 
+Coin type 60 is reserved for MetaMask accounts and blocked for snaps. 
 If you wish to connect to MetaMask accounts in a snap, use `eth_accounts`.
 :::
 


### PR DESCRIPTION
The callout for coin type 60 being blocked in Snaps should not have been a danger, changing to a caution instead