### PR TITLE
Direct Flask admonition to Flask page in docs

### DIFF
--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -22,7 +22,7 @@ export default function AdmonitionWrapper(props: Props): JSX.Element {
         icon={<FlaskIcon />}
         title="Flask Only"
       >
-        This feature is only available in <a href="https://metamask.io/flask" target="_blank" rel="noopener noreferrer">MetaMask Flask</a>, the canary distribution of MetaMask.
+        This feature is only available in <a href="https://docs.metamask.io/snaps/get-started/install-flask/" target="_blank" rel="noopener noreferrer">MetaMask Flask</a>, the canary distribution of MetaMask.
       </Admonition>
     );
   }

--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -22,7 +22,7 @@ export default function AdmonitionWrapper(props: Props): JSX.Element {
         icon={<FlaskIcon />}
         title="Flask Only"
       >
-        This feature is only available in <a href="https://docs.metamask.io/snaps/get-started/install-flask/" target="_blank" rel="noopener noreferrer">MetaMask Flask</a>, the canary distribution of MetaMask.
+        This feature is only available in <a href="https://docs.metamask.io/snaps/get-started/install-flask/">MetaMask Flask</a>, the canary distribution of MetaMask.
       </Admonition>
     );
   }


### PR DESCRIPTION
https://metamask.io/flask is being deprecated, this directs the Flask admonition to the docs site instead.