### PR TITLE
Correct return values for prompt dialog

### DIFF
--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -229,7 +229,7 @@ An object containing the contents of the prompt dialog:
 
 ##### Returns
 
-The text entered by the user if the prompt was submitted or `null` if the prompt was rejected or closed. If the user does not enter any text and submits the prompt, the value will be an empty string.
+The text entered by the user if the prompt was submitted or `null` if the prompt was rejected or closed. If the user does not enter any text and submits the prompt, the value is an empty string.
 
 #### Example
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -229,7 +229,7 @@ An object containing the contents of the prompt dialog:
 
 ##### Returns
 
-The text entered by the user.
+The text entered by the user if the prompt was submitted, `null` otherwise.
 
 #### Example
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -229,7 +229,7 @@ An object containing the contents of the prompt dialog:
 
 ##### Returns
 
-The text entered by the user if the prompt was submitted, `null` otherwise.
+The text entered by the user if the prompt was submitted or `null` if the prompt was rejected or closed. If the user does not enter any text and submits the prompt, the value will be an empty string.
 
 #### Example
 


### PR DESCRIPTION
This line was a bit misleading before because it didn't specify that the dialog returns `null` if rejected or closed.