### PR TITLE
Add condensed build steps to readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To contribute changes:
 
     ```bash
     git clone https://github.com/MetaMask/metamask-docs.git
-    cd https://github.com/MetaMask/metamask-docs.git
+    cd metamask-docs
     ```
 
    > **Note**: If you don't have write access to this repository, you must [fork the
@@ -48,7 +48,7 @@ To contribute changes:
    >
    > ```bash
    > git clone https://github.com/<YOUR-USERNAME>/metamask-docs.git
-   > git cd https://github.com/<YOUR-USERNAME>/metamask-docs.git
+   > cd metamask-docs
    > git remote add upstream https://github.com/MetaMask/metamask-docs.git
    > ```
 

--- a/README.md
+++ b/README.md
@@ -5,4 +5,43 @@ The documentation site is hosted at [`docs.metamask.io`](https://docs.metamask.i
 built using [Docusaurus](https://docusaurus.io/), a static site generator purpose-built for
 technical documentation.
 
-Learn how to [contribute to the documentation](CONTRIBUTING.md).
+## Build locally
+
+Build the documentation site locally using the following steps.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) version 16+
+- [Yarn](https://yarnpkg.com/) version 3
+- [Git](https://git-scm.com/)
+
+### Steps
+
+1. Clone the repository.
+
+    ```bash
+    git clone https://github.com/MetaMask/metamask-docs.git
+    cd metamask-docs
+    ```
+   
+2. Initialize and update the [`keyring-api`](https://github.com/MetaMask/keyring-api) submodule.
+
+    ```bash
+    git submodule init && git submodule update
+    ```
+   
+3. Install dependencies.
+
+    ```bash
+    yarn install
+    ```
+   
+4. Start the development server.
+
+    ```bash
+    yarn start
+    ```
+   
+    Once the server starts, you can view the documentation at `http://localhost:3000`.
+
+For more information on contributing to the documentation, see the [full contribution guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
To allow doc contributors to get started quickly, add condensed build steps to readme and link to full contribution guide.