### PR TITLE
Snaps "exports" -> "entry points"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -218,7 +218,7 @@ const config = {
           },
           {
             from: "/guide/snaps-exports",
-            to: "/snaps/reference/exports",
+            to: "/snaps/reference/entry-points",
           },
           {
             from: "/guide/snaps-patching-dependencies",
@@ -359,6 +359,10 @@ const config = {
           {
             from: "/snaps/how-to/work-with-existing-snaps",
             to: "/snaps/how-to/use-3rd-party-snaps",
+          },
+          {
+            from: "/snaps/reference/exports",
+            to: "/snaps/reference/entry-points",
           },
         ].reduce((acc, item) => {
           acc.push(item);

--- a/snaps-sidebar.js
+++ b/snaps-sidebar.js
@@ -57,7 +57,7 @@ const sidebar = {
         },
         {
           type: "doc",
-          id: "reference/exports",
+          id: "reference/entry-points",
         },
         {
           type: "doc",

--- a/snaps/concepts/anatomy.md
+++ b/snaps/concepts/anatomy.md
@@ -63,8 +63,8 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 };
 ```
 
-To communicate with the outside world, the Snap must implement its own JSON-RPC API by exposing
-the exported function [`onRpcRequest`](../reference/exports.md#onrpcrequest).
+To communicate with the outside world, the Snap must implement its own JSON-RPC API by exposing the
+[`onRpcRequest`](../reference/entry-points.md#onrpcrequest) entry point.
 Whenever the Snap receives a JSON-RPC request from a dapp or another Snap, this handler function is
 called with the specified parameters.
 
@@ -99,8 +99,8 @@ The Snap's RPC API is completely up to you, as long as it's a valid
 :::tip Does my Snap need to have an RPC API?
 No, that's also up to you!
 If your Snap can do something useful without receiving and responding to JSON-RPC requests, such as
-providing [transaction insights](../reference/exports.md#ontransaction), then you can skip exporting
-`onRpcRequest`.
+providing [transaction insights](../reference/entry-points.md#ontransaction), then you can skip
+using `onRpcRequest`.
 However, if you want to do something such as manage the user's keys for a particular protocol and
 create a dapp that, for example, sends transactions for that protocol using your Snap, you must
 specify an RPC API.

--- a/snaps/concepts/user-interface.md
+++ b/snaps/concepts/user-interface.md
@@ -17,8 +17,8 @@ Other than the settings page, a Snap can modify the MetaMask UI using
 [custom UI](../how-to/use-custom-ui.md) in only two ways:
 
 - By opening a dialog using the [`snap_dialog`](../reference/rpc-api.md#snap_dialog) RPC method.
-- By returning transaction insights from the [`onTransaction`](../reference/exports.md#ontransaction)
-  export.
+- By returning transaction insights from the [`onTransaction`](../reference/entry-points.md#ontransaction)
+  entry point.
 
 This means that most Snaps must rely on dapps/websites and their own RPC methods to present their
 data to the user.

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 # Develop a Snap
 
 A Snap can extend the dapp-facing [MetaMask JSON-RPC API](/wallet/reference/rpc-api) in
-arbitrary ways, or integrate with and extend the functionality of MetaMask using the
-[Snaps Exports](../reference/exports.md), [Snaps JSON-RPC API](../reference/rpc-api.md), and
+arbitrary ways, or integrate with and extend the functionality of MetaMask using
+[entry points](../reference/entry-points.md), [JSON-RPC API methods](../reference/rpc-api.md), and
 [permissions](request-permissions.md).
 
 :::caution important

--- a/snaps/how-to/use-3rd-party-snaps.md
+++ b/snaps/how-to/use-3rd-party-snaps.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 
 Some existing, third-party Snaps are designed to communicate with dapps.
 As a dapp developer, you can use these Snaps to take advantage of new features enabled by Snaps.
-This is possible because [Snaps can expose a JSON-RPC API](../reference/exports.md#onrpcrequest).
+This is possible because [Snaps can expose a JSON-RPC API](../reference/entry-points.md#onrpcrequest).
 Snaps can decide to make their API available to dapps by requesting the
 [`endowment:rpc`](../reference/permissions.md#endowmentrpc) permission.
 

--- a/snaps/how-to/use-custom-ui.md
+++ b/snaps/how-to/use-custom-ui.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 # Use custom UI
 
 The [`snap_dialog`](../reference/rpc-api.md#snap_dialog) RPC method and
-[`onTransaction`](../reference/exports.md#ontransaction) exported method use the
+[`onTransaction`](../reference/entry-points.md#ontransaction) entry point use the
 `@metamask/snaps-ui` module to display custom user interface (UI) components.
 
 To use custom UI, first install `@metamask/snaps-ui` using the following command:

--- a/snaps/how-to/use-keyring-api/create-account-snap.md
+++ b/snaps/how-to/use-keyring-api/create-account-snap.md
@@ -213,8 +213,8 @@ Notify MetaMask when the following events take place, using the `emitSnapKeyring
 
 ### 6. Expose the Keyring API
 
-Create a handler function using the `onKeyringRequest` export to expose the Keyring API methods to
-MetaMask and your dapp:
+Create a handler function using the `onKeyringRequest` entry point to expose the Keyring API methods
+to MetaMask and your dapp:
 
 ```typescript
 export const onKeyringRequest: OnKeyringRequestHandler = async ({

--- a/snaps/how-to/use-keyring-api/security.md
+++ b/snaps/how-to/use-keyring-api/security.md
@@ -179,12 +179,12 @@ For example:
   }
   ```
 
-## Expose Keyring API methods using the onKeyringRequest export
+## Expose Keyring API methods using the onKeyringRequest entry point
 
-The [`onRpcRequest`](../../reference/exports.md#onrpcrequest) export is a general-purpose export
-and has no restrictions on the methods that can be called.
-Ensure that you only export Keyring API methods using the `onKeyringRequest` export, which has extra
-security checks.
+The [`onRpcRequest`](../../reference/entry-points.md#onrpcrequest) entry point is a general-purpose
+entry point and has no restrictions on the methods that can be called.
+Ensure that you only expose Keyring API methods using the `onKeyringRequest` entry point, which has
+extra security checks.
 
 For example:
 

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -1,21 +1,21 @@
 ---
-description: See the Snaps exports reference.
+description: See the Snaps entry points reference.
 sidebar_position: 2
 ---
 
-# Snaps exports
+# Snaps entry points
 
-A Snap can export the following methods.
+A Snap can expose the following entry points.
 
 ## onRpcRequest
 
-To communicate with dapps and other Snaps, a Snap must implement its own JSON-RPC API by exporting
-`onRpcRequest`.
+To communicate with dapps and other Snaps, a Snap must implement its own JSON-RPC API by exposing
+the `onRpcRequest` entry point.
 Whenever the Snap receives a JSON-RPC request, the `onRpcRequest` handler method is called.
 
 :::caution important
 If your Snap can do something useful without receiving and responding to JSON-RPC requests, such as
-providing [transaction insights](#ontransaction), you can skip exporting `onRpcRequest`.
+providing [transaction insights](#ontransaction), you can skip using `onRpcRequest`.
 However, if you want to do something such as manage the user's keys for a particular protocol and
 create a dapp that sends transactions for that protocol via your Snap, for example, you must
 specify an RPC API.
@@ -73,7 +73,8 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 
 ## onTransaction
 
-To provide transaction insights before a user signs a transaction, a Snap must export `onTransaction`.
+To provide transaction insights before a user signs a transaction, a Snap must expose the
+`onTransaction` entry point.
 Whenever there's a contract interaction, and a transaction is submitted using the MetaMask
 extension, MetaMask calls this method.
 MetaMask passes the raw unsigned transaction payload to the `onTransaction` handler method.
@@ -210,7 +211,7 @@ module.exports.onTransaction = async ({
 
 ## onCronjob
 
-To run periodic actions for the user (cron jobs), a Snap must export `onCronjob`.
+To run periodic actions for the user (cron jobs), a Snap must expose the `onCronjob` entry point.
 This method is called at the specified times with the specified payloads defined in the
 [`endowment:cronjob`](permissions.md#endowmentcronjob) permission.
 

--- a/snaps/reference/jest.md
+++ b/snaps/reference/jest.md
@@ -47,7 +47,7 @@ A JSON-RPC request object with an addition optional `origin` property.
 
 #### Returns
 
-A promise that resolves to the response from the [`onRpcRequest`](exports.md#onrpcrequest) function,
+A promise that resolves to the response from the [`onRpcRequest`](entry-points.md#onrpcrequest) function,
 which can be checked using [Jest matchers](#jest-matchers).
 
 #### Example
@@ -100,7 +100,7 @@ Most values can be specified as a hex string or a decimal number.
 #### Returns
 
 An object with the user interface that was shown by the Snap, in the
-[`onTransaction`](exports.md#ontransaction) function.
+[`onTransaction`](entry-points.md#ontransaction) function.
 
 #### Example
 
@@ -138,7 +138,7 @@ A JSON-RPC request object.
 
 #### Returns
 
-A promise that resolves to the response from the [`onCronjob`](exports.md#oncronjob) function,
+A promise that resolves to the response from the [`onCronjob`](entry-points.md#oncronjob) function,
 which can be checked using [Jest matchers](#jest-matchers).
 
 #### Example
@@ -293,7 +293,7 @@ response from a Snap matches an expected value:
 - `toSendNotification(notificationText)` - Checks if a Snap sent a notification.
 - `toRender(expectedInterface)` - Checks if a Snap rendered an interface.
   This is useful for testing the user interface of a Snap, either for a [`snap_dialog`](rpc-api.md#snap_dialog)
-  or a user interface rendered by the [transaction insights API](exports.md#ontransaction).
+  or a user interface rendered by the [transaction insights API](entry-points.md#ontransaction).
 
 ## Options
 

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -26,8 +26,8 @@ manifest file:
 ### endowment:cronjob
 
 To run periodic actions for the user (cron jobs), a Snap must request the `endowment:cronjob` permission.
-This permission allows the Snap to specify cron jobs that trigger the exported
-[`onCronjob`](../reference/exports.md#oncronjob) method.
+This permission allows the Snap to specify cron jobs that trigger the
+[`onCronjob`](../reference/entry-points.md#oncronjob) entry point.
 
 Specify this permission in the manifest file as follows:
 
@@ -138,8 +138,8 @@ with the value `*` or `null` in the response.
 ### endowment:rpc
 
 To handle arbitrary JSON-RPC requests, a Snap must request the `endowment:rpc` permission.
-This permission grants a Snap access to JSON-RPC requests sent to the Snap, using the exported
-[`onRpcRequest`](exports.md#onrpcrequest) method.
+This permission grants a Snap access to JSON-RPC requests sent to the Snap, using the
+[`onRpcRequest`](entry-points.md#onrpcrequest) entry point.
 
 This permission requires an object with a `snaps` or `dapps` property (or both), to signal if the
 snap can receive JSON-RPC requests from other Snaps, or dapps, respectively.
@@ -185,7 +185,8 @@ If you specify `allowedOrigins`, you should not specify `dapps` or `snaps`.
 
 To provide transaction insights, a Snap must request the `endowment:transaction-insight` permission.
 This permission grants a Snap read-only access to raw transaction payloads, before they're accepted
-for signing by the user, by exporting the [`onTransaction`](../reference/exports.md#ontransaction) method.
+for signing by the user, by exposing the [`onTransaction`](../reference/entry-points.md#ontransaction)
+entry point.
 
 This permission requires an object with an `allowTransactionOrigin` property to signal if the Snap
 should pass the `transactionOrigin` property as part of the `onTransaction` parameters.

--- a/snaps/tutorials/transaction-insights.md
+++ b/snaps/tutorials/transaction-insights.md
@@ -151,8 +151,8 @@ To build and test your Snap:
     You can set up multiple accounts to transfer between your accounts.
 
 6. On the confirmation window, switch to the tab named **TYPESCRIPT EXAMPLE SNAP**.
-    Switching to the tab activates the [`onTransaction`](../reference/exports.md#ontransaction)
-    export of your Snap and displays the percentage of gas fees in the transaction insights UI:
+    Switching to the tab activates the [`onTransaction`](../reference/entry-points.md#ontransaction)
+    entry point of your Snap and displays the percentage of gas fees in the transaction insights UI:
 
 <p align="center">
 <img src={require('../assets/transaction-insights.png').default} alt="Transaction insights UI" style={{border: '1px solid gray'}} />
@@ -162,7 +162,7 @@ To build and test your Snap:
 
 The Snap should only display a gas fee percentage if the user is doing a regular ETH transfer.
 For contract interactions, it should display a UI that conveys that message.
-Add the following code to the beginning of the `onTransaction` export:
+Add the following code to the beginning of the `onTransaction` entry point:
 
 ```typescript
 if (typeof transaction.data === 'string' && transaction.data !== '0x') {


### PR DESCRIPTION
Rename Snaps "exports" to "entry points" throughout the docs. Fixes #842.