### PR TITLE
Update SDK example links

### DIFF
--- a/wallet/concepts/sdk/android.md
+++ b/wallet/concepts/sdk/android.md
@@ -6,13 +6,13 @@ sidebar_position: 2
 
 The Android version of [MetaMask SDK](index.md) enables your users to easily connect with their
 MetaMask Mobile wallet.
-The [architecture](#architecture-diagram) and [communication flow](#communication-flow-diagram) of
+The [architecture](#architecture) and [connection flow](#connection-flow) of
 the Android SDK differs from the other SDK platforms.
 
 :::tip Get started
 - Get started by [setting up the SDK in your Android dapp](../../how-to/connect/set-up-sdk/mobile/android.md).
-- See the [Android SDK example](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) for
-  advanced use cases.
+- See the [example Android dapp](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) in
+  the Android SDK GitHub repository for advanced use cases.
 :::
 
 ## Architecture

--- a/wallet/concepts/sdk/index.md
+++ b/wallet/concepts/sdk/index.md
@@ -52,8 +52,8 @@ to MetaMask Mobile using a QR code.
 
 :::tip Get started
 - Get started by [setting up the SDK in your web dapp](../../how-to/connect/set-up-sdk/javascript/index.md).
-- See the [JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-  for advanced use cases.
+- See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+  in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 # Mobile browser
@@ -71,8 +71,8 @@ This happens for all actions that need user approval.
 
 :::tip Get started
 - Get started by [setting up the SDK in your web dapp](../../how-to/connect/set-up-sdk/javascript/index.md).
-- See the [JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-  for advanced use cases.
+- See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+  in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 # iOS
@@ -90,7 +90,8 @@ This happens for all actions that need user approval.
 
 :::tip Get started
 - Get started by [setting up the SDK in your iOS dapp](../../how-to/connect/set-up-sdk/mobile/ios.md).
-- See the [iOS SDK example](https://github.com/MetaMask/metamask-ios-sdk) for advanced use cases.
+- See the [example iOS dapp](https://github.com/MetaMask/metamask-ios-sdk) in the iOS SDK GitHub
+  repository for advanced use cases.
 :::
 
 # Android
@@ -108,8 +109,8 @@ This happens for all actions that need user approval.
 
 :::tip Get started
 - Get started by [setting up the SDK in your Android dapp](../../how-to/connect/set-up-sdk/mobile/android.md).
-- See the [Android SDK example](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) and
-  [Android SDK architecture](android.md) for more information.
+- See the [example Android dapp](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) in
+  the Android SDK GitHub repository and the [Android SDK architecture](android.md) for more information.
 :::
 
 # Node.js
@@ -125,8 +126,8 @@ scan with their MetaMask Mobile app.
 
 :::tip Get started
 - Get started by [setting up the SDK in your Node.js dapp](../../how-to/connect/set-up-sdk/javascript/nodejs.md).
-- See the [Node.js SDK example](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
-for advanced use cases.
+- See the [example Node.js dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
+  in the Node.js SDK GitHub repository for advanced use cases.
 :::
 
 # Unity
@@ -144,7 +145,7 @@ It also supports deeplinking on mobile platforms, as demonstrated in the followi
 :::tip Get started
 - Get started by [setting up the SDK in your Unity game](../../how-to/connect/set-up-sdk/gaming/unity.md).
 - See the [Unity demo game with the SDK installed](https://assetstore.unity.com/packages/decentralization/demo-game-dragon-crasher-with-metamask-sdk-infura-and-truffle-249789)
-for advanced use cases.
+  for advanced use cases.
 :::
 
 <!--/tabs-->

--- a/wallet/how-to/connect/set-up-sdk/gaming/index.md
+++ b/wallet/how-to/connect/set-up-sdk/gaming/index.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Use MetaMask SDK with gaming dapps
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your gaming dapp to enable your users
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your gaming dapp to enable your users
 to easily connect with their MetaMask Mobile wallet.
 See the instructions for the following gaming platforms:
 

--- a/wallet/how-to/connect/set-up-sdk/gaming/unity.md
+++ b/wallet/how-to/connect/set-up-sdk/gaming/unity.md
@@ -7,7 +7,7 @@ import ReactPlayer from 'react-player/lazy'
 
 # Use MetaMask SDK with Unity
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your
 [Unity](https://assetstore.unity.com/packages/decentralization/infrastructure/metamask-246786) game
 to enable users to easily connect to their MetaMask Mobile wallet.
 The MetaMask Unity SDK supports macOS, Windows, Linux, iOS, Android, and WebGL.

--- a/wallet/how-to/connect/set-up-sdk/javascript/electron.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/electron.md
@@ -5,13 +5,13 @@ sidebar_position: 6
 
 # Use MetaMask SDK with Electron
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your Electron dapp to enable your users
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your Electron dapp to enable your users
 to easily connect to the MetaMask browser extension and MetaMask Mobile.
 
 On the frontend, see the instructions to [use the SDK with React](react/index.md).
 On the backend, see the instructions to [use the SDK with Node.js](nodejs.md).
 
 :::tip example
-See the [Electron SDK example](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/electronjs)
-for advanced use cases.
+See the [example Electron dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/electronjs)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::

--- a/wallet/how-to/connect/set-up-sdk/javascript/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/index.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Use MetaMask SDK with JavaScript
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your JavaScript dapp to enable your
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your JavaScript dapp to enable your
 users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The following instructions work for web dapps based on standard JavaScript.
 You can also see instructions for the following JavaScript-based platforms:
@@ -17,6 +17,11 @@ You can also see instructions for the following JavaScript-based platforms:
 - [React Native](react-native.md)
 - [Node.js](nodejs.md)
 - [Electron](electron.md)
+
+:::tip Examples
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for advanced use cases.
+:::
 
 ## Prerequisites
 

--- a/wallet/how-to/connect/set-up-sdk/javascript/nodejs.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/nodejs.md
@@ -5,13 +5,13 @@ sidebar_position: 5
 
 # Use MetaMask SDK with Node.js
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your Node.js dapp to enable your users
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your Node.js dapp to enable your users
 to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for Node.js has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
-:::tip example
-See the [Node.js SDK example](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
-for advanced use cases.
+:::tip Example
+See the [example Node.js dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Steps

--- a/wallet/how-to/connect/set-up-sdk/javascript/other-web-frameworks.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/other-web-frameworks.md
@@ -5,14 +5,14 @@ sidebar_position: 3
 
 # Use MetaMask SDK with other web frameworks
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your web dapp to enable your users to
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your web dapp to enable your users to
 easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for other web frameworks has the [same prerequisites](index.md#prerequisites) as for
 standard JavaScript.
 
 :::tip Examples
-See the [MetaMask JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-for advanced use cases.
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Steps

--- a/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
@@ -5,13 +5,13 @@ sidebar_position: 2
 
 # Use MetaMask SDK with pure JavaScript
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your pure JavaScript dapp to enable
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your pure JavaScript dapp to enable
 your users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for pure JavaScript has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
-:::tip example
-See the [pure JavaScript SDK example](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/pure-javascript)
-for advanced use cases.
+:::tip Example
+See the [example pure JavaScript dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/pure-javascript)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 To import, instantiate, and use the SDK, you can insert a script in the head section of your website:

--- a/wallet/how-to/connect/set-up-sdk/javascript/react-native.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react-native.md
@@ -5,12 +5,12 @@ sidebar_position: 4
 
 # Use MetaMask SDK with React Native
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your React Native dapp to enable your
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your React Native dapp to enable your
 users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 
-:::tip example
-See the [React Native SDK example](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/reactNativeDemo)
-for advanced use cases.
+:::tip Example
+See the [example React Native dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/reactNativeDemo)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Prerequisites

--- a/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Use MetaMask SDK with React
 
-You can import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your users to
+Import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your users to
 easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for React has the [same prerequisites](../index.md#prerequisites) as for standard JavaScript.
 
@@ -16,8 +16,8 @@ Alternatively, you can use the [`@metamask/sdk-react-ui`](react-ui.md) package t
 :::
 
 :::tip Examples
-See the [MetaMask JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-for advanced use cases.
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Steps

--- a/wallet/how-to/connect/set-up-sdk/javascript/react/react-ui.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react/react-ui.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Use MetaMask SDK with React UI
 
-You can import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your
+Import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your
 users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The `@metamask/sdk-react-ui` package not only exports hooks from [`@metamask/sdk-react`](index.md),
 but also provides wrappers around [wagmi](https://wagmi.sh/) hooks and a basic UI button component
@@ -18,8 +18,8 @@ into your React dapp.
 The SDK for React has the [same prerequisites](../index.md#prerequisites) as for standard JavaScript.
 
 :::tip Examples
-See the [MetaMask JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-for advanced use cases.
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Steps

--- a/wallet/how-to/connect/set-up-sdk/mobile/android.md
+++ b/wallet/how-to/connect/set-up-sdk/mobile/android.md
@@ -6,12 +6,12 @@ toc_max_heading_level: 4
 
 # Use MetaMask SDK with Android
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native Android dapp to enable
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native Android dapp to enable
 your users to easily connect with their MetaMask Mobile wallet.
 
 :::tip Learn more
-- See the [example Android dapp source code](https://github.com/MetaMask/metamask-android-sdk/tree/main/app)
-for examples on how to use the SDK to make Ethereum requests.
+- See the [example Android dapp](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) in
+  the Android SDK GitHub repository for advanced use cases.
 - See more information about the [Android SDK architecture](../../../../concepts/sdk/android.md).
 :::
 

--- a/wallet/how-to/connect/set-up-sdk/mobile/index.md
+++ b/wallet/how-to/connect/set-up-sdk/mobile/index.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Use MetaMask SDK with mobile dapps
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your mobile dapp to enable your users
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your mobile dapp to enable your users
 to easily connect with their MetaMask Mobile wallet.
 See the instructions for the following mobile platforms:
 

--- a/wallet/how-to/connect/set-up-sdk/mobile/ios.md
+++ b/wallet/how-to/connect/set-up-sdk/mobile/ios.md
@@ -6,11 +6,12 @@ toc_max_heading_level: 4
 
 # Use MetaMask SDK with iOS
 
-You can import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native iOS dapp to enable your
+Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native iOS dapp to enable your
 users to easily connect with their MetaMask Mobile wallet.
 
-:::tip example
-See the [iOS SDK example](https://github.com/MetaMask/metamask-ios-sdk) for advanced use cases.
+:::tip Example
+See the [example iOS dapp](https://github.com/MetaMask/metamask-ios-sdk) in the iOS SDK GitHub
+repository for advanced use cases.
 :::
 
 ## Prerequisites


### PR DESCRIPTION
Update links to example dapps / GH repo across the SDK pages. See the subsections in the [Set up SDK section](https://docs.metamask.io/update-gh-links/wallet/how-to/connect/set-up-sdk/).