### PR TITLE
[FLASK] Remove endowment:long-running from documentation

### DIFF
--- a/snaps/concepts/lifecycle.md
+++ b/snaps/concepts/lifecycle.md
@@ -10,8 +10,6 @@ AWS lambda functions, snaps are designed to wake up in response to messages/even
 when idle.
 Snaps have an ephemeral lifecycle: they're here one moment, gone the next.
 Also, if MetaMask detects that a snap becomes unresponsive, it shuts the snap down.
-This doesn't mean that you can't create long-running snaps, but it does mean that your snaps must
-handle being shut down, especially when they're not within the JSON-RPC request/response cycle.
 
 A snap is considered unresponsive if:
 

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -87,24 +87,6 @@ You can also use it to connect to Ethereum accounts with `eth_requestAccounts` a
 those connected accounts.
 :::
 
-### endowment:long-running
-
-:::caution
-`endowment:long-running` is deprecated.
-:::
-
-A snap that is computationally heavy and can't finish execution within the
-[snap lifecycle requirements](../concepts/lifecycle.md) must request the `endowment:long-running` permission.
-This permission allows the snap to run indefinitely while processing RPC requests.
-
-Specify this permission in the manifest file as follows:
-
-```json
-"initialPermissions": {
-  "endowment:long-running": {}
-},
-```
-
 ### endowment:network-access
 
 To access the internet, a snap must request the `endowment:network-access` permission.


### PR DESCRIPTION
This PR removes documentation related to the `long-running` endowment permission.

### Related ticket: 
https://github.com/MetaMask/snaps/issues/945

### Related PR:
https://github.com/MetaMask/metamask-extension/pull/20951
https://github.com/MetaMask/snaps/pull/1751
