### PR TITLE
Fix pure js connection (#892)

### DIFF
--- a/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
@@ -19,11 +19,13 @@ To import, instantiate, and use the SDK, you can insert a script in the head sec
 
 <script>
 
-    const MMSDK = new MetaMaskSDK()
+    const MMSDK = new MetaMaskSDK.MetaMaskSDK()
+    // Because init process of the MetaMaskSDK is async.
+    setTimeout(() => {
+        const ethereum = MMSDK.getProvider() // You can also access via window.ethereum
 
-    const ethereum = MMSDK.getProvider() // You can also access via window.ethereum
-
-    ethereum.request({method: 'eth_requestAccounts'})
+        ethereum.request({ method: 'eth_requestAccounts' })
+    }, 0)
 
 </script>
 


### PR DESCRIPTION
The SDK's `init` function is asynchronous, causing an error in `getProvider` without any handling.

Also fixed an issue with the initialization method in issue #892.
fixes #892 