### PR TITLE
Reference Infura API key allowlists

### DIFF
--- a/wallet/how-to/access-provider.md
+++ b/wallet/how-to/access-provider.md
@@ -1,6 +1,6 @@
 ---
 description: Access a user's MetaMask provider using metamask-extension-provider.
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Access a user's MetaMask provider

--- a/wallet/how-to/add-network.md
+++ b/wallet/how-to/add-network.md
@@ -1,6 +1,6 @@
 ---
 description: Prompt a user to add or switch to an Ethereum network.
-sidebar_position: 6
+sidebar_position: 8
 ---
 
 # Add a network

--- a/wallet/how-to/discover-multiple-wallets.md
+++ b/wallet/how-to/discover-multiple-wallets.md
@@ -1,6 +1,6 @@
 ---
 description: Use an alternative discovery mechanism for multiple wallets.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Discover multiple wallets

--- a/wallet/how-to/request-permissions.md
+++ b/wallet/how-to/request-permissions.md
@@ -1,6 +1,6 @@
 ---
 description: Request permissions to call restricted methods.
-sidebar_position: 7
+sidebar_position: 9
 ---
 
 # Request permissions

--- a/wallet/how-to/use-3rd-party-integrations/_category_.json
+++ b/wallet/how-to/use-3rd-party-integrations/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Use third party integrations",
-  "position": 11,
+  "position": 7,
   "link": {
     "type": "generated-index",
     "slug": "how-to/use-3rd-party-integrations",

--- a/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
+++ b/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
@@ -36,8 +36,20 @@ Configure your dapp to make read-only requests using the [Infura API](#use-the-i
 - An Infura API key.
   Create one by following the first two steps in the
   [Infura getting started guide](https://docs.infura.io/getting-started).
+
 - [An allowlist configured for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
-  If you don't protect your API key using an allowlist, all requests to your API key are accepted.
+
+  :::caution important
+  Your API key, when used with the SDK, is vulnerable to exposure.
+  If someone inspects your dapp's code, they can potentially retrieve your API key and submit
+  requests to Infura, impersonating your account.
+  
+  Use [allowlists](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+  to protect against this vulnerability.
+  You can restrict interactions with your API key to specific addresses, origins, user agents, and request methods.
+  We recommend using all allowlist options to maximize the security of your API key and dapp.
+  :::
+
 - [MetaMask SDK set up](../connect/set-up-sdk/javascript/index.md) in your JavaScript dapp.
 
 ## Use the Infura API

--- a/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
+++ b/wallet/how-to/use-3rd-party-integrations/js-infura-api.md
@@ -14,7 +14,7 @@ Your dapp can directly call most [JSON-RPC API methods](/wallet/reference/json-r
 user wallet authentication for read-only operations.
 
 :::note
-Your dapp CANNOT directly call the following RPC methods, which require user wallet interaction:
+Your dapp cannot directly call the following RPC methods, which require user wallet interaction:
 
 - `eth_requestAccounts`
 - `eth_sendTransaction`
@@ -36,6 +36,8 @@ Configure your dapp to make read-only requests using the [Infura API](#use-the-i
 - An Infura API key.
   Create one by following the first two steps in the
   [Infura getting started guide](https://docs.infura.io/getting-started).
+- [An allowlist configured for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+  If you don't protect your API key using an allowlist, all requests to your API key are accepted.
 - [MetaMask SDK set up](../connect/set-up-sdk/javascript/index.md) in your JavaScript dapp.
 
 ## Use the Infura API

--- a/wallet/how-to/use-3rd-party-integrations/unity-infura.md
+++ b/wallet/how-to/use-3rd-party-integrations/unity-infura.md
@@ -13,6 +13,8 @@ your Unity game.
 - An Infura API key.
   Create one by following the first two steps in the
   [Infura getting started guide](https://docs.infura.io/getting-started).
+- [An allowlist configured for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+  If you don't protect your API key using an allowlist, all requests to your API key are accepted.
 - [MetaMask SDK set up](../connect/set-up-sdk/gaming/unity.md) in your Unity game.
 
 ## Steps

--- a/wallet/how-to/use-3rd-party-integrations/unity-infura.md
+++ b/wallet/how-to/use-3rd-party-integrations/unity-infura.md
@@ -13,8 +13,20 @@ your Unity game.
 - An Infura API key.
   Create one by following the first two steps in the
   [Infura getting started guide](https://docs.infura.io/getting-started).
+
 - [An allowlist configured for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
-  If you don't protect your API key using an allowlist, all requests to your API key are accepted.
+
+  :::caution important
+  Your API key, when used with the SDK, is vulnerable to exposure.
+  If someone inspects your dapp's code, they can potentially retrieve your API key and submit
+  requests to Infura, impersonating your account.
+
+  Use [allowlists](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+  to protect against this vulnerability.
+  You can restrict interactions with your API key to specific addresses, origins, user agents, and request methods.
+  We recommend using all allowlist options to maximize the security of your API key and dapp.
+  :::
+
 - [MetaMask SDK set up](../connect/set-up-sdk/gaming/unity.md) in your Unity game.
 
 ## Steps

--- a/wallet/reference/sdk-js-options.md
+++ b/wallet/reference/sdk-js-options.md
@@ -222,13 +222,11 @@ The [Infura API key](https://docs.infura.io/networks/ethereum/how-to/secure-a-pr
 use for RPC requests.
 Configure this option to [make read-only RPC requests from your dapp](../how-to/use-3rd-party-integrations/js-infura-api.md).
 
-Make sure to [configure an allowlist for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
-If you don't protect your API key using an allowlist, all requests to your API key are accepted.
-
-:::tip
-To prevent committing your Infura API key, we recommend adding your key to a
-[`.env` file](https://docs.infura.io/tutorials/developer-tools/javascript-dotenv) and using the
-`process.env` global variable when specifying this option.
+:::caution important
+Use [Infura allowlists](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+to protect against other people submitting requests to your API key.
+You can restrict interactions to specific addresses, origins, user agents, and request methods.
+We recommend using all allowlist options to maximize the security of your API key and dapp.
 :::
 
 ### modals

--- a/wallet/reference/sdk-js-options.md
+++ b/wallet/reference/sdk-js-options.md
@@ -222,6 +222,9 @@ The [Infura API key](https://docs.infura.io/networks/ethereum/how-to/secure-a-pr
 use for RPC requests.
 Configure this option to [make read-only RPC requests from your dapp](../how-to/use-3rd-party-integrations/js-infura-api.md).
 
+Make sure to [configure an allowlist for your API key.](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
+If you don't protect your API key using an allowlist, all requests to your API key are accepted.
+
 :::tip
 To prevent committing your Infura API key, we recommend adding your key to a
 [`.env` file](https://docs.infura.io/tutorials/developer-tools/javascript-dotenv) and using the


### PR DESCRIPTION
Add prerequisite to protect your Infura API key using allowlists when configuring an API key with JS and Unity SDKs. Also move "third party integrations" section higher up in the sidebar. Fixes #1021.

Previews:
- https://docs.metamask.io/1021-infura-allowlists/wallet/how-to/use-3rd-party-integrations/js-infura-api/
- https://docs.metamask.io/1021-infura-allowlists/wallet/how-to/use-3rd-party-integrations/unity-infura/
- https://docs.metamask.io/1021-infura-allowlists/wallet/reference/sdk-js-options/#infuraapikey