### PR TITLE
Redirect install-snaps to install-flask

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -360,6 +360,10 @@ const config = {
             from: "/snaps/how-to/work-with-existing-snaps",
             to: "/snaps/how-to/use-3rd-party-snaps",
           },
+          {
+            from: "/snaps/get-started/install-snaps/",
+            to: "/snaps/get-started/install-flask/",
+          },
         ].reduce((acc, item) => {
           acc.push(item);
           acc.push({ from: item.from + ".html", to: item.to });


### PR DESCRIPTION
This page was deprecated in favor of install-flask but the redirect was never created.