### PR TITLE
Capitalize "Snap"

### DIFF
--- a/snaps/concepts/anatomy.md
+++ b/snaps/concepts/anatomy.md
@@ -1,5 +1,5 @@
 ---
-description: Learn about the anatomy of a snap project.
+description: Learn about the anatomy of a Snap project.
 sidebar_position: 1
 ---
 
@@ -23,7 +23,7 @@ template-snap-monorepo/
 |  |  |  |- index.ts
 |  |  ├─ snap.manifest.json
 |  |  ├─ package.json
-|  |  |- ... (snap content)
+|  |  |- ... (Snap content)
 ├─ package.json
 ├─ ... (other stuff)
 ```
@@ -31,24 +31,24 @@ template-snap-monorepo/
 Source files other than `index.ts` are located through its imports.
 The defaults can be overwritten in the [configuration file](#configuration-file).
 
-:::tip Create a snap project
-When you create a new snap project using `mm-snap init`, it has all these files.
+:::tip Create a Snap project
+When you create a new Snap project using `mm-snap init`, it has all these files.
 Still, we recommend
-[cloning the template snap repository to get started](../get-started/quickstart.md).
+[cloning the template Snap repository to get started](../get-started/quickstart.md).
 :::
 
-This page examines the major components of a snap:
+This page examines the major components of a Snap:
 
-- [The source code](#source-code) contains the primary code of the snap.
-- [The manifest file](#manifest-file) tells MetaMask important information about the snap.
-- [The configuration file](#configuration-file) specifies configuration options for the snap.
-- [The bundle file](#bundle-file) is the output file of the published snap.
+- [The source code](#source-code) contains the primary code of the Snap.
+- [The manifest file](#manifest-file) tells MetaMask important information about the Snap.
+- [The configuration file](#configuration-file) specifies configuration options for the Snap.
+- [The bundle file](#bundle-file) is the output file of the published Snap.
 
 ## Source code
 
-If you're familiar with JavaScript or TypeScript development, developing a snap might feel familiar
+If you're familiar with JavaScript or TypeScript development, developing a Snap might feel familiar
 to you.
-Consider this simple snap, `Hello World`:
+Consider this simple Snap, `Hello World`:
 
 ```typescript title="index.ts"
 module.exports.onRpcRequest = async ({ origin, request }) => {
@@ -63,19 +63,19 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 };
 ```
 
-To communicate with the outside world, the snap must implement its own JSON-RPC API by exposing
+To communicate with the outside world, the Snap must implement its own JSON-RPC API by exposing
 the exported function [`onRpcRequest`](../reference/exports.md#onrpcrequest).
-Whenever the snap receives a JSON-RPC request from a dapp or another snap, this handler function is
+Whenever the Snap receives a JSON-RPC request from a dapp or another Snap, this handler function is
 called with the specified parameters.
 
-In addition to being able to expose a JSON-RPC API, snaps can access the global object `snap`.
+In addition to being able to expose a JSON-RPC API, Snaps can access the global object `snap`.
 You can use this object to make Snaps-specific JSON-RPC requests.
 
-If a dapp wants to use `Hello World`, assuming the snap is published to npm using the package name `hello-snap`, the dapp can implement something like this:
+If a dapp wants to use `Hello World`, assuming the Snap is published to npm using the package name `hello-snap`, the dapp can implement something like this:
 
 ```javascript
-// Connect to the snap, enabling its usage inside the dapp
-// If the snap is not already installed, the MetaMask user 
+// Connect to the Snap, enabling its usage inside the dapp
+// If the Snap is not already installed, the MetaMask user 
 // will be prompted to install it
 await window.ethereum.request({
   method: "wallet_requestSnaps",
@@ -84,7 +84,7 @@ await window.ethereum.request({
   },
 });
 
-// Invoke the "hello" RPC method exposed by the snap
+// Invoke the "hello" RPC method exposed by the Snap
 const response = await window.ethereum.request({
   method: "wallet_invokeSnap",
   params: { snapId: "npm:hello-snap", request: { method: "hello" } },
@@ -93,22 +93,22 @@ const response = await window.ethereum.request({
 console.log(response); // 'world!'
 ```
 
-The snap's RPC API is completely up to you, as long as it's a valid
+The Snap's RPC API is completely up to you, as long as it's a valid
 [JSON-RPC](https://www.jsonrpc.org/specification) API.
 
-:::tip Does my snap need to have an RPC API?
+:::tip Does my Snap need to have an RPC API?
 No, that's also up to you!
-If your snap can do something useful without receiving and responding to JSON-RPC requests, such as
+If your Snap can do something useful without receiving and responding to JSON-RPC requests, such as
 providing [transaction insights](../reference/exports.md#ontransaction), then you can skip exporting
 `onRpcRequest`.
 However, if you want to do something such as manage the user's keys for a particular protocol and
-create a dapp that, for example, sends transactions for that protocol using your snap, you must
+create a dapp that, for example, sends transactions for that protocol using your Snap, you must
 specify an RPC API.
 :::
 
 ## Manifest file
 
-To get MetaMask to execute your snap, you must have a valid manifest file named `snap.manifest.json`,
+To get MetaMask to execute your Snap, you must have a valid manifest file named `snap.manifest.json`,
 located in your package root directory.
 The manifest file of `Hello World` would look something like this:
 
@@ -137,18 +137,18 @@ The manifest file of `Hello World` would look something like this:
 }
 ```
 
-The manifest tells MetaMask important information about your snap, such as where it's published
-(using `source.location`) and how to verify the integrity of the snap source code (by attempting to
+The manifest tells MetaMask important information about your Snap, such as where it's published
+(using `source.location`) and how to verify the integrity of the Snap source code (by attempting to
 reproduce the `source.shasum` value).
 
 :::note
-Currently, snaps can only be
+Currently, Snaps can only be
 [published to the official npm registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry),
 and the manifest must also match the corresponding fields of the `package.json` file.
-In the future, developers will be able to distribute snaps in different ways, and the manifest will
+In the future, developers will be able to distribute Snaps in different ways, and the manifest will
 expand to support different publishing solutions.
 
-The [snaps publishing specification](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-9.md)
+The [Snaps publishing specification](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-9.md)
 details the requirements of both `snap.manifest.json` and its relationship to `package.json`.
 :::
 
@@ -160,7 +160,7 @@ For example, `mm-snap build` or `mm-snap manifest --fix` updates `source.shasum`
 
 ## Configuration file
 
-The snap configuration file, `snap.config.ts`, should be placed in the project root directory.
+The Snap configuration file, `snap.config.ts`, should be placed in the project root directory.
 You can override the default values of the [Snaps CLI options](../reference/cli/options.md) by specifying
 them in the `config` object of the configuration file.
 For example:
@@ -192,18 +192,18 @@ shouldn't contain any secrets.
 
 ## Bundle file
 
-Because of the way snaps are executed, they must be published as a single `.js` file containing the
+Because of the way Snaps are executed, they must be published as a single `.js` file containing the
 entire source code and all dependencies.
 Moreover, the [Snaps execution environment](execution-environment.md) has no DOM, no Node.js
 APIs, and no filesystem access, so anything that relies on the DOM doesn't work, and any Node
-built-ins must be bundled along with the snap.
+built-ins must be bundled along with the Snap.
 
-Use the command `mm-snap build` to bundle your snap using 
+Use the command `mm-snap build` to bundle your Snap using 
 [webpack](https://webpack.js.org/) or 
 [Browserify](https://browserify.org).
 This command finds all dependencies using your specified main entry point and outputs a bundle
 file to your specified output path.
 
 :::note
-If you are using the template snap monorepo, running `yarn start` will bundle your snap for you.
+If you are using the template Snap monorepo, running `yarn start` will bundle your Snap for you.
 :::

--- a/snaps/concepts/design-guidelines.md
+++ b/snaps/concepts/design-guidelines.md
@@ -1,29 +1,29 @@
 ---
-description: Learn about best practices for creating snap installation flows.
+description: Learn about best practices for creating Snap installation flows.
 sidebar_position: 5
 ---
 
 # Snaps design guidelines
 
-This page outlines guiding principles for designers, developers, builders, and writers to create snap installation flows that are accessible to all users. Use these guidelines when introducing your snap within a dapp or website.
+This page outlines guiding principles for designers, developers, builders, and writers to create Snap installation flows that are accessible to all users. Use these guidelines when introducing your Snap within a dapp or website.
 
 ## Why this matters
 
-The snap installation process contains critical info about your snap, including what it does, how it enhances your application, and why it’s beneficial for users. It's important to provide this information on your website or dapp to help users understand the purpose and benefits of the snap before installing it. Without this information, users may drop out during installation or install the snap without fully understanding its purpose.
+The Snap installation process contains critical info about your Snap, including what it does, how it enhances your application, and why it’s beneficial for users. It's important to provide this information on your website or dapp to help users understand the purpose and benefits of the Snap before installing it. Without this information, users may drop out during installation or install the Snap without fully understanding its purpose.
 
 ## Guidelines at a glance
 
 **Metadata must-haves**
 
 - Keep your name to **21 characters or less** (including spaces).
-- Never use “snap” in your snap’s name. Use the space for something more descriptive.
+- Never use “Snap” in your Snap’s name. Use the space for something more descriptive.
 - Your avatar should fit in a **32px circular frame, SVG format**.
 - Always aim for a short and simple copy.
 
 **Before** asking for permission to install, provide users with **clear and concise information** about:
 
-- _What_ the snap does and _how_ it meets their needs.
-- _How_ the snap works.
+- _What_ the Snap does and _how_ it meets their needs.
+- _How_ the Snap works.
 - Any _security precautions_ they may need to know about.
 
 Write in active voice and use sentence case. Avoid jargon—write in plain language that can be understood at a glance.
@@ -44,69 +44,69 @@ Consider whether the details that interest you as a developer are relevant to th
 
   Identify synonyms and eliminate them. Each important object and action should have a single word to represent it. Inconsistency can blur the lines for users, creating uncertainty and confusion.
 
-## Introducing your snap
+## Introducing your Snap
 
-Use conversational language when explaining the snap. If you need to use a technical term, briefly define it so everyone can understand. Avoid jargon whenever possible, and keep your words short and simple. Introduce your snap in the context of your application to make it clear what the user gets if they install it.
+Use conversational language when explaining the Snap. If you need to use a technical term, briefly define it so everyone can understand. Avoid jargon whenever possible, and keep your words short and simple. Introduce your Snap in the context of your application to make it clear what the user gets if they install it.
 
-![Introducing your snap's features via a modal](../assets/install-modal.png)
+![Introducing your Snap's features via a modal](../assets/install-modal.png)
 
-:::note How to (not) describe what your snap does
+:::note How to (not) describe what your Snap does
 
 **Don'ts**
 
-❌ _Allow the snap to perform actions that run periodically at fixed times, dates, or intervals. This can be used to trigger time-sensitive interactions or notifications._
+❌ _Allow the Snap to perform actions that run periodically at fixed times, dates, or intervals. This can be used to trigger time-sensitive interactions or notifications._
 
-❌ _Allow this snap to display notifications regarding your Ethereum Name Service expiration._
+❌ _Allow this Snap to display notifications regarding your Ethereum Name Service expiration._
 
 **Do's**
 
-✅ _Let this snap schedule and run recurring tasks or notifications._
+✅ _Let this Snap schedule and run recurring tasks or notifications._
 
-✅ _Let this snap notify you when your ENS is about to expire._
+✅ _Let this Snap notify you when your ENS is about to expire._
 
 :::
 
-### Details to include when introducing your snap
+### Details to include when introducing your Snap
 
-This is your chance to share the benefits of your snap with the intended user. If it isn’t clear what a user stands to gain from your snap, chances are they won’t even install it. So don’t be afraid to think like a marketer and emphasize the benefits of your snap.
+This is your chance to share the benefits of your Snap with the intended user. If it isn’t clear what a user stands to gain from your Snap, chances are they won’t even install it. So don’t be afraid to think like a marketer and emphasize the benefits of your Snap.
 
-Consider introducing your snap on your website with a modal, tooltip, or card. This introduction can happen before or alongside the installation prompt, but should always be clear and descriptive.
+Consider introducing your Snap on your website with a modal, tooltip, or card. This introduction can happen before or alongside the installation prompt, but should always be clear and descriptive.
 
 #### Important details include:
 
-- What your snap does, why someone would use it, and how it works.
+- What your Snap does, why someone would use it, and how it works.
 - Security precautions in plain, basic language that anyone can understand.
-- Descriptions of the features that make your snap appealing to the intended users.
+- Descriptions of the features that make your Snap appealing to the intended users.
 
 :::tip Tip
-Some studies estimate users read only 20-28% of the text on any screen, so write about your snap with language that’s impactful, clear, and direct.
+Some studies estimate users read only 20-28% of the text on any screen, so write about your Snap with language that’s impactful, clear, and direct.
 :::
 
 ## Embedded in existing flows
 
-Introduce the snap as a natural extension of existing elements on your screen, and suggest installation when the time is right. This can be a make or break moment for your snap, so put yourself in the shoes of the intended user.
+Introduce the Snap as a natural extension of existing elements on your screen, and suggest installation when the time is right. This can be a make or break moment for your Snap, so put yourself in the shoes of the intended user.
 
-At what point does it make the most sense to prompt an install? Don’t ask the user to install your snap before they do anything in the dapp or website, as they will probably decline. Instead, **wait to prompt installation** **until a point where the snap is required**.
+At what point does it make the most sense to prompt an install? Don’t ask the user to install your Snap before they do anything in the dapp or website, as they will probably decline. Instead, **wait to prompt installation** **until a point where the Snap is required**.
 
-In the following example, a key management snap is suggested in the context of a network picker screen.
+In the following example, a key management Snap is suggested in the context of a network picker screen.
 
-![Installation and connection to your snap embedded in existing flows](../assets/picker.png)
+![Installation and connection to your Snap embedded in existing flows](../assets/picker.png)
 
 ## Making the most of your metadata
 
-Your snap’s avatar and name will be among the first things a user sees when deciding whether to install your snap. These are also a key part of your identity, so it’s worth spending a bit of time on this step.
+Your Snap’s avatar and name will be among the first things a user sees when deciding whether to install your Snap. These are also a key part of your identity, so it’s worth spending a bit of time on this step.
 
 **Avatar**
 
-Your snap’s avatar should be suitable for a **32 px circular frame in SVG format**. Avoid using images with small details, as they won't be impactful in the allotted space. Aim for something bold, simple, and easily understood.
+Your Snap’s avatar should be suitable for a **32 px circular frame in SVG format**. Avoid using images with small details, as they won't be impactful in the allotted space. Aim for something bold, simple, and easily understood.
 
 **Name**
 
-Your snap's name should be short and easy to remember. It should be **21 characters maximum**, **including spaces**, to ensure that it is easy to read and fits comfortably on small screens.
+Your Snap's name should be short and easy to remember. It should be **21 characters maximum**, **including spaces**, to ensure that it is easy to read and fits comfortably on small screens.
 
-Using a descriptive name can help users understand how they will benefit from installing your snap, and may increase the likelihood that they will install and use it. **Never** use the word **“snap”** in your name — your name should be specific and memorable, and which will differentiate your snap from others.
+Using a descriptive name can help users understand how they will benefit from installing your Snap, and may increase the likelihood that they will install and use it. **Never** use the word **“Snap”** in your name — your name should be specific and memorable, and which will differentiate your Snap from others.
 
-:::note How to (not) name your snap
+:::note How to (not) name your Snap
 
 **Don'ts**
 
@@ -126,9 +126,9 @@ Using a descriptive name can help users understand how they will benefit from in
 
 :::
 
-![How your snap’s avatar and name is displayed during installation](../assets/install.png)
-![How your snap’s name is displayed during transaction insights](../assets/insights.png)
-![How your snap’s avatar and name is displayed during a custom dialog screen](../assets/dialog.png)
+![How your Snap’s avatar and name is displayed during installation](../assets/install.png)
+![How your Snap’s name is displayed during transaction insights](../assets/insights.png)
+![How your Snap’s avatar and name is displayed during a custom dialog screen](../assets/dialog.png)
 
 ## Upleveling your copy
 

--- a/snaps/concepts/execution-environment.md
+++ b/snaps/concepts/execution-environment.md
@@ -31,13 +31,13 @@ The following globals are also available:
 
 The execution environment is instrumented in this way to:
 
-1. Prevent snaps from influencing any other running code, including MetaMask itself.
-   That is, prevent all snaps from polluting the global environment and malicious snaps from
+1. Prevent Snaps from influencing any other running code, including MetaMask itself.
+   That is, prevent all Snaps from polluting the global environment and malicious Snaps from
    stealing the user's stuff.
-1. Prevent snaps from accessing sensitive JavaScript APIs (such as `fetch`) without permission.
+1. Prevent Snaps from accessing sensitive JavaScript APIs (such as `fetch`) without permission.
 1. Ensure that the execution environment is "fully virtualizable," that is, platform-independent.
 
-This allows you to safely execute snaps anywhere, without the snap needing to worry about where and
+This allows you to safely execute Snaps anywhere, without the Snap needing to worry about where and
 how it's executed.
 
 ## Secure ECMAScript (SES)

--- a/snaps/concepts/keyring-api.md
+++ b/snaps/concepts/keyring-api.md
@@ -20,10 +20,10 @@ Previously, you needed a companion dapp to display custom EVM accounts, such mul
 Now you can display these custom accounts alongside regular MetaMask accounts in the UI:
 
 <p align="center">
-<img src={require('../assets/keyring/accounts-ui.png').default} alt="Keyring snap accounts in Metamask UI" width="360" />
+<img src={require('../assets/keyring/accounts-ui.png').default} alt="Keyring Snap accounts in Metamask UI" width="360" />
 </p>
 
-[Create a Keyring snap to integrate custom EVM accounts in MetaMask.](../tutorials/custom-evm-accounts.md)
+[Create a Keyring Snap to integrate custom EVM accounts in MetaMask.](../tutorials/custom-evm-accounts.md)
 Your dapp can then use the [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) MetaMask
 JSON-RPC API method to connect to the custom accounts, and seamlessly interact with them using other
 [JSON-RPC methods](/wallet/reference/eth_subscribe).
@@ -36,33 +36,33 @@ The following terminology is used across the Keyring API:
     balance, nonce, and other account details.
 - **Request**: A request from a dapp to MetaMask.
 - **Keyring account**: An account model that represents one or more blockchain accounts.
-- **Keyring snap**: A snap that implements the Keyring API.
-- **Keyring request**: A request from MetaMask to a Keyring snap. 
+- **Keyring Snap**: A Snap that implements the Keyring API.
+- **Keyring request**: A request from MetaMask to a Keyring Snap. 
     MetaMask wraps the original request sent by the dapp and adds some metadata to it.
 
 ## Components diagram
 
 The following diagram shows the components you encounter when interacting with accounts managed by a
-Keyring snap:
+Keyring Snap:
 
 <p align="center">
 
-![Keyring snap component diagram](../assets/keyring/components-diagram.png)
+![Keyring Snap component diagram](../assets/keyring/components-diagram.png)
 
 </p>
 
-- **User**: The user interacting with the snap, the dapp, and MetaMask.
+- **User**: The user interacting with the Snap, the dapp, and MetaMask.
 - **Dapp**: The dapp requesting an action to be performed on an account.
 - **MetaMask**: The wallet the dapp connects to.
-  MetaMask routes requests to the Keyring snaps and lets the user perform some level of account management.
-- **Snap**: A snap that implements the Keyring API to manage the user's accounts, and to handle
+  MetaMask routes requests to the Keyring Snaps and lets the user perform some level of account management.
+- **Snap**: A Snap that implements the Keyring API to manage the user's accounts, and to handle
   requests that use these accounts.
-- **Snap UI**: The snap's UI component that allows the user to interact with the snap to perform
+- **Snap UI**: The Snap's UI component that allows the user to interact with the Snap to perform
   custom operations on accounts and requests.
 
 ## Keyring interface
 
-The first step to create a Keyring snap is to implement the
+The first step to create a Keyring Snap is to implement the
 [`Keyring`](../reference/keyring-api/type-aliases/Keyring.md) interface.
 This interface describes all the methods necessary to make your custom EVM accounts work inside
 MetaMask with your own logic.
@@ -71,51 +71,51 @@ The following sections describe the different flows that the `Keyring` interface
 
 ### Snap account creation flow
 
-The first interaction between users and the Keyring snap is the snap account creation process.
+The first interaction between users and the Keyring Snap is the Snap account creation process.
 The flow looks like the following:
 
-![Keyring snap account creation flow](../assets/keyring/create-account-flow.png)
+![Keyring Snap account creation flow](../assets/keyring/create-account-flow.png)
 
-The MetaMask account selection modal has an option called **Add snap account**:
+The MetaMask account selection modal has an option called **Add Snap account**:
 
 <p align="center">
-<img src={require('../assets/keyring/add-snap-account.png').default} alt="Add snap account option" width="360" />
+<img src={require('../assets/keyring/add-snap-account.png').default} alt="Add Snap account option" width="360" />
 </p>
 
-This option shows a list of Keyring snaps.
-Each snap redirects the user to the companion dapp that contains all the UI to configure and manage the snap.
+This option shows a list of Keyring Snaps.
+Each Snap redirects the user to the companion dapp that contains all the UI to configure and manage the Snap.
 
 The dapp presents a custom UI allowing the user to configure their custom EVM account.
 The dapp uses the [`createAccount`](../reference/keyring-api/classes/KeyringSnapRpcClient.md#createaccount)
 method of the `KeyringSnapRpcClient`, which calls the `Keyring` interface's method of the same name.
-You can find an example of this in the [example Keyring snap companion dapp](https://github.com/MetaMask/snap-simple-keyring/blob/d3f7f0156c59059c995fea87f90a3d0ad3a4c135/packages/site/src/pages/index.tsx#L136).
+You can find an example of this in the [example Keyring Snap companion dapp](https://github.com/MetaMask/snap-simple-keyring/blob/d3f7f0156c59059c995fea87f90a3d0ad3a4c135/packages/site/src/pages/index.tsx#L136).
 
 The `createAccount` method of the `Keyring` interface creates the account based on the parameters passed
 to the method.
-The snap keeps track of the accounts that it creates using [`snap_manageState`](../reference/rpc-api.md#snap_managestate).
-Once the snap has created an account, it notifies MetaMask using the
+The Snap keeps track of the accounts that it creates using [`snap_manageState`](../reference/rpc-api.md#snap_managestate).
+Once the Snap has created an account, it notifies MetaMask using the
 [`createAccount`](../reference/rpc-api.md#createaccount) sub-method of `snap_manageAccounts`.
 You can find an example of this process in the
 [example companion dapp](https://github.com/MetaMask/snap-simple-keyring/blob/d3f7f0156c59059c995fea87f90a3d0ad3a4c135/packages/snap/src/keyring.ts#L61).
 
-Once the snap has created an account, that account can be used to sign messages and transactions.
+Once the Snap has created an account, that account can be used to sign messages and transactions.
 
 ### Synchronous signing flow
 
-If the Keyring snap can sign transactions directly, it implements a simple synchronous signing flow.
-If the snap needs a third party such as a hardware key or a second account's signature (for example,
+If the Keyring Snap can sign transactions directly, it implements a simple synchronous signing flow.
+If the Snap needs a third party such as a hardware key or a second account's signature (for example,
 in a threshold signature scheme), it implements an [asynchronous signing flow](#asynchronous-signing-flow).
 The synchronous flow looks like the following:
 
 ![Synchronous signing flow](../assets/keyring/synchronous-flow.png)
 
-See the [example Keyring snap companion dapp](https://github.com/MetaMask/snap-simple-keyring) for a
+See the [example Keyring Snap companion dapp](https://github.com/MetaMask/snap-simple-keyring) for a
 full example.
 
 The flow starts when a dapp calls a [MetaMask JSON-RPC method](/wallet/reference/eth_subscribe), or
 when the user initiates a new funds transfer from the MetaMask UI.
 At that point, MetaMask detects that this interaction is requested for an account controlled by the
-Keyring snap.
+Keyring Snap.
 
 After the user approves the transaction in the UI, MetaMask calls the `submitRequest` method of the
 `Keyring` interface.
@@ -124,16 +124,16 @@ After the user approves the transaction in the UI, MetaMask calls the `submitReq
 with `pending` set to `false`, and `result` set to the requested signature.
 
 :::caution important
-If the Keyring snap receives an
+If the Keyring Snap receives an
 [`eth_sendTransaction`](/wallet/reference/eth_sendTransaction) request, it should treat it like an
 [`eth_signTransaction`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_signtransaction) request.
-That is, the snap is responsible for providing the signature in the response, and MetaMask is
+That is, the Snap is responsible for providing the signature in the response, and MetaMask is
 responsible for broadcasting the transaction.
 :::
 
 ### Asynchronous signing flow
 
-If the Keyring snap implements a complex scheme such as threshold signing, it implements an
+If the Keyring Snap implements a complex scheme such as threshold signing, it implements an
 asynchronous signing flow with more `Keyring` methods.
 The asynchronous flow looks like the following:
 
@@ -141,21 +141,21 @@ The asynchronous flow looks like the following:
 
 The flow starts the same way as the [synchronous flow](#synchronous-signing-flow): a dapp or user
 initiates a request to sign a transaction or arbitrary data.
-After approval, the `submitRequest` method of the snap's `Keyring` interface is called.
+After approval, the `submitRequest` method of the Snap's `Keyring` interface is called.
 
-Since the snap doesn't answer the request directly, it stores the pending request in its internal
+Since the Snap doesn't answer the request directly, it stores the pending request in its internal
 state using [`snap_manageState`](../reference/rpc-api.md#snap_managestate).
 This list of pending requests is returned when the `listRequests` or `getRequest` methods of the
 `Keyring` interface are called.
 
-After storing the pending request, the snap creates a pop-up using
+After storing the pending request, the Snap creates a pop-up using
 [`snap_dialog`](../reference/rpc-api.md#snap_dialog) instructing the user to go to the companion
 dapp's URL.
 
-The dapp lists the snap's pending requests using an RPC call facilitated by the
+The dapp lists the Snap's pending requests using an RPC call facilitated by the
 [`listRequests`](../reference/keyring-api/classes/KeyringSnapRpcClient.md#listrequests)
 method of the `KeyringSnapRpcClient`.
-The user can then act on those requests using whatever process applies to the snap.
+The user can then act on those requests using whatever process applies to the Snap.
 
 Once the signing process completes, the companion dapp resolves the request using the
 [`approveRequest`](../reference/keyring-api/classes/KeyringSnapRpcClient.md#approverequest)

--- a/snaps/concepts/lifecycle.md
+++ b/snaps/concepts/lifecycle.md
@@ -1,20 +1,20 @@
 ---
-description: Learn about the lifecycle of a snap.
+description: Learn about the lifecycle of a Snap.
 sidebar_position: 2
 ---
 
 # Snaps lifecycle
 
 Just like [service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) or
-AWS lambda functions, snaps are designed to wake up in response to messages/events, and shut down
+AWS lambda functions, Snaps are designed to wake up in response to messages/events, and shut down
 when idle.
 Snaps have an ephemeral lifecycle: they're here one moment, gone the next.
-Also, if MetaMask detects that a snap becomes unresponsive, it shuts the snap down.
+Also, if MetaMask detects that a Snap becomes unresponsive, it shuts the Snap down.
 
-A snap is considered unresponsive if:
+A Snap is considered unresponsive if:
 
 1. It hasn't received a JSON-RPC request for 30 seconds.
 1. It takes more than 60 seconds to process a JSON-RPC request.
 
-Stopped snaps start whenever they receive a JSON-RPC request, unless they're disabled.
-If a snap is disabled, the user must re-enable it before it can start again.
+Stopped Snaps start whenever they receive a JSON-RPC request, unless they're disabled.
+If a Snap is disabled, the user must re-enable it before it can start again.

--- a/snaps/concepts/user-interface.md
+++ b/snaps/concepts/user-interface.md
@@ -1,28 +1,28 @@
 ---
-description: Learn about the user interface of a snap.
+description: Learn about the user interface of a Snap.
 sidebar_position: 3
 ---
 
 # Snaps user interface
 
-Any snap must represent itself and what it does to the end user.
-Using the MetaMask settings page, the user can see their installed snaps.
-For each snap, the user can:
+Any Snap must represent itself and what it does to the end user.
+Using the MetaMask settings page, the user can see their installed Snaps.
+For each Snap, the user can:
 
 - See most of its manifest data.
 - See its execution status (running, stopped, or crashed).
-- Enable and disable the snap.
+- Enable and disable the Snap.
 
-Other than the settings page, a snap can modify the MetaMask UI using
+Other than the settings page, a Snap can modify the MetaMask UI using
 [custom UI](../how-to/use-custom-ui.md) in only two ways:
 
 - By opening a dialog using the [`snap_dialog`](../reference/rpc-api.md#snap_dialog) RPC method.
 - By returning transaction insights from the [`onTransaction`](../reference/exports.md#ontransaction)
   export.
 
-This means that most snaps must rely on dapps/websites and their own RPC methods to present their
+This means that most Snaps must rely on dapps/websites and their own RPC methods to present their
 data to the user.
 
-Providing more ways for snaps to modify the MetaMask UI is an important goal of the Snaps system,
-and over time more and more snaps will be able to contain their user interfaces entirely within
+Providing more ways for Snaps to modify the MetaMask UI is an important goal of the Snaps system,
+and over time more and more Snaps will be able to contain their user interfaces entirely within
 MetaMask itself.

--- a/snaps/get-started/install-flask.md
+++ b/snaps/get-started/install-flask.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Install MetaMask Flask
 
-To get started building your own snaps, you must [install the MetaMask Flask browser extension](#install-the-metamask-flask-browser-extension).
+To get started building your own Snaps, you must [install the MetaMask Flask browser extension](#install-the-metamask-flask-browser-extension).
 
 :::danger Developers only
 MetaMask Flask is an experimental tool only for developers. 
@@ -23,9 +23,13 @@ If you are not a developer, you should not install MetaMask Flask.
 [MetaMask Flask](https://metamask.io/flask/) is an experimental playground that provides developers 
 access to upcoming MetaMask features. It is available as a browser extension.
 
-While a small set of audited snaps are allowlisted in the stable version of the MetaMask browser extension, MetaMask Flask is intended for developers building and testing snaps locally or from npm. Also, new Snaps API features are enabled in Flask for testing and developer feedback before they're enabled in MetaMask stable.
+While a small set of audited Snaps are allowlisted in the stable version of the MetaMask browser
+extension, MetaMask Flask is intended for developers building and testing Snaps locally or from npm.
+Also, new Snaps API features are enabled in Flask for testing and developer feedback before they're
+enabled in MetaMask stable.
 
 :::caution Install in a new browser profile
-Install the [Metamask Flask browser extension](https://chrome.google.com/webstore/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk) in a new browser profile, or disable any existing installed versions of MetaMask before installing
+Install the [Metamask Flask browser extension](https://chrome.google.com/webstore/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk)
+in a new browser profile, or disable any existing installed versions of MetaMask before installing
 Flask. Running multiple instances of MetaMask in the same browser profile breaks dapp interactions.
 :::

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 # Snaps quickstart
 
 Get started with Snaps using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap).
-With the CLI, you can initialize a snap monorepo project built with TypeScript and React.
+With the CLI, you can initialize a Snap monorepo project built with TypeScript and React.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ With the CLI, you can initialize a snap monorepo project built with TypeScript a
 
 ## Create the project
 
-Create a new snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
+Create a new Snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
 
 ```bash
 yarn create @metamask/snap your-snap-name
@@ -34,9 +34,9 @@ or
 npm create @metamask/snap your-snap-name
 ```
 
-See the section [Snaps anatomy](../concepts/anatomy.md) to learn about the anatomy of your snap project files.
+See the section [Snaps anatomy](../concepts/anatomy.md) to learn about the anatomy of your Snap project files.
 
-## Start the snap
+## Start the Snap
 
 From the root of the newly created project, install the project dependencies using Yarn:
 
@@ -50,20 +50,20 @@ Start the development server:
 yarn start
 ```
 
-You are now serving the snap at [`http://localhost:8080`](http://localhost:8080/) and its front-end at [`http://localhost:8000`](http://localhost:8000/).
+You are now serving the Snap at [`http://localhost:8080`](http://localhost:8080/) and its front-end at [`http://localhost:8000`](http://localhost:8000/).
 
-## Connect to the snap
+## Connect to the Snap
 
 On the front-end, select the **Connect** button and the MetaMask Flask extension pops up and
-requires you to approve the snap's permissions.
+requires you to approve the Snap's permissions.
 
 Once connected, select the **Send message** button to display a custom message within a confirmation
 screen in MetaMask Flask.
 
-## Customize the snap
+## Customize the Snap
 
 Open the project in a text editor.
-You can customize your snap by editing `index.ts` in the `packages/snap/src` folder.
+You can customize your Snap by editing `index.ts` in the `packages/snap/src` folder.
 
 `index.ts` contains an example request that uses the
 [`snap_dialog`](../reference/rpc-api.md#snapdialog) method to display a custom confirmation screen:
@@ -83,7 +83,7 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
             text(`Hello, **${origin}**!`),
             text('This custom confirmation is just for display purposes.'),
             text(
-              'But you can edit the snap source code to make it do something, if you want to!',
+              'But you can edit the Snap source code to make it do something, if you want to!',
             ),
           ]),
         },
@@ -95,14 +95,14 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
 ```
 
 Edit the text in any `text()` component and select the **Reconnect** button
-on the front-end to re-install the snap.
+on the front-end to re-install the Snap.
 
 :::note
-MetaMask Flask automatically re-installs locally hosted snaps whenever it receives a connection request
+MetaMask Flask automatically re-installs locally hosted Snaps whenever it receives a connection request
 for them.
 :::
 
 The next time you select the **Send message** button, you see the updated text in the confirmation screen.
 
-You've now successfully connected, installed, interacted with, and customized your snap!
-Learn more about [developing a snap](../how-to/develop-a-snap.md).
+You've now successfully connected, installed, interacted with, and customized your Snap!
+Learn more about [developing a Snap](../how-to/develop-a-snap.md).

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -1,28 +1,31 @@
 ---
-description: Develop, test, and publish a snap.
+description: Develop, test, and publish a Snap.
 sidebar_position: 1
 ---
 
-# Develop a snap
+# Develop a Snap
 
-A snap can extend the dapp-facing [MetaMask JSON-RPC API](/wallet/reference/rpc-api) in
-arbitrary ways, or integrate with and extend the functionality of MetaMask using the [Snaps Exports](../reference/exports.md), [Snaps JSON-RPC API](../reference/rpc-api.md), and [permissions](request-permissions.md).
+A Snap can extend the dapp-facing [MetaMask JSON-RPC API](/wallet/reference/rpc-api) in
+arbitrary ways, or integrate with and extend the functionality of MetaMask using the
+[Snaps Exports](../reference/exports.md), [Snaps JSON-RPC API](../reference/rpc-api.md), and
+[permissions](request-permissions.md).
 
-Before developing a snap, it's important to understand:
+Before developing a Snap, it's important to understand:
 
-- [The snap anatomy](../concepts/anatomy.md).
-- [The snap lifecycle](../concepts/lifecycle.md).
-- [The snap user interface](../concepts/user-interface.md).
+- [The Snap anatomy](../concepts/anatomy.md).
+- [The Snap lifecycle](../concepts/lifecycle.md).
+- [The Snap user interface](../concepts/user-interface.md).
 - [The MetaMask Snaps execution environment](../concepts/execution-environment.md).
 
 You can [get started quickly using the Snaps template](../get-started/quickstart.md) or follow a
 [tutorial](/snaps/category/tutorials).
 
-This page describes additional important steps when developing a snap.
+This page describes additional important steps when developing a Snap.
 
 ## Detect the user's MetaMask version
 
-When developing a website that depends on [MetaMask Flask](../get-started/install-flask.md#install-metamask-flask), you first need to know whether the user has it installed.
+When developing a website that depends on [MetaMask Flask](../get-started/install-flask.md#install-metamask-flask),
+you first need to know whether the user has it installed.
 
 The following example uses the
 [`@metamask/detect-provider`](https://npmjs.com/package/@metamask/detect-provider) package to get
@@ -48,29 +51,29 @@ if (provider && isFlask) {
 }
 ```
 
-## Test your snap
+## Test your Snap
 
-Test your snap by hosting it locally using `mm-snap serve`, installing it in Flask, and calling its
+Test your Snap by hosting it locally using `mm-snap serve`, installing it in Flask, and calling its
 API methods from a web page.
 
 :::note
-If you use the template snap monorepo, running `yarn start` will serve the snap at 
+If you use the template Snap monorepo, running `yarn start` will serve the Snap at 
 [`http://localhost:8080`](http://localhost:8080/)
 :::
 
-## Debug your snap
+## Debug your Snap
 
-To debug your snap, use `console.log` and inspect the MetaMask background process.
-You can add your log statements in your source code and build your snap, or add them directly
-to your snap bundle and use `mm-snap manifest --fix` to update the `shasum` in your snap manifest file.
-The manifest `shasum` must match the contents of your bundle at the time MetaMask fetches your snap.
+To debug your Snap, use `console.log` and inspect the MetaMask background process.
+You can add your log statements in your source code and build your Snap, or add them directly
+to your Snap bundle and use `mm-snap manifest --fix` to update the `shasum` in your Snap manifest file.
+The manifest `shasum` must match the contents of your bundle at the time MetaMask fetches your Snap.
 
 :::note
-Because adding logs modifies the snap source code, you must re-install the snap whenever you add a
+Because adding logs modifies the Snap source code, you must re-install the Snap whenever you add a
 log statement.
 :::
 
-The snap log output is only visible in the extension background process console.
+The Snap log output is only visible in the extension background process console.
 If you're using a Chromium browser, use the following steps to inspect the background process and
 view its console:
 
@@ -81,57 +84,59 @@ view its console:
 
 The log output displays in the console that pops up.
 
-## Publish your snap
+## Publish your Snap
 
-Snaps are npm packages, so publishing a snap is as simple as publishing an npm package.
+Snaps are npm packages, so publishing a Snap is as simple as publishing an npm package.
 Refer to the [npm CLI documentation](https://docs.npmjs.com/cli/v8/commands/npm-publish) for details
 on publishing to the public registry.
 The following details are specific to Snaps:
 
-- The version in `package.json` and `snap.manifest.json` must match.
-- The `repository.url` field in `package.json` should match the correct repository for your snap.
-- The `source.location.npm.packageName` in `snap.manifest.json` must match the name in `package.json`.
-- The `proposedName` in `snap.manifest.json` should be a human-readable name and should not include the words "MetaMask" or "Snap." 
-- The image specified in `iconPath` in the manifest file is used as the icon displayed when installing the snap, in custom dialogs, and in the settings menu.
-  - This icon must be a valid SVG.
+- The version in `package.json` and `snap.manifest.json` should match.
+- The `repository.url` field in `package.json` should match the correct repository for your Snap.
+- The `source.location.npm.packageName` in `snap.manifest.json` should match the name in `package.json`.
+- The `proposedName` in `snap.manifest.json` should be a human-readable name and should not include
+  the words "MetaMask" or "Snap." 
+- The image specified in `iconPath` in the manifest file is used as the icon displayed when
+  installing the Snap, in custom dialogs, and in the settings menu.
+  - This icon should be a valid SVG.
   - The icon will be cropped in a circle when displayed in MetaMask; you do not need to make the icon circular.
 
-After publishing the snap, any dapp can connect to the snap by using the snap ID `npm:[packageName]`.
+After publishing the Snap, any dapp can connect to the Snap by using the Snap ID `npm:[packageName]`.
 
 :::caution
-If you are using the snap template, make sure to only publish the snap package in `/packages/snap`. 
+If you are using the Snap template, make sure to only publish the Snap package in `/packages/snap`. 
 You can use the [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/staging/#/manifest) to verify 
-that your snap was published correctly &mdash; just click on "localhost" in the top right corner and change the 
-snap location to be "npm" and the ID of your snap. 
+that your Snap was published correctly &mdash; just select **localhost** in the top right corner and change the 
+Snap location to **npm** and the ID of your Snap. 
 
-Also, make sure to update the manifest file, icon file, and README to differentiate your snap from the template.
+Also, make sure to update the manifest file, icon file, and README to differentiate your Snap from the template.
 :::
 
-## Distribute your snap
+## Distribute your Snap
 
-You should deploy a dapp where users can learn about your snap and install it, or integrate with your existing dapp.
+You should deploy a dapp where users can learn about your Snap and install it, or integrate with your existing dapp.
 
-If your snap is designed to communicate with dapps, you can encourage other dapp developers to [integrate your snap](work-with-existing-snaps.md).
+If your Snap is designed to communicate with dapps, you can encourage other dapp developers to [integrate your Snap](work-with-existing-snaps.md).
 
 ## Resources and tools
 
-You can review the growing number of [example snaps](https://github.com/MetaMask/snaps/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source snaps: 
+You can review the growing number of [example Snaps](https://github.com/MetaMask/snaps/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source Snaps: 
 
 - [Dogecoin](https://github.com/ziad-saab/dogecoin-snap)
 - [StarkNet](https://github.com/Consensys/starknet-snap)
 - [MobyMask Phishing Warning](https://github.com/Montoya/mobymask-snap)
 - [Transaction Simulation with Ganache](https://github.com/Montoya/tx-simulation-with-ganache-snap)
 
-MetaMask also maintains tools to help developers build, debug, and maintain snaps:
+MetaMask also maintains tools to help developers build, debug, and maintain Snaps:
 
-- [Template snap](https://github.com/MetaMask/template-snap-monorepo) - A template that includes
+- [Template Snap](https://github.com/MetaMask/template-snap-monorepo) - A template that includes
   TypeScript/React and vanilla JavaScript options and a CLI for building, packaging, and deploying
-  your snap and a companion dapp.
-- [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/latest) - A developer tool built for simulating snaps in the browser, streamlining the development process.
+  your Snap and a companion dapp.
+- [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/latest) - A developer tool built for simulating Snaps in the browser, streamlining the development process.
 - [Snaps Truffle Box](https://trufflesuite.com/boxes/metamask-snap-box/) - A template that combines
-  the TypeScript template snap and Truffle so you can easily test snaps that use smart contracts
+  the TypeScript template Snap and Truffle so you can easily test Snaps that use smart contracts
   with Ganache.
-- [Test snaps](https://github.com/MetaMask/test-snaps) - A collection of test snaps and a dapp for
+- [Test Snaps](https://github.com/MetaMask/test-snaps) - A collection of test Snaps and a dapp for
   evaluating them.
 
 If you have any questions, ask them on

--- a/snaps/how-to/manage-keys.md
+++ b/snaps/how-to/manage-keys.md
@@ -10,7 +10,7 @@ their approval.
 
 :::caution important
 Managing users' keys comes with great responsibility: Misplaced or stolen
-private keys can lead to a complete loss of funds for users of your snap.
+private keys can lead to a complete loss of funds for users of your Snap.
 :::
 
 ## Responsible key management
@@ -30,7 +30,7 @@ The general rule is: **Don't create a situation where your users can lose assets
 
 :::danger examples of irresponsible key management:
 
-- Allowing extraction of private keys outside the snap in any way, especially through RPC or
+- Allowing extraction of private keys outside the Snap in any way, especially through RPC or
   network connections.
 - Executing arbitrary or untrusted code with access to private keys.
 - Not getting properly informed consent before performing irreversible operations.
@@ -81,7 +81,7 @@ For example, to derive Dogecoin keys:
    m/44'/3'/0'/0/{address_index}
    ```
 
-   To get the second Dogecoin account, add the following code to your snap:
+   To get the second Dogecoin account, add the following code to your Snap:
 
    ```javascript
    import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
@@ -106,8 +106,8 @@ For example, to derive Dogecoin keys:
    
 ## Examples
 
-The following are examples of existing snaps that manage accounts and keys:
+The following are examples of existing Snaps that manage accounts and keys:
 
-- [Dogecoin snap tutorial](https://github.com/ziad-saab/dogecoin-snap)
-- [Consensys StarkNet snap](https://github.com/Consensys/starknet-snap)
-- [Account Labs Bitcoin snap](https://github.com/snapdao/btcsnap)
+- [Dogecoin Snap tutorial](https://github.com/ziad-saab/dogecoin-snap)
+- [Consensys StarkNet Snap](https://github.com/Consensys/starknet-snap)
+- [Account Labs Bitcoin Snap](https://github.com/snapdao/btcsnap)

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -5,9 +5,9 @@ sidebar_position: 2
 
 # Request permissions
 
-To access certain powerful JavaScript globals or API methods, a snap must ask the user for permission.
+To access certain powerful JavaScript globals or API methods, a Snap must ask the user for permission.
 Snaps follow the [EIP-2255 wallet permissions specification](https://eips.ethereum.org/EIPS/eip-2255),
-and you must specify a snap's required permissions (except for [dynamic permissions](#dynamic-permissions))
+and you must specify a Snap's required permissions (except for [dynamic permissions](#dynamic-permissions))
 in the `initialPermissions` field of the [manifest file](../concepts/anatomy.md#manifest-file).
 
 ## RPC API permissions
@@ -42,9 +42,9 @@ permission, add the following to the manifest file:
 ## Dynamic permissions
 
 Dynamic permissions are not requested in the manifest file.
-Instead, your snap can acquire dynamic permissions during its lifecycle.
+Instead, your Snap can acquire dynamic permissions during its lifecycle.
 
-For example, your snap can request permission to call the Ethereum provider's
+For example, your Snap can request permission to call the Ethereum provider's
 [`eth_accounts`](../reference/permissions.md#eth_accounts) RPC method by calling the provider's
 [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) RPC method.
 

--- a/snaps/how-to/troubleshoot.md
+++ b/snaps/how-to/troubleshoot.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 
 # Troubleshoot
 
-This page describes common issues you may encounter when developing a snap, and how to resolve them.
+This page describes common issues you may encounter when developing a Snap, and how to resolve them.
 
 If you encounter any issues that you can't solve on your own, please
 [open a GitHub issue](https://github.com/MetaMask/snaps-monorepo/issues).
@@ -15,7 +15,7 @@ If you encounter any issues that you can't solve on your own, please
 Because [Secure ECMAScript (SES)](../concepts/execution-environment.md) adds additional restrictions
 on the JavaScript runtime on top of strict mode, code that executes normally under strict mode might
 not under SES.
-`mm-snap build` by default attempts to execute a snap in a stubbed SES environment.
+`mm-snap build` by default attempts to execute a Snap in a stubbed SES environment.
 You can also disable this behavior and run the evaluation step separately using `mm-snap eval`.
 If an error is thrown during this step, it's likely due to a SES incompatibility, and you must fix
 the issues manually.
@@ -23,7 +23,7 @@ These incompatibilities tend to occur in dependencies.
 
 While the errors you get from SES may seem scary, they're usually not that hard to fix.
 The actual file, function, and variable names in the `mm-snap eval` error stack trace might not make
-a lot of sense to you, but the line numbers should correspond to your snap
+a lot of sense to you, but the line numbers should correspond to your Snap
 [bundle file](../concepts/anatomy.md#bundle-file).
 Thus, you can identify if the error is due to your code or one of your dependencies.
 If the problem is in a dependency, you can try a different version or to fix the issue locally by
@@ -34,18 +34,18 @@ To give you an idea of a common error and how to fix it, "sloppily" declared var
 assigning to a new variable without an explicit variable declaration) are forbidden in strict mode,
 and therefore in SES as well.
 If you get an error during the `eval` step that says something like `variableName is not defined`,
-simply prepending `var variableName;` to your snap bundle may solve the problem.
+simply prepending `var variableName;` to your Snap bundle may solve the problem.
 (This actually happened so frequently with [Babel's](https://babeljs.io/) `regeneratorRuntime` that
 `mm-snap build` automatically handles that one.)
 
 :::caution
-Run `mm-snap manifest --fix` if you modified your snap bundle after building.
-Otherwise your manifest `shasum` value won't be correct, and attempting to install your snap fails.
+Run `mm-snap manifest --fix` if you modified your Snap bundle after building.
+Otherwise your manifest `shasum` value won't be correct, and attempting to install your Snap fails.
 :::
 
 ### Use other build tools
 
-If you prefer building your snap with a build system you're more comfortable with, Snaps implements
+If you prefer building your Snap with a build system you're more comfortable with, Snaps implements
 plugins for several other build systems:
 
 - [Webpack](https://www.npmjs.com/package/@metamask/snaps-webpack-plugin)
@@ -61,7 +61,7 @@ You may also benefit from running `mm-snap eval` to detect any SES issues up fro
 
 ## Patch dependencies
 
-Some dependencies might make use of APIs that aren't available in the
+Some dependencies might use APIs that aren't available in the
 [Snaps execution environment](../concepts/execution-environment.md).
 To work around this, we recommend checking if another library is available that makes use of those APIs.
 
@@ -104,7 +104,7 @@ This section also describes patching strategies for fixing dependencies that try
 
 `cross-fetch` is a popular library used for cross-platform access to the `fetch` API across multiple
 environments.
-Under the hood, however, the library uses `XMLHttpRequest` and thus causes issues when used in a snap.
+Under the hood, however, the library uses `XMLHttpRequest` and thus causes issues when used in a Snap.
 
 You can easily patch this issue using `patch-package`.
 Open `node_modules/cross-fetch/browser-ponyfill.js` and find the following lines near the bottom of

--- a/snaps/how-to/use-keyring-api.md
+++ b/snaps/how-to/use-keyring-api.md
@@ -14,10 +14,10 @@ sidebar_custom_props:
 
 Your dapp can use the [Keyring API](../concepts/keyring-api.md) to interact with custom EVM accounts.
 Use the [`KeyringSnapRpcClient`](../reference/keyring-api/classes/KeyringSnapRpcClient.md)
-of the Keyring API to invoke Keyring RPC methods on your [Keyring snap](../concepts/keyring-api.md#terminology).
+of the Keyring API to invoke Keyring RPC methods on your [Keyring Snap](../concepts/keyring-api.md#terminology).
 
 :::tip tutorial
-You can follow the end-to-end tutorial to [create a snap to connect to custom EVM accounts](../tutorials/custom-evm-accounts.md).
+You can follow the end-to-end tutorial to [create a Snap to connect to custom EVM accounts](../tutorials/custom-evm-accounts.md).
 :::
 
 :::info API documentation
@@ -50,7 +50,7 @@ let client = new KeyringSnapRpcClient(snapId, window.ethereum);
 ## Call Keyring API methods
 
 You can now use the `KeyringSnapRpcClient` to invoke the following
-[`Keyring API`](../reference/keyring-api/index.md) methods on your snap.
+[`Keyring API`](../reference/keyring-api/index.md) methods on your Snap.
 
 ### createAccount
 
@@ -71,7 +71,7 @@ let keyringAccount = await client.getAccount(accountId);
 
 ### listAccounts
 
-Lists all Keyring accounts created by the snap.
+Lists all Keyring accounts created by the Snap.
 
 ```ts
 let keyringAccounts = await client.listAccounts();
@@ -109,7 +109,7 @@ let submitRequestResponse = await client.submitRequest({
         jsonrpc: "2.0",
         // Unique ID to identify every request
         id: uuid(),
-        // The method and parameter structure is subjective to the Keyring API implementation in the snap code.
+        // The method and parameter structure is subjective to the Keyring API implementation in the Snap code.
         method: "eth_sendTransaction",
         params:
             {
@@ -134,7 +134,7 @@ let keyringRequest = await client.getRequest(requestId);
 
 ### listRequests
 
-Lists all requests submitted to the snap.
+Lists all requests submitted to the Snap.
 
 ```ts
 let requests = await client.listRequests();

--- a/snaps/how-to/work-with-existing-snaps.md
+++ b/snaps/how-to/work-with-existing-snaps.md
@@ -1,22 +1,22 @@
 ---
-description: Connect your dapp to existing, third-party snaps.
+description: Connect your dapp to existing, third-party Snaps.
 sidebar_position: 6
 ---
 
-# Work with third-party snaps
+# Work with third-party Snaps
 
-Some existing, third-party snaps are designed to communicate with dapps.
-As a dapp developer, you can use these snaps to take advantage of new features enabled by snaps.
-This is possible because [snaps can expose a JSON-RPC API](../reference/exports.md#onrpcrequest).
+Some existing, third-party Snaps are designed to communicate with dapps.
+As a dapp developer, you can use these Snaps to take advantage of new features enabled by Snaps.
+This is possible because [Snaps can expose a JSON-RPC API](../reference/exports.md#onrpcrequest).
 Snaps can decide to make their API available to dapps by requesting the
 [`endowment:rpc`](../reference/permissions.md#endowmentrpc) permission.
 
-## Connect to a snap
+## Connect to a Snap
 
-Connect to a snap by calling the [`wallet_requestSnaps`](../reference/rpc-api.md#wallet_requestsnaps)
+Connect to a Snap by calling the [`wallet_requestSnaps`](../reference/rpc-api.md#wallet_requestsnaps)
 method from your dapp.
-If a user doesn't have the snap installed in their MetaMask wallet, MetaMask prompts the user to
-install the snap.
+If a user doesn't have the Snap installed in their MetaMask wallet, MetaMask prompts the user to
+install the Snap.
 The following are different possible outcomes from calling `wallet_requestSnaps`.
 
 ### User rejects the installation request
@@ -39,7 +39,7 @@ with the following shape:
         "enabled": true,
         "id": "SNAP_ID",
         "initialPermissions": {
-            // ...all the permissions in the snap's manifest
+            // ...all the permissions in the Snap's manifest
         },
         "version": "SNAP_VERSION"
     }
@@ -48,31 +48,31 @@ with the following shape:
 
 ### Snap is already installed
 
-If the snap is already installed, the call to `wallet_requestSnaps` returns the same object as for a
-new installation of the snap, but the user won't see a confirmation pop-up asking them to install the snap.
+If the Snap is already installed, the call to `wallet_requestSnaps` returns the same object as for a
+new installation of the Snap, but the user won't see a confirmation pop-up asking them to install the Snap.
 
 :::caution important
 Snaps are installed into the MetaMask instance of each user.
-If a snap stores data, that data is specific to that user's MetaMask instance.
+If a Snap stores data, that data is specific to that user's MetaMask instance.
 However, that data can be shared with multiple dapps.
-Do not assume that data stored by a snap is unique to your dapp. 
+Do not assume that data stored by a Snap is unique to your dapp. 
 :::
 
-## Determine whether a snap is installed
+## Determine whether a Snap is installed
 
-Determine whether a snap is installed by calling the [`wallet_getSnaps`](../reference/rpc-api.md#wallet_getsnaps)
+Determine whether a Snap is installed by calling the [`wallet_getSnaps`](../reference/rpc-api.md#wallet_getsnaps)
 method from your dapp.
-This method returns a list of only those snaps that are connected to your current dapp.
+This method returns a list of only those Snaps that are connected to your current dapp.
 
-The response is in the form of an object keyed by the ID of the snap.
-Each value is a nested object with additional information, such as the version of the snap that is installed.
+The response is in the form of an object keyed by the ID of the Snap.
+Each value is a nested object with additional information, such as the version of the Snap that is installed.
 
 :::note
-`wallet_getSnaps` only returns the snaps that are connected to your dapp.
-The user may have other snaps installed that your dapp is not aware of. 
+`wallet_getSnaps` only returns the Snaps that are connected to your dapp.
+The user may have other Snaps installed that your dapp is not aware of. 
 :::
 
-The following example verifies whether a snap with ID `npm:super-snap` is installed:
+The following example verifies whether a Snap with ID `npm:super-snap` is installed:
 
 ```ts
 const snaps = await ethereum.request({
@@ -82,25 +82,25 @@ const snaps = await ethereum.request({
 const isMySnapInstalled = Object.keys(snaps).includes('npm:super-snap');
 ```
 
-If you need to work with a specific version of a snap, you can instead iterate over
+If you need to work with a specific version of a Snap, you can instead iterate over
 `Object.values(snaps)`, and use the `id` and `version` properties inside each object to determine
-whether the snap is installed with the required version.
+whether the Snap is installed with the required version.
 
 :::note
-A user cannot install multiple versions of a snap into a single MetaMask instance.
-You should avoid requiring a specific version of a snap unless you absolutely need to.
-In most cases, you should request the latest version of the snap and architect your dapp to be able
+A user cannot install multiple versions of a Snap into a single MetaMask instance.
+You should avoid requiring a specific version of a Snap unless you absolutely need to.
+In most cases, you should request the latest version of the Snap and architect your dapp to be able
 to work with that version.
 :::
 
-## Reconnect to a snap
+## Reconnect to a Snap
 
-At any time, a user can open their MetaMask Snaps settings menu and see all the dapps connected to a snap.
+At any time, a user can open their MetaMask Snaps settings menu and see all the dapps connected to a Snap.
 From that menu they can revoke a dapp connection.
-If your dapp loses the connection to a snap, you can reconnect by calling
+If your dapp loses the connection to a Snap, you can reconnect by calling
 [`wallet_requestSnaps`](../reference/rpc-api.md#wallet_requestsnaps).
-Since the snap is already installed, this returns a success response without MetaMask showing a pop-up.
-However, if the user has disabled the snap, the response has `enabled` set to `false` for your `SNAP_ID`:
+Since the Snap is already installed, this returns a success response without MetaMask showing a pop-up.
+However, if the user has disabled the Snap, the response has `enabled` set to `false` for your `SNAP_ID`:
 
 ```json
 {
@@ -109,7 +109,7 @@ However, if the user has disabled the snap, the response has `enabled` set to `f
         "enabled": false,
         "id": "SNAP_ID",
         "initialPermissions": {
-            // ...all the permissions in the snap's manifest
+            // ...all the permissions in the Snap's manifest
         },
         "version": "SNAP_VERSION"
     }

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -85,5 +85,5 @@ Features include:
 ## Questions?
 
 If you have questions about using MetaMask Snaps or want to propose a new feature, you can interact with the
-MetaMask Snaps team and community on [GitHub discussions](https://github.com/MetaMask/Snaps-monorepo/discussions)
+MetaMask Snaps team and community on [GitHub discussions](https://github.com/MetaMask/snaps/discussions)
 and the **snaps-dev-metamask** channel on [Consensys Discord](https://discord.gg/consensys).

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -16,15 +16,15 @@ To learn how to integrate your dapp with MetaMask, visit the
 [MetaMask wallet developer documentation](../wallet).
 :::
 
-## What is a snap?
+## What is a Snap?
 
-A snap is a JavaScript program run in an isolated environment that customizes the wallet experience.
+A Snap is a JavaScript program run in an isolated environment that customizes the wallet experience.
 Snaps have access to a limited set of capabilities, determined by the
 [permissions](how-to/request-permissions.md) the user granted them during installation.
 
-## What can you do with a snap?
+## What can you do with a Snap?
 
-A snap can add new API methods to MetaMask, add support for different blockchain protocols, or
+A Snap can add new API methods to MetaMask, add support for different blockchain protocols, or
 modify existing functionalities using the [Snaps JSON-RPC API](reference/rpc-api.md).
 
 Features include:
@@ -85,5 +85,5 @@ Features include:
 ## Questions?
 
 If you have questions about using MetaMask Snaps or want to propose a new feature, you can interact with the
-MetaMask Snaps team and community on [GitHub discussions](https://github.com/MetaMask/snaps-monorepo/discussions)
-and the Snaps Dev channel on [Consensys Discord](https://discord.gg/consensys).
+MetaMask Snaps team and community on [GitHub discussions](https://github.com/MetaMask/Snaps-monorepo/discussions)
+and the **snaps-dev-metamask** channel on [Consensys Discord](https://discord.gg/consensys).

--- a/snaps/reference/cli/index.md
+++ b/snaps/reference/cli/index.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 This reference describes the syntax of the Snaps command line interface (CLI) subcommands and options.
 
 :::note
-The CLI is installed when you [create a snap project](../../get-started/quickstart.md).
+The CLI is installed when you [create a Snap project](../../get-started/quickstart.md).
 :::
 
 You can specify subcommands and options using the `mm-snap` command:

--- a/snaps/reference/cli/options.md
+++ b/snaps/reference/cli/options.md
@@ -32,7 +32,7 @@ bundle: 'out/bundle.js'
 
 <!--/tabs-->
 
-Path to the snap [bundle file](../../concepts/anatomy.md#bundle-file).
+Path to the Snap [bundle file](../../concepts/anatomy.md#bundle-file).
 The default is `dist/bundle.js`.
 
 You can use this option with the [`eval`](subcommands.md#e-eval) subcommand.
@@ -125,7 +125,7 @@ eval: false
 
 <!--/tabs-->
 
-Indicates whether to attempt to evaluate the snap bundle in SES.
+Indicates whether to attempt to evaluate the Snap bundle in SES.
 The default is `true`.
 
 You can use this option with the [`build`](subcommands.md#b-build) and
@@ -157,7 +157,7 @@ fix: false
 
 <!--/tabs-->
 
-When validating the snap [manifest file](../../concepts/anatomy.md#manifest-file) using the
+When validating the Snap [manifest file](../../concepts/anatomy.md#manifest-file) using the
 [`manifest`](subcommands.md#m-manifest) subcommand, indicates whether to make necessary changes to
 the manifest file.
 The default is `true`.
@@ -199,7 +199,7 @@ manifest: false
 
 <!--/tabs-->
 
-Indicates whether to validate the snap [manifest file](../../concepts/anatomy.md#manifest-file).
+Indicates whether to validate the Snap [manifest file](../../concepts/anatomy.md#manifest-file).
 The default is `true`.
 
 You can use this option with the [`build`](subcommands.md#b-build) and
@@ -231,7 +231,7 @@ outfileName: 'snap.js'
 
 <!--/tabs-->
 
-Output file name when building a snap from source.
+Output file name when building a Snap from source.
 The default is `bundle.js`.
 
 You can use this option with the [`build`](subcommands.md#b-build) and
@@ -327,7 +327,7 @@ src: 'lib/index.js'
 
 <!--/tabs-->
 
-Path to the snap source file.
+Path to the Snap source file.
 The default is `src/index.js`.
 
 You can use this option with the [`build`](subcommands.md#b-build) and
@@ -460,7 +460,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 [`watch`](subcommands.md#w-watch) subcommands.
 
 :::note
-For TypeScript snaps, `--transpilationMode` must be set to either `localOnly` or `localAndDeps`.
+For TypeScript Snaps, `--transpilationMode` must be set to either `localOnly` or `localAndDeps`.
 :::
 
 ## verboseErrors

--- a/snaps/reference/cli/subcommands.md
+++ b/snaps/reference/cli/subcommands.md
@@ -26,7 +26,7 @@ mm-snap b -s lib/index.js -d out -n snap.js
 
 <!--/tabs-->
 
-Builds a snap from source.
+Builds a Snap from source.
 
 `b` is an alias for `build`.
 
@@ -48,7 +48,7 @@ mm-snap e -b out/snap.js
 
 <!--/tabs-->
 
-Attempts to evaluate the snap bundle in SES.
+Attempts to evaluate the Snap bundle in SES.
 
 `e` is an alias for `eval`.
 
@@ -70,8 +70,8 @@ mm-snap i my-snap
 
 <!--/tabs-->
 
-Initializes a snap project in the specified directory.
-If no directory is specified, the snap project is initialized in the current directory.
+Initializes a Snap project in the specified directory.
+If no directory is specified, the Snap project is initialized in the current directory.
 
 `i` is an alias for `init`.
 
@@ -93,7 +93,7 @@ mm-snap m --fix false
 
 <!--/tabs-->
 
-Validates the snap [manifest file](../../concepts/anatomy.md#manifest-file).
+Validates the Snap [manifest file](../../concepts/anatomy.md#manifest-file).
 
 `m` is an alias for `manifest`.
 
@@ -115,7 +115,7 @@ mm-snap s -r out -p 9000
 
 <!--/tabs-->
 
-Locally serves snap files for testing.
+Locally serves Snap files for testing.
 
 `s` is an alias for `serve`.
 
@@ -137,7 +137,7 @@ mm-snap w -s lib/index.js -d out
 
 <!--/tabs-->
 
-Rebuilds a snap from source upon changes to the files in the parent and child directories of the
+Rebuilds a Snap from source upon changes to the files in the parent and child directories of the
 source directory.
 
 :::note

--- a/snaps/reference/exports.md
+++ b/snaps/reference/exports.md
@@ -6,19 +6,19 @@ sidebar_position: 2
 
 # Snaps exports
 
-A snap can export the following methods.
+A Snap can export the following methods.
 
 ## onRpcRequest
 
-To communicate with dapps and other snaps, a snap must implement its own JSON-RPC API by exporting
+To communicate with dapps and other Snaps, a Snap must implement its own JSON-RPC API by exporting
 `onRpcRequest`.
-Whenever the snap receives a JSON-RPC request, the `onRpcRequest` handler method is called.
+Whenever the Snap receives a JSON-RPC request, the `onRpcRequest` handler method is called.
 
 :::caution important
-If your snap can do something useful without receiving and responding to JSON-RPC requests, such as
+If your Snap can do something useful without receiving and responding to JSON-RPC requests, such as
 providing [transaction insights](#ontransaction), you can skip exporting `onRpcRequest`.
 However, if you want to do something such as manage the user's keys for a particular protocol and
-create a dapp that sends transactions for that protocol via your snap, for example, you must
+create a dapp that sends transactions for that protocol via your Snap, for example, you must
 specify an RPC API.
 :::
 
@@ -74,13 +74,13 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 
 ## onTransaction
 
-To provide transaction insights before a user signs a transaction, a snap must export `onTransaction`.
+To provide transaction insights before a user signs a transaction, a Snap must export `onTransaction`.
 Whenever there's a contract interaction, and a transaction is submitted using the MetaMask
 extension, MetaMask calls this method.
 MetaMask passes the raw unsigned transaction payload to the `onTransaction` handler method.
 
 :::note
-For MetaMask to call the snap's `onTransaction` method, you must request the
+For MetaMask to call the Snap's `onTransaction` method, you must request the
 [`endowment:transaction-insight`](permissions.md#endowmenttransaction-insight) permission.
 :::
 
@@ -150,12 +150,12 @@ module.exports.onTransaction = async ({
 
 ## onCronjob
 
-To run periodic actions for the user (cron jobs), a snap must export `onCronjob`.
+To run periodic actions for the user (cron jobs), a Snap must export `onCronjob`.
 This method is called at the specified times with the specified payloads defined in the
 [`endowment:cronjob`](permissions.md#endowmentcronjob) permission.
 
 :::note
-For MetaMask to call the snap's `onCronjob` method, you must request the
+For MetaMask to call the Snap's `onCronjob` method, you must request the
 [`endowment:cronjob`](permissions.md#endowmentcronjob) permission.
 :::
 

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # Snaps permissions
 
-Your snap can [request the following permissions](../how-to/request-permissions.md).
+Your Snap can [request the following permissions](../how-to/request-permissions.md).
 
 ## RPC API permissions
 
@@ -25,8 +25,8 @@ manifest file:
 
 ### endowment:cronjob
 
-To run periodic actions for the user (cron jobs), a snap must request the `endowment:cronjob` permission.
-This permission allows the snap to specify cron jobs that trigger the exported
+To run periodic actions for the user (cron jobs), a Snap must request the `endowment:cronjob` permission.
+This permission allows the Snap to specify cron jobs that trigger the exported
 [`onCronjob`](../reference/exports.md#oncronjob) method.
 
 Specify this permission in the manifest file as follows:
@@ -68,8 +68,8 @@ Specify this permission in the manifest file as follows:
 
 ### endowment:ethereum-provider
 
-To communicate with a node using MetaMask, a snap must request the `endowment:ethereum-provider` permission.
-This permission exposes the global API `ethereum` to the snap execution environment.
+To communicate with a node using MetaMask, a Snap must request the `endowment:ethereum-provider` permission.
+This permission exposes the global API `ethereum` to the Snap execution environment.
 This global is an EIP-1193 provider.
 
 Specify this permission in the manifest file as follows:
@@ -89,7 +89,7 @@ those connected accounts.
 
 ### endowment:network-access
 
-To access the internet, a snap must request the `endowment:network-access` permission.
+To access the internet, a Snap must request the `endowment:network-access` permission.
 This permission exposes the global `fetch` API to the Snaps execution environment.
 
 :::caution
@@ -108,21 +108,21 @@ Specify this permission in the manifest file as follows:
 
 #### Same-origin policy and CORS
 
-`fetch()` requests in a snap are bound by the browser's [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_network_access).
-Since snap code is executed in an iframe with the `sandbox` property, the browser sends an `Origin`
+`fetch()` requests in a Snap are bound by the browser's [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_network_access).
+Since Snap code is executed in an iframe with the `sandbox` property, the browser sends an `Origin`
 header with the value `null` with outgoing requests.
-For the snap to be able to read the response, the server must send an
+For the Snap to be able to read the response, the server must send an
 [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) CORS header
 with the value `*` or `null` in the response.
 
 ### endowment:rpc
 
-To handle arbitrary JSON-RPC requests, a snap must request the `endowment:rpc` permission.
-This permission grants a snap access to JSON-RPC requests sent to the snap, using the exported
+To handle arbitrary JSON-RPC requests, a Snap must request the `endowment:rpc` permission.
+This permission grants a Snap access to JSON-RPC requests sent to the Snap, using the exported
 [`onRpcRequest`](exports.md#onrpcrequest) method.
 
 This permission requires an object with a `snaps` or `dapps` property (or both), to signal if the
-snap can receive JSON-RPC requests from other snaps, or dapps, respectively.
+snap can receive JSON-RPC requests from other Snaps, or dapps, respectively.
 The default for both properties is `false`.
 
 Specify this permission in the manifest file as follows:
@@ -140,11 +140,11 @@ Specify this permission in the manifest file as follows:
 
 ### endowment:transaction-insight
 
-To provide transaction insights, a snap must request the `endowment:transaction-insight` permission.
-This permission grants a snap read-only access to raw transaction payloads, before they're accepted
+To provide transaction insights, a Snap must request the `endowment:transaction-insight` permission.
+This permission grants a Snap read-only access to raw transaction payloads, before they're accepted
 for signing by the user, by exporting the [`onTransaction`](../reference/exports.md#ontransaction) method.
 
-This permission requires an object with an `allowTransactionOrigin` property to signal if the snap
+This permission requires an object with an `allowTransactionOrigin` property to signal if the Snap
 should pass the `transactionOrigin` property as part of the `onTransaction` parameters.
 This property represents the transaction initiator origin.
 The default is `false`.
@@ -161,8 +161,8 @@ Specify this permission in the manifest file as follows:
 
 ### endowment:webassembly
 
-To use WebAssembly, a snap must request the `endowment:webassembly` permission.
-This permission exposes the global `WebAssembly` API to the snap execution environment.
+To use WebAssembly, a Snap must request the `endowment:webassembly` permission.
+This permission exposes the global `WebAssembly` API to the Snap execution environment.
 
 Specify this permission in the manifest file as follows:
 
@@ -175,17 +175,17 @@ Specify this permission in the manifest file as follows:
 ## Dynamic permissions
 
 Dynamic permissions are not requested in the manifest file.
-Instead, your snap can acquire dynamic permissions during its lifecycle.
+Instead, your Snap can acquire dynamic permissions during its lifecycle.
 
 ### eth_accounts
 
-A snap can request permission to call the Ethereum provider's [`eth_accounts`](/wallet/reference/eth_accounts)
+A Snap can request permission to call the Ethereum provider's [`eth_accounts`](/wallet/reference/eth_accounts)
 RPC method by calling the provider's [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) RPC method.
 Calling `eth_requestAccounts` requires the [`ethereum-provider`](#endowmentethereum-provider) endowment.
 
 You can check the presence of the permission by calling [`wallet_getPermissions`](/wallet/reference/wallet_getpermissions).
 If the permission is present, the result contains a permission with a `parentCapability` of `eth_accounts`.
-It comes with a caveat of `restrictReturnedAccounts`, an array of all the accounts the user allows for this snap.
+It comes with a caveat of `restrictReturnedAccounts`, an array of all the accounts the user allows for this Snap.
 The following is an example `eth_accounts` permission:
 
 ```json
@@ -205,4 +205,4 @@ The following is an example `eth_accounts` permission:
 }
 ```
 
-The user can revoke this permission by going to the snap's settings under **Snap permissions**.
+The user can revoke this permission by going to the Snap's settings under **Snap permissions**.

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -6,9 +6,9 @@ sidebar_position: 1
 # Snaps JSON-RPC API
 
 Snaps communicate with MetaMask using the Snaps JSON-RPC API.
-These API methods allow snaps to modify the functionality of MetaMask, and websites (dapps) to
-install and communicate with individual snaps.
-Some methods are only callable by snaps, and some are only callable by websites.
+These API methods allow Snaps to modify the functionality of MetaMask, and websites (dapps) to
+install and communicate with individual Snaps.
+Some methods are only callable by Snaps, and some are only callable by websites.
 
 ## Unrestricted methods
 
@@ -16,21 +16,21 @@ You can call unrestricted methods without requesting permission to do so.
 
 ### wallet_getSnaps
 
-Returns the IDs of the caller's permitted snaps and some relevant metadata.
+Returns the IDs of the caller's permitted Snaps and some relevant metadata.
 
 This method is only callable by websites.
 
 #### Returns
 
-An object containing the requester's permitted snaps.
-Each snap is an object containing:
+An object containing the requester's permitted Snaps.
+Each Snap is an object containing:
 
-- `id` - The ID of the snap.
-- `initialPermissions` - The initial permissions of the snap, which will be requested when the snap
+- `id` - The ID of the Snap.
+- `initialPermissions` - The initial permissions of the Snap, which will be requested when the Snap
   is installed.
-- `version` - The version of the snap.
-- `enabled` - `true` if the snap is enabled, `false` otherwise.
-- `blocked` - `true` if the snap is blocked, `false` otherwise.
+- `version` - The version of the Snap.
+- `enabled` - `true` if the Snap is enabled, `false` otherwise.
+- `blocked` - `true` if the Snap is blocked, `false` otherwise.
 
 #### Example
 
@@ -47,7 +47,7 @@ console.log(result);
 # Result
 
 ```javascript
-// Example result if any snaps are permitted
+// Example result if any Snaps are permitted
 {
   'npm:@metamask/example-snap': {
     version: '1.0.0',
@@ -62,26 +62,26 @@ console.log(result);
 
 ### wallet_requestSnaps
 
-Requests permission for a website to communicate with the specified snaps and attempts to install
+Requests permission for a website to communicate with the specified Snaps and attempts to install
 them if they're not already installed.
-If the installation of any snap fails, returns the error that caused the failure.
+If the installation of any Snap fails, returns the error that caused the failure.
 
-You can optionally specify a [SemVer range](https://www.npmjs.com/package/semver) for a snap.
-MetaMask attempts to install a version of the snap that satisfies the requested range.
-If a compatible version of a snap is already installed, the request succeeds.
-If an incompatible version is installed, MetaMask attempts to update the snap to the latest version
+You can optionally specify a [SemVer range](https://www.npmjs.com/package/semver) for a Snap.
+MetaMask attempts to install a version of the Snap that satisfies the requested range.
+If a compatible version of a Snap is already installed, the request succeeds.
+If an incompatible version is installed, MetaMask attempts to update the Snap to the latest version
 that satisfies the requested range.
-The request succeeds if the snap is successfully updated.
+The request succeeds if the Snap is successfully updated.
 
 This method is only callable by websites.
 
 #### Parameters
 
-An object containing the snaps to request permission to communicate with.
+An object containing the Snaps to request permission to communicate with.
 
 #### Returns
 
-An object mapping the IDs of installed snaps to either their metadata or an error if installation fails.
+An object mapping the IDs of installed Snaps to either their metadata or an error if installation fails.
 
 #### Example
 
@@ -133,7 +133,7 @@ try {
 
 ## Restricted methods
 
-For restricted methods callable by snaps, a snap must request permission to call the method in the
+For restricted methods callable by Snaps, a Snap must request permission to call the method in the
 [snap manifest file](../how-to/request-permissions.md).
 For restricted methods callable by websites, a website must request permission to call the method using
 [`wallet_requestPermissions`](/wallet/reference/rpc-api/#wallet_requestpermissions).
@@ -147,7 +147,7 @@ There are three types of dialogs with different parameters and return types:
 - [Confirmation](#confirmation-dialog)
 - [Prompt](#prompt-dialog)
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Alert dialog
 
@@ -269,7 +269,7 @@ This method is designed to be used with the
 for user addresses, but it's your responsibility to know how to use those keys to, for example,
 derive an address for the relevant protocol or sign a transaction for the user.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Parameters
 
@@ -349,7 +349,7 @@ Gets the [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 derivation path specified by the `path` parameter.
 Note that this returns the public key, not the extended public key (`xpub`), or Ethereum address.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Parameters
 
@@ -426,11 +426,11 @@ This method is designed to be used with the
 for user addresses, but it's your responsibility to know how to use those keys to, for example,
 derive an address for the relevant protocol or sign a transaction for the user.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 :::caution 
-Coin type 60 is reserved for MetaMask accounts and blocked for snaps. 
-If you wish to connect to MetaMask accounts in a snap, use 
+Coin type 60 is reserved for MetaMask accounts and blocked for Snaps. 
+If you wish to connect to MetaMask accounts in a Snap, use 
 [`endowment:ethereum-provider`](../reference/permissions.md/#endowmentethereum-provider) and 
 `eth_requestAccounts`.
 :::
@@ -506,17 +506,17 @@ const addressKey1 = await deriveDogecoinAddress(1);
 
 ### snap_getEntropy
 
-Gets a deterministic 256-bit entropy value, specific to the snap and the user's account.
+Gets a deterministic 256-bit entropy value, specific to the Snap and the user's account.
 You can use this entropy to generate a private key, or any other value that requires a high level of
 randomness.
-Other snaps can't access this entropy, and it changes if the user's secret recovery phrase changes.
+Other Snaps can't access this entropy, and it changes if the user's secret recovery phrase changes.
 
 You can optionally specify a salt to generate different entropy for different purposes.
 Using a salt results in entropy unrelated to the entropy generated without a salt.
 
-This value is deterministic: it's always the same for the same snap, user account, and salt.
+This value is deterministic: it's always the same for the same Snap, user account, and salt.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Parameters
 
@@ -564,7 +564,7 @@ console.log(entropy);
 
 ### snap_manageAccounts
 
-Manages [Keyring snap](../concepts/keyring-api.md) accounts.
+Manages [Keyring Snap](../concepts/keyring-api.md) accounts.
 This method is organized into multiple sub-methods which each take their own parameters:
 
 - [`createAccount`](#createaccount)
@@ -573,14 +573,14 @@ This method is organized into multiple sub-methods which each take their own par
 - [`listAccounts`](#listaccounts)
 - [`submitResponse`](#submitresponse)
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### `createAccount`
 
-Creates a new snap account.
+Creates a new Snap account.
 
 :::note
-The snap is responsible for maintaining its own record of accounts.
+The Snap is responsible for maintaining its own record of accounts.
 This can be done using [`snap_manageState`](#snap_managestate).
 :::
 
@@ -641,10 +641,10 @@ class MyKeyring implements Keyring {
 
 #### `updateAccount`
 
-Updates an existing snap account.
+Updates an existing Snap account.
 
 :::note
-The snap is responsible for maintaining its own record of accounts.
+The Snap is responsible for maintaining its own record of accounts.
 This can be done using [`snap_manageState`](#snap_managestate).
 :::
 
@@ -680,10 +680,10 @@ class MyKeyring implements Keyring {
 
 #### `deleteAccount`
 
-Deletes a snap account.
+Deletes a Snap account.
 
 :::note
-The snap is responsible for maintaining its own record of accounts.
+The Snap is responsible for maintaining its own record of accounts.
 This can be done using [`snap_manageState`](#snap_managestate).
 :::
 
@@ -719,9 +719,9 @@ class MyKeyring implements Keyring {
 
 #### `listAccounts`
 
-Lists the calling snap's accounts that are known to MetaMask.
-This method does not call back to the snap.
-Instead, the snap can use it to check whether there's a discrepancy between the snap's internal
+Lists the calling Snap's accounts that are known to MetaMask.
+This method does not call back to the Snap.
+Instead, the Snap can use it to check whether there's a discrepancy between the Snap's internal
 state of accounts and the state known to MetaMask.
 
 ##### Returns
@@ -738,7 +738,7 @@ class MyKeyring implements Keyring {
 
   async checkIfAccountsInSync(): Promise<boolean> {
 
-    const knownAccounts: KeyringAccount[] = /* grab accounts from snap state */;
+    const knownAccounts: KeyringAccount[] = /* grab accounts from Snap state */;
 
     const listedAccounts: KeyringAccount[] = await snap.request({
       method: 'snap_manageAccounts',
@@ -777,7 +777,7 @@ class MyKeyring implements Keyring {
   // ... other methods
 
   async approveRequest(id: string, result?: Json): Promise<void> {
-    // Do any snap-side logic to finish approving the request
+    // Do any Snap-side logic to finish approving the request
 
     await snap.request({
       method: 'snap_manageAccounts',
@@ -792,10 +792,10 @@ class MyKeyring implements Keyring {
 
 ### snap_manageState
 
-Allows the snap to persist up to 100 MB of data to disk and retrieve it at will.
-The data is automatically encrypted using a snap-specific key and automatically decrypted when retrieved.
+Allows the Snap to persist up to 100 MB of data to disk and retrieve it at will.
+The data is automatically encrypted using a Snap-specific key and automatically decrypted when retrieved.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Parameters
 
@@ -838,7 +838,7 @@ await snap.request({
 Displays a notification in MetaMask or natively in the browser.
 Snaps can trigger a short notification text for actionable or time sensitive information.
 
-This method is only callable by snaps.
+This method is only callable by Snaps.
 
 #### Parameters
 
@@ -867,35 +867,35 @@ await snap.request({
 
 A website must request the `wallet_snap` permission using
 [`wallet_requestPermissions`](/wallet/reference/rpc-api/#wallet_requestpermissions) to
-interact with the specified snaps.
+interact with the specified Snaps.
 
-A website can also call this method to invoke the specified JSON-RPC method of the specified snap.
+A website can also call this method to invoke the specified JSON-RPC method of the specified Snap.
 
 This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap).
 
 :::note
 Most websites only make one call to `wallet_requestPermissions`.
 Consecutive calls to `wallet_requestPermissions` for the `wallet_snap` permission overwrites a
-website's existing permissions to interact with snaps.
-To deal with this, you must write custom logic to merge existing snap IDs with new ones you're requesting.
-Use [`wallet_getSnaps`](#wallet_getsnaps) to get a list of a website's permitted snaps.
+website's existing permissions to interact with Snaps.
+To deal with this, you must write custom logic to merge existing Snap IDs with new ones you're requesting.
+Use [`wallet_getSnaps`](#wallet_getsnaps) to get a list of a website's permitted Snaps.
 :::
 
 #### Parameters
 
 When requesting this permission, specify a caveat of type `snapIds`.
-Specify each snap to request permission to interact with as an entry in the `value` field of the caveat.
-Each snap entry can include a `version` to install.
+Specify each Snap to request permission to interact with as an entry in the `value` field of the caveat.
+Each Snap entry can include a `version` to install.
 The default is the latest version.
 
 When calling this method, specify an object containing:
 
-- `snapId` - The ID of the snap to invoke.
-- `request` - The JSON-RPC request object to send to the invoked snap.
+- `snapId` - The ID of the Snap to invoke.
+- `request` - The JSON-RPC request object to send to the invoked Snap.
 
 #### Returns
 
-Result of the snap method call.
+Result of the Snap method call.
 
 #### Example
 
@@ -947,23 +947,23 @@ console.log(result); // In this example, the result is a boolean.
 
 ### wallet_invokeSnap
 
-Invokes the specified JSON-RPC method of the specified snap.
-The snap must be installed and the caller must have the permission to communicate with the snap, or
+Invokes the specified JSON-RPC method of the specified Snap.
+The Snap must be installed and the caller must have the permission to communicate with the Snap, or
 the request is rejected.
 
 Snaps are fully responsible for implementing their JSON-RPC API.
-Consult the snap's documentation for available methods, their parameters, and return values.
+Consult the Snap's documentation for available methods, their parameters, and return values.
 
 #### Parameters
 
 An object containing:
 
-- `snapId` - The ID of the snap to invoke.
-- `request` - The JSON-RPC request object to send to the invoked snap.
+- `snapId` - The ID of the Snap to invoke.
+- `request` - The JSON-RPC request object to send to the invoked Snap.
 
 #### Returns
 
-Result of the snap method call.
+Result of the Snap method call.
 
 #### Example
 

--- a/snaps/tutorials/custom-evm-accounts.md
+++ b/snaps/tutorials/custom-evm-accounts.md
@@ -1,12 +1,12 @@
 ---
-description: Create a Keyring snap to connect to custom EVM accounts in MetaMask.
+description: Create a Keyring Snap to connect to custom EVM accounts in MetaMask.
 sidebar_custom_props:
   flask_only: true
 ---
 
-# Create a snap to connect to custom EVM accounts
+# Create a Snap to connect to custom EVM accounts
 
-This tutorial walks you through creating a snap that uses the [Keyring API](../concepts/keyring-api.md)
+This tutorial walks you through creating a Snap that uses the [Keyring API](../concepts/keyring-api.md)
 to integrate custom EVM accounts in MetaMask.
 
 :::flaskOnly
@@ -14,7 +14,7 @@ to integrate custom EVM accounts in MetaMask.
 
 ## Prerequisites
 
-- A snap set up using the [Snaps quickstart](../get-started/quickstart.md)
+- A Snap set up using the [Snaps quickstart](../get-started/quickstart.md)
 - Business logic written for your custom EVM account type
 
 ## Steps
@@ -22,7 +22,7 @@ to integrate custom EVM accounts in MetaMask.
 ### 1. Add the snap_manageAccounts permission
 
 Request permission to call [`snap_manageAccounts`](../reference/rpc-api.md#snap_manageaccounts) by
-editing the `snap.manifest.json` file in your snap:
+editing the `snap.manifest.json` file in your Snap:
 
 ```json title="snap.manifest.json"
 {
@@ -36,7 +36,7 @@ editing the `snap.manifest.json` file in your snap:
 
 ### 2. Expose the Keyring interface as a JSON-RPC API
 
-Export the [`onRpcRequest`](../reference/exports.md#onrpcrequest) function from the snap to expose
+Export the [`onRpcRequest`](../reference/exports.md#onrpcrequest) function from the Snap to expose
 the [`Keyring`](../reference/keyring-api/type-aliases/Keyring.md)
 interface as a JSON-RPC API.
 
@@ -47,7 +47,7 @@ It responds to requests where the `method` is of type `keyring_*`, and throws a
 [`MethodNotSupportedError`](../reference/keyring-api/classes/MethodNotSupportedError.md)
 if it doesn't recognize the request method.
 
-Since your snap most likely wants to answer other JSON-RPC requests in addition to the `keyring_*` ones,
+Since your Snap most likely wants to answer other JSON-RPC requests in addition to the `keyring_*` ones,
 another helper called [`buildHandlersChain`](../reference/keyring-api/functions/buildHandlersChain.md)
 lets you chain multiple RPC handlers together.
 As each handler in the chain throws a
@@ -92,7 +92,7 @@ const keyringHandler: OnRpcRequestHandler = async ({ request }) => {
 };
 
 /**
- * Execute a custom snap request.
+ * Execute a custom Snap request.
  *
  * @param args - Request arguments.
  * @param args.request - Request to execute.
@@ -124,8 +124,8 @@ export const onRpcRequest: OnRpcRequestHandler = buildHandlersChain(
 
 ### 3. Use the Keyring API from a dapp
 
-As you build a companion dapp to provide a user interface for your Keyring snap, you'll need to
-interact with your snap's JSON-RPC API.
+As you build a companion dapp to provide a user interface for your Keyring Snap, you'll need to
+interact with your Snap's JSON-RPC API.
 While you could do this by making regular RPC calls using
 [`wallet_invokeSnap`](../reference/rpc-api.md#wallet_invokesnap), we recommend
 [using the Keyring API from your dapp](../how-to/use-keyring-api.md):

--- a/snaps/tutorials/gas-estimation.md
+++ b/snaps/tutorials/gas-estimation.md
@@ -1,12 +1,12 @@
 ---
-description: Create a snap that estimates gas fees.
+description: Create a Snap that estimates gas fees.
 sidebar_position: 1
 ---
 
-# Create a snap to estimate gas fees
+# Create a Snap to estimate gas fees
 
-This tutorial walks you through creating a snap that estimates gas fees.
-The snap uses the `fetch` API to request information from the internet, and displays custom
+This tutorial walks you through creating a Snap that estimates gas fees.
+The Snap uses the `fetch` API to request information from the internet, and displays custom
 information in an alert dialog.
 
 ## Prerequisites
@@ -19,7 +19,7 @@ information in an alert dialog.
 
 ### 1. Set up the project
 
-Create a new snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
+Create a new Snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
 
 ```bash
 yarn create @metamask/snap gas-estimation-snap
@@ -42,7 +42,7 @@ This initializes your development environment with the required dependencies.
 ### 2. Set a custom icon
 
 Open `/packages/snap/snap.manifest.json` in a text editor.
-This file contains the main configuration details for your snap.
+This file contains the main configuration details for your Snap.
 Edit the `npm` object (within the `location` object) and change the value for the `iconPath` key by giving the path `"images/gas.svg"` to your new icon:
 
 ```json title="snap.manifest.json"
@@ -62,7 +62,7 @@ This is a free icon, **Gas** by Mello from
 
 ### 3. Enable network access
 
-To enable your snap to use the `fetch` API, make a request for the
+To enable your Snap to use the `fetch` API, make a request for the
 [`endowment:network-access`](../reference/permissions.md#endowmentnetwork-access) permission by
 adding `"endowment:network-access": {}` to the `initialPermissions` object in `snap.manifest.json`:
 
@@ -82,7 +82,7 @@ adding `"endowment:network-access": {}` to the `initialPermissions` object in `s
 ### 4. Fetch gas fee estimates
 
 Open `/packages/snap/src/index.ts`.
-This is the main code file for your snap.
+This is the main code file for your Snap.
 To get a gas fee estimate, use the public API endpoint provided by
 [Open Source Ethereum Explorer](https://beaconcha.in/).
 Add the following `getFees()` function to the top of the file:
@@ -97,7 +97,7 @@ async function getFees() {
 }
 ```
 
-Next, modify the snap RPC message handler that displays the confirmation window.
+Next, modify the Snap RPC message handler that displays the confirmation window.
 This handler uses a switch statement to handle various request methods, but in this case there is
 only one method, `hello`.
 For this method, the handler returns a call to MetaMask with the parameters to display a
@@ -128,9 +128,9 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
 };
 ```
 
-### 5. Build and test the snap
+### 5. Build and test the Snap
 
-To build and test your snap:
+To build and test your Snap:
 
 1. Open `package.json` in the root directory of the project, and increase the `"version"` (if the `"version"` is
     `0.1.0`, increase it to `0.2.0`).
@@ -147,14 +147,14 @@ To build and test your snap:
 3. Open [`localhost:8000`](http://localhost:8000/) in your browser (with MetaMask Flask installed).
     A page like the following displays:
 
-    ![Test dapp with template snap](../assets/template-snap.png)
+    ![Test dapp with template Snap](../assets/template-snap.png)
 
-    This is a boilerplate test dapp for installing and testing your snap.
+    This is a boilerplate test dapp for installing and testing your Snap.
 
 4. Select **Connect** to connect Flask to the dapp.
-    After connecting, you're prompted to install the snap with the following permissions:
+    After connecting, you're prompted to install the Snap with the following permissions:
 
-    - **Allow websites to communicate directly with this snap.**
+    - **Allow websites to communicate directly with this Snap.**
     - **Access the internet.**
     - **Display dialog windows in MetaMask.**
 
@@ -178,16 +178,16 @@ Next, you can try:
 - Parsing the JSON response from the remote API.
 - Displaying the fees in a nicely formatted way.
 
-You can also update the fields in `snap.manifest.json` to match your custom snap:
+You can also update the fields in `snap.manifest.json` to match your custom Snap:
 
-- `proposedName` - The name of your snap.
-- `description` - The description of your snap.
+- `proposedName` - The name of your Snap.
+- `description` - The description of your Snap.
 - `repository` - The URL of your cloned GitHub repository.
 - `source` - The `shasum` is set automatically when you build from the command line.
-  If you decided to publish your snap to npm, update the `location` to its published location.
+  If you decided to publish your Snap to npm, update the `location` to its published location.
 
 Similarly, you should update the `name`, `version`, `description`, and `repository` sections of
-`/packages/snap/package.json` even if you do not plan to publish your snap to [`npm`](https://www.npmjs.com/).
+`/packages/snap/package.json` even if you do not plan to publish your Snap to [`npm`](https://www.npmjs.com/).
 
 :::tip
 The `version` field in `snap.manifest.json` inherits the `version` field from `package.json`.
@@ -199,4 +199,4 @@ If you change the method name, make sure to change the method name in `/packages
 to match.
 
 After you have made all necessary changes, you can
-[publish your snap to npm](../how-to/develop-a-snap.md#publish-your-snap).
+[publish your Snap to npm](../how-to/develop-a-snap.md#publish-your-snap).

--- a/snaps/tutorials/transaction-insights.md
+++ b/snaps/tutorials/transaction-insights.md
@@ -1,13 +1,13 @@
 ---
-description: Create a snap that provides transaction insights.
+description: Create a Snap that provides transaction insights.
 sidebar_position: 2
 ---
 
-# Create a snap to calculate gas fee percentages
+# Create a Snap to calculate gas fee percentages
 
-This tutorial walks you through creating a snap that calculates the percentage of gas fees that
+This tutorial walks you through creating a Snap that calculates the percentage of gas fees that
 a user would pay when creating a transaction.
-The snap provides transaction insights in the MetaMask transaction window.
+The Snap provides transaction insights in the MetaMask transaction window.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ The snap provides transaction insights in the MetaMask transaction window.
 
 ### 1. Set up the project
 
-Create a new snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
+Create a new Snap project using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap) by running:
 
 ```bash
 yarn create @metamask/snap transaction-insights-snap
@@ -49,17 +49,17 @@ This initializes your development environment with the required dependencies.
 
 ### 2. Enable transaction insights and the Ethereum provider
 
-The default template snap, such as the one in [Create a gas estimation snap](./gas-estimation.md#5-build-and-test-the-snap), is set up to expose a JSON-RPC API with a simple hello command, which brings up a
+The default template Snap, such as the one in [Create a gas estimation Snap](./gas-estimation.md#5-build-and-test-the-snap), is set up to expose a JSON-RPC API with a simple hello command, which brings up a
 dialog box.
-In contrast, the snap you're creating in this tutorial doesn't expose any API.
+In contrast, the Snap you're creating in this tutorial doesn't expose any API.
 Instead, it provides transaction insights directly in the MetaMask transaction window.
 
-In particular, the snap shows the user the percentage of gas fees they would pay for their transaction.
+In particular, the Snap shows the user the percentage of gas fees they would pay for their transaction.
 It gets the current gas price by calling the
 [`eth_gasPrice`](/wallet/reference/eth_gasPrice) RPC
-method using the global Ethereum provider made available to snaps.
+method using the global Ethereum provider made available to Snaps.
 
-To enable your snap to provide transaction insights and use the global Ethereum provider, open
+To enable your Snap to provide transaction insights and use the global Ethereum provider, open
 `/packages/snap/snap.manifest.json` in a text editor.
 Request the
 [`endowment:transaction-insight`](../reference/permissions.md#endowmenttransaction-insight) and
@@ -112,7 +112,7 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   // Display percentage of gas fees in the transaction insights UI.
   return {
     content: panel([
-      heading('Transaction insights snap'),
+      heading('Transaction insights Snap'),
       text(
         `As set up, you are paying **${gasFeesPercentage.toFixed(
           2,
@@ -123,14 +123,14 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
 };
 ```
 
-### 4. Build and test the snap
+### 4. Build and test the Snap
 
-To build and test your snap:
+To build and test your Snap:
 
 1. From the command line, run `yarn start` in the root of your project.
-    This starts two development servers: one for watching and compiling the snap, and another for the
+    This starts two development servers: one for watching and compiling the Snap, and another for the
     React site.
-    The snap bundle is served from `localhost:8080`, and the site is served from `localhost:8000`.
+    The Snap bundle is served from `localhost:8080`, and the site is served from `localhost:8000`.
     You should get a message that includes:
 
     ```bash
@@ -143,7 +143,7 @@ To build and test your snap:
 
 3. Select **Connect**, and accept the permission request.
 
-4. After connecting, you're prompted to install the snap with the **Fetch and display transaction
+4. After connecting, you're prompted to install the Snap with the **Fetch and display transaction
     insights** and **Access the Ethereum provider** permissions.
     Select **Approve & install**.
 
@@ -152,7 +152,7 @@ To build and test your snap:
 
 6. On the confirmation window, switch to the tab named **TYPESCRIPT EXAMPLE SNAP**.
     Switching to the tab activates the [`onTransaction`](../reference/exports.md#ontransaction)
-    export of your snap and displays the percentage of gas fees in the transaction insights UI:
+    export of your Snap and displays the percentage of gas fees in the transaction insights UI:
 
 <p align="center">
 
@@ -162,7 +162,7 @@ To build and test your snap:
 
 ### 5. Display a different UI for contract interactions
 
-The snap should only display a gas fee percentage if the user is doing a regular ETH transfer.
+The Snap should only display a gas fee percentage if the user is doing a regular ETH transfer.
 For contract interactions, it should display a UI that conveys that message.
 Add the following code to the beginning of the `onTransaction` export:
 
@@ -172,7 +172,7 @@ if (typeof transaction.data === 'string' && transaction.data !== '0x') {
     content: panel([
       heading('Percent Snap'),
       text(
-        'This snap only provides transaction insights for simple ETH transfers.',
+        'This Snap only provides transaction insights for simple ETH transfers.',
       ),
     ]),
   };
@@ -182,17 +182,17 @@ if (typeof transaction.data === 'string' && transaction.data !== '0x') {
 ### 6. Next steps
 
 The initial project has generic names in multiple places.
-You can update the fields in `snap.manifest.json` to match your custom snap:
+You can update the fields in `snap.manifest.json` to match your custom Snap:
 
-- `proposedName` - The name of your snap.
+- `proposedName` - The name of your Snap.
   This replaces **TYPESCRIPT EXAMPLE SNAP** in the transaction insights UI.
-- `description` - The description of your snap.
+- `description` - The description of your Snap.
 - `repository` - The URL of your cloned GitHub repository.
 - `source` - The `shasum` is set automatically when you build from the command line.
-  If you decided to publish your snap to npm, update the `location` to its published location.
+  If you decided to publish your Snap to npm, update the `location` to its published location.
 
 Similarly, you should update the `name`, `version`, `description`, and `repository` sections of
-`/packages/snap/package.json` even if you don't plan to publish your snap to npm.
+`/packages/snap/package.json` even if you don't plan to publish your Snap to npm.
 
 :::note
 The `version` field in `snap.manifest.json` inherits the `version` field from `package.json`.
@@ -202,4 +202,4 @@ Lastly, you can update the content of `/packages/site/src/pages/index.tsx`, such
 template **Send Hello** button.
 
 Once you've made all necessary changes, you can
-[publish your snap to npm](../how-to/develop-a-snap.md#publish-your-snap).
+[publish your Snap to npm](../how-to/develop-a-snap.md#publish-your-snap).

--- a/src/components/SnapsSection.tsx
+++ b/src/components/SnapsSection.tsx
@@ -6,7 +6,7 @@ const CardList: CardItem[] = [
     title: "🏁 Get started with Snaps",
     link: "/snaps/get-started/quickstart",
     description: (<>
-      Get started quickly by creating and customizing a simple snap, using the Snaps template built
+      Get started quickly by creating and customizing a simple Snap, using the Snaps template built
       with React and TypeScript.
     </>),
   },
@@ -14,15 +14,15 @@ const CardList: CardItem[] = [
     title: "⚙️ Snaps tutorials",
     link: "/snaps/tutorials",
     description: (<>
-      Follow the step-by-step tutorials to create snaps that estimate gas fees and provide
-      transaction insights with custom UI.
+      Follow the step-by-step tutorials to create Snaps that estimate gas fees, provide
+      transaction insights with custom UI, and more.
     </>),
   },
   {
     title: "🌐 Snaps JSON-RPC API",
     link: "/snaps/reference/rpc-api",
     description: (<>
-      Use the Snaps JSON-RPC API to modify the functionality of MetaMask and communicate between dapps and snaps.
+      Use the Snaps JSON-RPC API to modify the functionality of MetaMask and communicate between dapps and Snaps.
     </>),
   },
 ];
@@ -32,8 +32,8 @@ export default function SnapsSection(): JSX.Element {
     <section className="container margin-top--lg margin-bottom--lg">
       <h1>Extend the functionality of MetaMask using Snaps</h1>
       <p>
-        A snap is a JavaScript program run in an isolated environment that customizes the MetaMask
-        wallet experience. You can create a snap that adds new API methods, adds support for
+        A Snap is a JavaScript program run in an isolated environment that customizes the MetaMask
+        wallet experience. You can create a Snap that adds new API methods, adds support for
         different blockchain protocols, or modifies existing functionalities.
       </p>
       <div className="row">


### PR DESCRIPTION
Capitalize references to a Snap or Snaps across the docs. Fixes #946.