### PR TITLE
Update Broken Footer Link (wallet/how-to)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -405,7 +405,7 @@ const config = {
               },
               {
                 label: "How to guides",
-                to: "/wallet/category/how-to",
+                to: "/wallet/wallet/how-to",
               },
               {
                 label: "Concepts",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -405,7 +405,7 @@ const config = {
               },
               {
                 label: "How to guides",
-                to: "/wallet/wallet/how-to",
+                to: "/wallet/how-to",
               },
               {
                 label: "Concepts",


### PR DESCRIPTION
fix broken link in footer:

Should be: `https://docs.metamask.io/wallet/how-to/`
Currently: `https://docs.metamask.io/wallet/category/how-to/`