### PR TITLE
Remove communicationServerUrl option from React SDK example

### DIFF
--- a/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
@@ -65,7 +65,6 @@ root.render(
       logging:{
           developerMode: false,
         },
-        communicationServerUrl: process.env.REACT_APP_COMM_SERVER_URL,
         checkInstallationImmediately: false, // This will automatically connect to MetaMask on page load
         dappMetadata: {
           name: "Demo React App",


### PR DESCRIPTION
Remove unnecessary `communicationServerUrl` option from the React SDK example.