### PR TITLE
Add remote content plugin for Gas API

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -475,10 +475,11 @@ const config = {
             to: "/wallet/how-to/connect/set-up-sdk",
             label: "SDK",
           },
-          {
-            to: "web3-services",
-            label: "Web3 services",
-          },
+          ... INFURA_DOCS_PAGES.length > 0 ?
+            [{
+              to: "web3-services",
+              label: "Web3 services",
+            }] : [],
           {
             to: "snaps",
             label: "Snaps",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,6 +6,71 @@ const remarkCodesandbox = require("remark-codesandbox");
 const path = require("path");
 const isProd = process.env.NODE_ENV === 'production';
 
+const DOCS_REPO_SRC = "https://raw.githubusercontent.com/INFURA/docs/main/docs";
+
+const INFURA_DOCS_PAGES = [
+  // {
+  //   name: "network-endpoints",
+  //   token: "GHSAT0AAAAAACFCLQUUDH4GNNQJTIKNUUPCZL2O3SA",
+  // },
+];
+
+const generateRemoteContent = (pages = []) => {
+  if (pages.length === 0) return [];
+  const contentItems = pages.map((item, i) => (
+    [
+      "docusaurus-plugin-remote-content",
+      {
+        name: item.name,
+        id: `${i}`,
+        sourceBaseUrl: DOCS_REPO_SRC,
+        outDir: "web3-services",
+        documents: [`${item.name}.md`],
+        requestConfig: {
+          headers: {
+            "header": item.name,
+          },
+          params: {
+            token: item.token,
+          },
+          responseType: "arraybuffer",
+        },
+      },
+    ]
+  ));
+  contentItems.push([
+    "@docusaurus/plugin-content-docs",
+    ({
+      id: "web3-services",
+      path: "web3-services",
+      routeBasePath: "web3-services",
+      editUrl: "https://github.com/MetaMask/metamask-docs/edit/main/",
+      breadcrumbs: false,
+      remarkPlugins: [
+        require("remark-docusaurus-tabs"),
+      ],
+      admonitions: {
+        tag: ":::",
+        keywords: [
+          "info",
+          "success",
+          "danger",
+          "note",
+          "tip",
+          "warning",
+          "important",
+          "caution",
+          "security",
+          "flaskOnly",
+        ],
+      },
+    }),
+  ]);
+  return contentItems;
+};
+
+const INT_INFURA_PAGES = generateRemoteContent(INFURA_DOCS_PAGES);
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "MetaMask developer documentation",
@@ -37,6 +102,10 @@ const config = {
     { src: "/js/feedback-script.js", defer: true, async: true },
     { src: "/js/getfeedback.js", defer: true, async: true },
   ],
+  clientModules: ["/js/update-links.js"],
+  customFields: {
+    infuraRemotePages: INFURA_DOCS_PAGES,
+  },
 
   markdown: {
     mermaid: true,
@@ -375,6 +444,7 @@ const config = {
         },
       },
     ],
+    ...INT_INFURA_PAGES,
     isProd ? 
     [
       "docusaurus-plugin-segment",
@@ -404,6 +474,10 @@ const config = {
           {
             to: "/wallet/how-to/connect/set-up-sdk",
             label: "SDK",
+          },
+          {
+            to: "web3-services",
+            label: "Web3 services",
           },
           {
             to: "snaps",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@metamask/design-tokens": "^1.11.1",
     "@metamask/docusaurus-openrpc": "^0.3.1",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-remote-content": "^4.0.0",
     "docusaurus-plugin-segment": "^1.0.4",
     "docusaurus-plugin-typedoc": "1.0.0-next.17",
     "node-polyfill-webpack-plugin": "^2.0.1",

--- a/static/js/update-links.js
+++ b/static/js/update-links.js
@@ -1,0 +1,18 @@
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+
+export function onRouteDidUpdate({ location }) {
+  const initPath = location.pathname;
+  const getRelativePath = (str) => str.replace(/^(?:\/\/|[^/]+)*\//, "");
+  if (initPath.includes("/infura") && ExecutionEnvironment.canUseDOM) {
+    const links = document.querySelectorAll("main .theme-doc-markdown a:not([href^='#'])");
+    if (links.length > 0) {
+      links.forEach(link => {
+        if (!link.href.includes("https")) {
+          const path = getRelativePath(link.href);
+          const url = path.substring(0, path.indexOf(".md/"));
+          link.href = `https://docs.infura.io/${url}`;
+        }
+      });
+    }
+  }
+}

--- a/web3-services/index.md
+++ b/web3-services/index.md
@@ -1,5 +1,0 @@
----
-sidebar_label: Introduction
----
-
-# Use Web3 services with your dapp

--- a/web3-services/index.md
+++ b/web3-services/index.md
@@ -1,0 +1,5 @@
+---
+sidebar_label: Introduction
+---
+
+# Use Web3 services with your dapp

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,6 +4934,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
+  languageName: node
+  linkType: hard
+
 "at-least-node@npm:^1.0.0":
   version: 1.0.0
   resolution: "at-least-node@npm:1.0.0"
@@ -4982,6 +4989,17 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.7
   checksum: 2a8a3787c05f2a0c9c3878f49782357e2a9f38945b93018fb0c4fd788171c43dceefbb577988628e09fea53952744d1ecebde234b561f1e703aa43e0a598a3ad
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.0":
+  version: 1.6.2
+  resolution: "axios@npm:1.6.2"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 4a7429e2b784be0f2902ca2680964391eae7236faa3967715f30ea45464b98ae3f1c6f631303b13dfe721b17126b01f486c7644b9ef276bfc63112db9fd379f8
   languageName: node
   linkType: hard
 
@@ -6048,6 +6066,15 @@ __metadata:
   version: 1.2.0
   resolution: "combine-promises@npm:1.2.0"
   checksum: ddce91436e24da03d5dc360c59cd55abfc9da5e949a26255aa42761925c574797c43138f0aabfc364e184e738e5e218a94ac6e88ebc459045bcf048ac7fe5f07
+  languageName: node
+  linkType: hard
+
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: ~1.0.0
+  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
   languageName: node
   linkType: hard
 
@@ -7283,6 +7310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
+  languageName: node
+  linkType: hard
+
 "delegates@npm:^1.0.0":
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
@@ -7428,6 +7462,20 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"docusaurus-plugin-remote-content@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "docusaurus-plugin-remote-content@npm:4.0.0"
+  dependencies:
+    axios: ^1.6.0
+    picocolors: ^1.0.0
+    pretty-ms: ^7.0.1
+    rimraf: ^5.0.5
+  peerDependencies:
+    "@docusaurus/core": 2.x || 3.x
+  checksum: aec9b868fc0d12520fd75b742e46372a755671da85d0605094aadf3588be40011188e118d433d296e110d938e20dbe324c7b9c39047d78829eab153d6998321a
   languageName: node
   linkType: hard
 
@@ -8660,7 +8708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.7":
+"follow-redirects@npm:^1.14.7, follow-redirects@npm:^1.15.0":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
@@ -8717,6 +8765,17 @@ __metadata:
     vue-template-compiler:
       optional: true
   checksum: 9732a49bfeed8fc23e6e8a59795fa7c238edeba91040a9b520db54b4d316dda27f9f1893d360e296fd0ad8930627d364417d28a8c7007fba60cc730ebfce4956
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -9064,7 +9123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -11975,6 +12034,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.41.0
     "@typescript-eslint/parser": ^5.41.0
     clsx: ^1.2.1
+    docusaurus-plugin-remote-content: ^4.0.0
     docusaurus-plugin-segment: ^1.0.4
     docusaurus-plugin-typedoc: 1.0.0-next.17
     eslint: ^8.26.0
@@ -12358,7 +12418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -13512,6 +13572,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-ms@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "parse-ms@npm:2.1.0"
+  checksum: d5c66c76cca8df5bd0574e2d11b9c3752893b59b466e74308d4a2f09760dc5436a1633f549cad300fc8c3c19154d14959a3b8333d3b2f7bd75898fe18149d564
+  languageName: node
+  linkType: hard
+
 "parse-numeric-range@npm:^1.3.0":
   version: 1.3.0
   resolution: "parse-numeric-range@npm:1.3.0"
@@ -14211,6 +14278,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-ms@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "pretty-ms@npm:7.0.1"
+  dependencies:
+    parse-ms: ^2.1.0
+  checksum: d76c4920283b48be91f1d3797a2ce4bd51187d58d2a609ae993c028f73c92d16439449d857af57ccad91ae3a38b30c87307f5589749a056102ebb494c686957e
+  languageName: node
+  linkType: hard
+
 "pretty-time@npm:^1.1.0":
   version: 1.1.0
   resolution: "pretty-time@npm:1.1.0"
@@ -14351,6 +14427,13 @@ __metadata:
     forwarded: 0.2.0
     ipaddr.js: 1.9.1
   checksum: 29c6990ce9364648255454842f06f8c46fcd124d3e6d7c5066df44662de63cdc0bad032e9bf5a3d653ff72141cc7b6019873d685708ac8210c30458ad99f2b74
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 
@@ -15460,6 +15543,17 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "rimraf@npm:5.0.5"
+  dependencies:
+    glob: ^10.3.7
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: d66eef829b2e23b16445f34e73d75c7b7cf4cbc8834b04720def1c8f298eb0753c3d76df77325fad79d0a2c60470525d95f89c2475283ad985fd7441c32732d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Install and configure [`docusaurus-plugin-remote-content`](https://github.com/rdilweb/docusaurus-plugin-remote-content) v4.0.0. This PR follows the configuration of and supersedes #993.

To do: port [Gas API content](https://docs.infura.io/infura-expansion-apis/gas-api) from Infura.

Fixes #1051 