### PR TITLE
Fix typo

### DIFF
--- a/snaps/tutorials/gas-estimation.md
+++ b/snaps/tutorials/gas-estimation.md
@@ -31,7 +31,7 @@ or
 npm create @metamask/snap gas-estimation-snap
 ```
 
-Next, `cd` into the `gas-estimation-map` project directory and run:
+Next, `cd` into the `gas-estimation-snap` project directory and run:
 
 ```bash
 yarn install


### PR DESCRIPTION
Fixes a small typo in the gas estimation snap tutorial. 