### PR TITLE
Document Web3-Onboard integration

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -101,6 +101,7 @@ h4 {
   grid-auto-rows: auto;
   grid-gap: 2rem;
   padding: 1rem 0rem 3rem;
+  margin-bottom: -15px;
 }
 
 .card {

--- a/wallet/concepts/convenience-libraries.md
+++ b/wallet/concepts/convenience-libraries.md
@@ -23,6 +23,8 @@ connection from your dapp to the MetaMask wallet.
 It onboards users smoothly from multiple dapp platforms using the MetaMask browser extension or
 MetaMask Mobile, and your dapp can call any [provider API method](../reference/provider-api.md)
 with the SDK installed.
-
 Get started by [setting up the SDK](../how-to/connect/set-up-sdk/index.md).
 :::
+
+You can also [use Web3-Onboard with MetaMask SDK](../how-to/use-3rd-party-integrations/web3-onboard.md)
+in your JavaScript dapp.

--- a/wallet/concepts/sdk/index.md
+++ b/wallet/concepts/sdk/index.md
@@ -31,7 +31,7 @@ With MetaMask SDK, there are more ways to connect:
 
 MetaMask SDK enables your dapp to provide a seamless user experience for MetaMask users, from
 multiple dapp platforms, without relying on third-party libraries.
-Moreover, it uses the [Ethereum provider](../apis.md#ethereum-provider-api) that developers are
+Moreover, the SDK uses the [Ethereum provider](../apis.md#ethereum-provider-api) that developers are
 already used to, so existing dapps work out of the box with the SDK.
 
 ## User experience

--- a/wallet/concepts/sdk/index.md
+++ b/wallet/concepts/sdk/index.md
@@ -31,6 +31,8 @@ With MetaMask SDK, there are more ways to connect:
 
 MetaMask SDK enables your dapp to provide a seamless user experience for MetaMask users, from
 multiple dapp platforms, without relying on third-party libraries.
+Moreover, it uses the [Ethereum provider](../apis.md#ethereum-provider-api) that developers are
+already used to, so existing dapps work out of the box with the SDK.
 
 ## User experience
 

--- a/wallet/how-to/connect/set-up-sdk/index.md
+++ b/wallet/how-to/connect/set-up-sdk/index.md
@@ -50,11 +50,11 @@ It supports the following dapp platforms:
 </div>
 <div class="card margin-bottom--lg">
   <div class="card__header">
-    <h3>↔️ <a href="gaming">Third-party integrations</a></h3>
+    <h3>↔️ <a href="../../use-3rd-party-integrations">Third-party integrations</a></h3>
   </div>
   <div class="card__body">
     <ul>
-      <li><a href="gaming/unity">Web3-Onboard</a></li>
+      <li><a href="../../use-3rd-party-integrations/web3-onboard">Web3-Onboard</a></li>
       <li>Wagmi (coming soon)</li>
     </ul>
   </div>

--- a/wallet/how-to/connect/set-up-sdk/index.md
+++ b/wallet/how-to/connect/set-up-sdk/index.md
@@ -48,8 +48,14 @@ It supports the following dapp platforms:
     </div>
   </div>
 </div>
-
-:::note
-MetaMask SDK uses the [Ethereum provider](../../../reference/provider-api.md) that developers are
-already used to, so existing dapps work out of the box with the SDK.
-:::
+<div class="card margin-bottom--lg">
+  <div class="card__header">
+    <h3>↔️ <a href="gaming">Third-party integrations</a></h3>
+  </div>
+  <div class="card__body">
+    <ul>
+      <li><a href="gaming/unity">Web3-Onboard</a></li>
+      <li>Wagmi (coming soon)</li>
+    </ul>
+  </div>
+</div>

--- a/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
+++ b/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 description: Use Infura and custom nodes to make direct, read-only requests.
 ---
 
-# Make read-only requests from JavaScript dapps
+# Make read-only requests in JavaScript
 
 You can use the [Infura API](https://docs.infura.io/) from your JavaScript dapp with
 [MetaMask SDK](../connect/set-up-sdk/javascript/index.md) installed to make direct, read-only

--- a/wallet/how-to/use-3rd-party-integrations/unity-dweb.md
+++ b/wallet/how-to/use-3rd-party-integrations/unity-dweb.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 description: Integrate Decentraweb into your Unity game to enable human-readable addresses.
 ---
 

--- a/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
+++ b/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
@@ -72,5 +72,5 @@ console.log(connectedWallets)
 For an example of using Web3-Onboard with MetaMask SDK, see the
 [example dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/with-web3onboard)
 in the JavaScript SDK GitHub repository.
-In particular, see the [`App.tsx`](https://github.com/MetaMask/metamask-sdk/blob/main/packages/examples/with-web3onboard/src/App.tsx)
+See the [`App.tsx`](https://github.com/MetaMask/metamask-sdk/blob/main/packages/examples/with-web3onboard/src/App.tsx)
 file for more details on implementing the integration in a React dapp.

--- a/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
+++ b/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
@@ -36,7 +36,7 @@ In your project script, add the following to import the module:
 import metamaskSDK from '@web3-onboard/metamask'
 ```
 
-### 2. Instantiate the module
+### 3. Instantiate the module
 
 Instantiate the module using any [JavaScript SDK options](../../reference/sdk-js-options.md), for
 example, [`dappMetadata`](../../reference/sdk-js-options.md#dappmetadata):
@@ -50,7 +50,7 @@ const metamaskSDKWallet = metamaskSDK({options: {
 }})
 ```
 
-### 3. Use the module
+### 4. Use the module
 
 Use the module as follows:
 

--- a/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
+++ b/wallet/how-to/use-3rd-party-integrations/web3-onboard.md
@@ -1,0 +1,76 @@
+---
+description: Integrate the MetaMask JavaScript SDK with Web3-Onboard.
+sidebar_position: 1
+---
+
+# Use Web3-Onboard with MetaMask SDK
+
+[Web3-Onboard](https://onboard.blocknative.com/) is a JavaScript library that simplifies the process
+of onboarding users into dapps.
+It provides a smooth user interface, a variety of wallet integrations, and is highly customizable to
+meet the needs of your dapp.
+
+You can integrate [MetaMask SDK](../../concepts/sdk/index.md) into your dapp alongside Web3-Onboard,
+using the Web3-Onboard MetaMask module, to enable your users to easily connect to the MetaMask
+browser extension and MetaMask Mobile.
+
+## Prerequisites
+
+A project set up with [Web3-Onboard](https://onboard.blocknative.com/docs/getting-started/installation).
+
+## Steps
+
+### 1. Install the module
+
+Install the Web3-Onboard MetaMask module into your dapp:
+
+```bash
+npm i @web3-onboard/metamask
+```
+
+### 2. Import the module
+
+In your project script, add the following to import the module:
+
+```javascript
+import metamaskSDK from '@web3-onboard/metamask'
+```
+
+### 2. Instantiate the module
+
+Instantiate the module using any [JavaScript SDK options](../../reference/sdk-js-options.md), for
+example, [`dappMetadata`](../../reference/sdk-js-options.md#dappmetadata):
+
+```javascript
+const metamaskSDKWallet = metamaskSDK({options: {
+  extensionOnly: false,
+  dappMetadata: {
+    name: 'Demo Web3Onboard'
+  }
+}})
+```
+
+### 3. Use the module
+
+Use the module as follows:
+
+```javascript
+const onboard = Onboard({
+  // Other Onboard options
+  wallets: [
+    metamaskSDKWallet
+    // Other wallets
+  ]
+})
+
+const connectedWallets = await onboard.connectWallet()
+console.log(connectedWallets)
+```
+
+## Example
+
+For an example of using Web3-Onboard with MetaMask SDK, see the
+[example dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/with-web3onboard)
+in the JavaScript SDK GitHub repository.
+In particular, see the [`App.tsx`](https://github.com/MetaMask/metamask-sdk/blob/main/packages/examples/with-web3onboard/src/App.tsx)
+file for more details on implementing the integration in a React dapp.


### PR DESCRIPTION
Add page for Web3-Onboard JS SDK integration. Minor updates to related content.
Preview: https://docs.metamask.io/sdk-web3onboard/wallet/how-to/use-3rd-party-integrations/web3-onboard/

Also add card to main SDK page for third-party integrations.
Preview: https://docs.metamask.io/sdk-web3onboard/wallet/how-to/connect/set-up-sdk/