### PR TITLE
Improve docs around wallet permissions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -347,6 +347,10 @@ const config = {
             from: "/wallet/reference/rpc-api",
             to: "/wallet/reference/json-rpc-api",
           },
+          {
+            from: "/wallet/how-to/request-permissions",
+            to: "/wallet/how-to/manage-permissions",
+          },
         ].reduce((acc, item) => {
           acc.push(item);
           acc.push({ from: item.from + ".html", to: item.to });

--- a/wallet/how-to/connect/access-accounts.md
+++ b/wallet/how-to/connect/access-accounts.md
@@ -7,9 +7,15 @@ sidebar_position: 4
 
 User accounts are used in a variety of contexts in Ethereum, including as identifiers and for
 [signing transactions](../sign-data/index.md).
-To request a signature from a user or have a user approve a transaction, your dapp must
+To request a signature from a user or have a user approve a transaction, your dapp can
 access the user's accounts using the
 [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) RPC method.
+
+:::info note
+`eth_requestAccounts` internally calls [`wallet_requestPermissions`](/wallet/reference/wallet_requestPermissions)
+to [request permission](../manage-permissions.md) to call the restricted
+[`eth_accounts`](/wallet/reference/eth_accounts) method.
+:::
 
 When accessing a user's accounts:
 
@@ -118,3 +124,11 @@ function handleAccountsChanged(accounts) {
 Previously, `eth_accounts` returned at most one account in the `accounts` array.
 The first account in the array will always be considered the user's "selected" account.
 :::
+
+## Revoke access to a user's accounts
+
+Since `eth_requestAccounts` internally calls `wallet_requestPermissions` for permission to call
+`eth_accounts`, you can use [`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions)
+to revoke this permission, revoking your dapp's access to the user's accounts.
+
+See [how to revoke permissions](../manage-permissions.md#revoke-permissions-example) for an example.

--- a/wallet/how-to/connect/access-accounts.md
+++ b/wallet/how-to/connect/access-accounts.md
@@ -125,10 +125,14 @@ Previously, `eth_accounts` returned at most one account in the `accounts` array.
 The first account in the array will always be considered the user's "selected" account.
 :::
 
-## Revoke access to a user's accounts
+## Disconnect a user's accounts
 
 Since `eth_requestAccounts` internally calls `wallet_requestPermissions` for permission to call
 `eth_accounts`, you can use [`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions)
 to revoke this permission, revoking your dapp's access to the user's accounts.
+
+This is useful as a method for users to log out (or disconnect) from your dapp.
+You can then use [`wallet_getPermissions`](/wallet/reference/wallet_getPermissions) to determine
+whether the user is connected or disconnected to your dapp.
 
 See [how to revoke permissions](../manage-permissions.md#revoke-permissions-example) for an example.

--- a/wallet/how-to/manage-permissions.md
+++ b/wallet/how-to/manage-permissions.md
@@ -7,8 +7,9 @@ sidebar_position: 7
 
 To call a restricted RPC method, your dapp must request permission from the user using
 the [`wallet_requestPermissions`](/wallet/reference/wallet_requestPermissions) RPC method.
-You can revoke previously granted permissions using the
-[`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions) RPC method.
+You can get the user's current permissions using [`wallet_getPermissions`](/wallet/reference/wallet_getPermissions),
+and revoke permissions previously granted to your dapp using
+[`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions).
 These methods are specified by [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255) and
 [MIP-2](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-2.md).
 

--- a/wallet/how-to/manage-permissions.md
+++ b/wallet/how-to/manage-permissions.md
@@ -28,16 +28,16 @@ the [`eth_accounts`](/wallet/reference/eth_accounts) restricted method:
     </div>
 </div>
 
-:::info Accessing accounts
-We recommend using [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts), which
-internally calls `wallet_requestPermissions` for permission to call `eth_accounts`.
+:::info note
+To access accounts, we recommend using [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts),
+which automatically asks for permission to use `eth_accounts` by calling `wallet_requestPermissions`
+internally.
 See [how to access a user's accounts](connect/access-accounts.md) for more information.
 :::
 
 ## Request permissions example
 
-The following is an example of using `wallet_requestPermissions` to request permission from the user
-to call `eth_accounts`.
+The following example uses `wallet_requestPermissions` to request permission from the user to call `eth_accounts`:
 
 ```javascript
 document.getElementById('requestPermissionsButton', requestPermissions);
@@ -69,8 +69,7 @@ function requestPermissions() {
 
 ## Revoke permissions example
 
-The following is an example of using `wallet_revokePermissions` to revoke the dapp's permission to
-call `eth_accounts`:
+The following example uses `wallet_revokePermissions` to revoke the dapp's permission to call `eth_accounts`:
 
 ```javascript
 await window.ethereum.request({

--- a/wallet/how-to/manage-permissions.md
+++ b/wallet/how-to/manage-permissions.md
@@ -1,13 +1,16 @@
 ---
-description: Request permissions to call restricted methods.
+description: Request and revoke permissions to call restricted methods.
 sidebar_position: 7
 ---
 
-# Request permissions
+# Manage permissions
 
-To call a restricted RPC method, your dapp must request permission from the user to call it using
+To call a restricted RPC method, your dapp must request permission from the user using
 the [`wallet_requestPermissions`](/wallet/reference/wallet_requestPermissions) RPC method.
-This method is specified by [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
+You can revoke previously granted permissions using the
+[`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions) RPC method.
+These methods are specified by [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255) and
+[MIP-2](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-2.md).
 
 `wallet_requestPermissions` creates a confirmation asking the user to connect to an account and
 allow the dapp to call the requested method.
@@ -15,7 +18,7 @@ The confirmation screen describes the functions and data the requested method ca
 For example, something like the following confirmation displays when you request permission to call
 the [`eth_accounts`](/wallet/reference/eth_accounts) restricted method:
 
-<div class="row">
+<div class="row margin-bottom--md">
     <div class="column">
         <img src={require("../assets/request-permissions.png").default} alt="Request permissions confirmation 1" style={{border: '1px solid black'}} />
     </div>
@@ -24,7 +27,13 @@ the [`eth_accounts`](/wallet/reference/eth_accounts) restricted method:
     </div>
 </div>
 
-## Example
+:::info Accessing accounts
+We recommend using [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts), which
+internally calls `wallet_requestPermissions` for permission to call `eth_accounts`.
+See [how to access a user's accounts](connect/access-accounts.md) for more information.
+:::
+
+## Request permissions example
 
 The following is an example of using `wallet_requestPermissions` to request permission from the user
 to call `eth_accounts`.
@@ -55,4 +64,20 @@ function requestPermissions() {
       }
     });
 }
+```
+
+## Revoke permissions example
+
+The following is an example of using `wallet_revokePermissions` to revoke the dapp's permission to
+call `eth_accounts`:
+
+```javascript
+await window.ethereum.request({
+  "method": "wallet_revokePermissions",
+  "params": [
+    {
+      "eth_accounts": {}
+    }
+  ]
+});
 ```


### PR DESCRIPTION
- Update "request permissions" page to "manage permissions" and include info on `wallet_revokePermissions`. Link to accessing accounts page.
- Update accessing accounts page to reference permissioning.

Previews:
- https://docs.metamask.io/1020-revokepermissions/wallet/how-to/manage-permissions/
- https://docs.metamask.io/1020-revokepermissions/wallet/how-to/connect/access-accounts/

Fixes #1020 