### PR TITLE
Update Snaps resources

### DIFF
--- a/snaps-sidebar.js
+++ b/snaps-sidebar.js
@@ -97,6 +97,10 @@ const sidebar = {
           },
           items: require("./snaps/reference/keyring-api/typedoc-sidebar.cjs"),
         },
+        {
+          type: "doc",
+          id: "reference/resources",
+        },
       ],
     },
   ],

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -124,23 +124,7 @@ You should deploy a dapp where users can learn about your Snap and install it, o
 
 If your Snap is designed to communicate with dapps, you can encourage other dapp developers to [integrate your Snap](use-3rd-party-snaps.md).
 
-## Resources and tools
+## Resources
 
-You can review the growing number of [example Snaps](https://github.com/MetaMask/snaps/tree/main/packages/examples) maintained by MetaMask, as well as the following fully functional and open source Snaps: 
-
-- [Dogecoin](https://github.com/ziad-saab/dogecoin-snap)
-- [StarkNet](https://github.com/Consensys/starknet-snap)
-- [MobyMask Phishing Warning](https://github.com/Montoya/mobymask-snap)
-
-MetaMask also maintains tools to help developers build, debug, and maintain Snaps:
-
-- [Template Snap](https://github.com/MetaMask/template-snap-monorepo) - A template that includes
-  TypeScript/React and vanilla JavaScript options and a CLI for building, packaging, and deploying
-  your Snap and a companion dapp.
-- [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/latest) - A developer tool built for simulating Snaps in the browser, streamlining the development process.
-- [Test Snaps](https://github.com/MetaMask/test-snaps) - A collection of test Snaps and a dapp for
-  evaluating them.
-
-If you have any questions, ask them on
-[GitHub discussions](https://github.com/MetaMask/snaps-monorepo/discussions), and if you encounter
-any issues, please [open a GitHub issue](https://github.com/MetaMask/snaps-monorepo/issues).
+See the full list of [Snaps resources](../reference/resources.md) for more information on developer
+tools, example Snaps, and more.

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -103,4 +103,6 @@ Features include:
 
 If you have questions about using MetaMask Snaps or want to propose a new feature, you can interact with the
 MetaMask Snaps team and community on [GitHub discussions](https://github.com/MetaMask/snaps/discussions)
-and the **snaps-dev-metamask** channel on [Consensys Discord](https://discord.gg/consensys).
+and the **mm-snaps-dev** channel on [Consensys Discord](https://discord.gg/consensys).
+
+See the full list of [Snaps resources](reference/resources.md) for more information.

--- a/snaps/reference/resources.md
+++ b/snaps/reference/resources.md
@@ -10,7 +10,6 @@ View the following Snaps resources in addition to this documentation site.
 
 - [Snaps homepage](https://metamask.io/snaps/)
 - [Snaps directory](https://snaps.metamask.io/) - A directory of allowlisted Snaps you can try.
-- [MetaMask Flask](https://metamask.io/flask/) - Install Flask to build your own Snaps and run Snaps locally.
 - [SIPs](https://github.com/MetaMask/SIPs) - Snaps Improvement Proposals.
 - [Open Beta Readiness Guide](https://github.com/MetaMask/snaps/discussions/1411) - A guide to get
   your Snap allowlisted on MetaMask.
@@ -36,8 +35,8 @@ View the following Snaps resources in addition to this documentation site.
   deploying your Snap, and a companion dapp UI you can build on.
 - [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/latest) - A tool for simulating
   Snaps in the browser, streamlining the development process.
-- [Test Snaps](https://github.com/MetaMask/test-snaps) - A collection of test Snaps and a dapp for
-  evaluating them.
+- [Test Snaps](https://github.com/MetaMask/snaps/tree/main/packages/test-snaps) - A collection of
+  test Snaps and [a dapp for evaluating them](https://metamask.github.io/snaps/test-snaps/latest/).
 
 ## Blog posts
 

--- a/snaps/reference/resources.md
+++ b/snaps/reference/resources.md
@@ -1,0 +1,74 @@
+---
+description: See more Snaps resources.
+---
+
+# Resources
+
+View the following Snaps resources in addition to this documentation site.
+
+## Primary resources
+
+- [Snaps homepage](https://metamask.io/snaps/)
+- [Snaps directory](https://snaps.metamask.io/) - A directory of allowlisted Snaps you can try.
+- [MetaMask Flask](https://metamask.io/flask/) - Install Flask to build your own Snaps and run Snaps locally.
+- [SIPs](https://github.com/MetaMask/SIPs) - Snaps Improvement Proposals.
+- [Open Beta Readiness Guide](https://github.com/MetaMask/snaps/discussions/1411) - A guide to get
+  your Snap allowlisted on MetaMask.
+
+## Example Snaps
+
+- [Example Snaps](https://github.com/MetaMask/snaps/tree/main/packages/examples) - A directory of
+  Snaps maintained by MetaMask.
+- [Dogecoin Snap](https://github.com/ziad-saab/dogecoin-snap) - A tutorial for creating a Snap to
+  add Dogecoin to MetaMask.
+- [Starknet Snap](https://github.com/Consensys/starknet-snap) - A Snap to add Starknet to MetaMask.
+- [MobyMask Phishing Warning Snap](https://github.com/Montoya/mobymask-snap) - A Snap that warns you
+  when interacting with phishing contracts.
+- [Mystery Snap](https://github.com/Montoya/random-snap) - A Snap that returns random numbers and answers.
+- [Snappy Recovery](https://github.com/ziad-saab/snappy-recovery) - A Snap that enables social
+  recovery of private keys.
+- [Pet Fox game](https://github.com/Montoya/pet-fox) - A simple game built using a Snap.
+
+## Developer tools
+
+- [Template Snap](https://github.com/MetaMask/template-snap-monorepo) - A rich template that
+  includes TypeScript/React and vanilla JavaScript options, a CLI for building, packaging, and
+  deploying your Snap, and a companion dapp UI you can build on.
+- [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/latest) - A tool for simulating
+  Snaps in the browser, streamlining the development process.
+- [Test Snaps](https://github.com/MetaMask/test-snaps) - A collection of test Snaps and a dapp for
+  evaluating them.
+
+## Blog posts
+
+- [Making the Wallet Personal](https://thedefiant.io/making-the-wallet-personal) by Christian
+  Montoya
+- [Permissionless Innovation and You](https://metamask.io/news/latest/permissionless-innovation-and-you/)
+  by Erik Marks
+- [Snaps in MetaMask Stable and Where We Go From
+  Here](https://metamask.io/news/latest/snaps-in-metamask-stable-and-where-we-go-from-here/) by Dan
+  Finlay
+- [MetaMask Snaps Launch with Hardened JavaScript Under the
+  Hood](https://agoric.com/blog/announcements/metamask-snaps-launch-with-hardened-javascript-under-the-hood) by Agoric
+- [Navigating the Security Landscape of MetaMask Snaps](https://metamask.io/news/developers/navigating-the-security-landscape-of-metamask-snaps/)
+  by Martin Ortner & Valentin Quelquejay
+
+## Videos
+
+- [MetaMask Snaps Public Launch](https://www.youtube.com/watch?v=cbkjbYd71OY) (12 min)
+- [What is MetaMask Snaps? Main Functions and Features Explained](https://www.youtube.com/watch?v=Dlw9yLpEm7E) (53 mins)
+- [Deep Dive into MetaMask Snaps](https://www.youtube.com/watch?v=qXEBqamnv5w) (57 min)
+- [Building a Universal Web3 Interface](https://vimeo.com/864943019)
+  (16 min) ([Slides](https://docs.google.com/presentation/d/1pnx6JdpFaj6LsW3B89jqumYgmHvirOE2H-_2S1ggRvY/edit?usp=sharing))
+- [It's Our Wallet, Let's Build It Together](https://www.youtube.com/watch?v=G6qunL2gnjE) (19 min)
+  ([Slides](https://docs.google.com/presentation/d/1ZjhYF-3mwGmsFdcbDgqgFR6t3YIab4_Hk3dRAWjvSQg/edit?usp=sharing))
+- [Building the Future with MetaMask Snaps](https://www.youtube.com/watch?v=iE8CGzadKZ8&t=288s) (22 min)
+  ([Slides](https://docs.google.com/presentation/d/1LG8MqRrbb9qSg4m8ZjJXPQFccb9YPc-6387hSNpscpY/edit?usp=sharing))
+
+## Community
+
+- [Snaps GitHub discussions](https://github.com/MetaMask/snaps/discussions) - Browse discussions and
+  ask questions about Snaps.
+- [Consensys Discord](https://discord.gg/consensys) - Ask questions about Snaps on the **mm-snaps-dev** channel.
+- [Snaps GitHub issues](https://github.com/MetaMask/snaps/issues) - If you encounter any issues with
+  Snaps, open a GitHub issue.


### PR DESCRIPTION
Moves resources section from Develop a Snap page to its own reference page. Updates the list with all info from [this resources list](https://github.com/MetaMask/snaps/discussions/675). Fixes #844.