### PR TITLE
Improve Flask page

### DIFF
--- a/snaps/get-started/install-flask.md
+++ b/snaps/get-started/install-flask.md
@@ -5,37 +5,30 @@ sidebar_position: 1
 
 # Install MetaMask Flask
 
-To get started building your own Snaps, you must install the MetaMask Flask browser extension.
-
-:::danger Developers only
-MetaMask Flask is an experimental tool only for developers. 
-If you are not a developer, you should not install MetaMask Flask. 
-:::
-
-## Prerequisites
-
-- Up-to-date Chromium or Firefox browser
-
-## Install the MetaMask Flask browser extension
-
-MetaMask Flask is an experimental playground that provides developers access to upcoming MetaMask features. 
-It is available as a browser extension. 
-You can install MetaMask Flask for 
+To get started building your own Snaps, install the MetaMask Flask browser extension on
 [Google Chrome](https://chromewebstore.google.com/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk) 
-and 
+or 
 [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/metamask-flask/).
 
+Install Flask in a new browser profile, or disable any existing installed versions of MetaMask
+before installing Flask.
+Running multiple instances of MetaMask in the same browser profile can break dapp interactions.
+
+:::caution Developers only
+MetaMask Flask is an experimental tool only for developers.
+If you are not a developer, you should not install MetaMask Flask.
+:::
+
+:::danger Do not import accounts with funds to Flask
+We do not recommend importing your Secret Recovery Phrase from MetaMask stable to MetaMask Flask.
+If you import accounts with funds into Flask, you do so at your own risk.
+:::
+
+## About MetaMask Flask
+
+MetaMask Flask is an experimental playground that provides developers access to upcoming MetaMask features.
 While a small set of audited Snaps are allowlisted in the stable version of the MetaMask browser extension, MetaMask Flask is intended for developers building and testing Snaps locally or from npm.
 Also, new Snaps API features are enabled in Flask for testing and developer feedback before they're enabled in MetaMask stable. 
-These features appear in the documentation with the "Flask" or "FLASK ONLY" tag. 
-You can also view Flask-specific features by looking for the \[FLASK\] label in the 
-[MetaMask Extension changelog](https://github.com/MetaMask/metamask-extension/blob/develop/CHANGELOG.md). 
-
-:::caution Install in a new browser profile
-Install the Metamask Flask browser extension in a new browser profile, or disable any existing installed versions of MetaMask before installing Flask. 
-Running multiple instances of MetaMask in the same browser profile breaks dapp interactions.
-:::
-
-:::danger Do not import accounts with funds to Flask 
-We do not recommend importing your Secret Recovery Phrase from MetaMask stable to MetaMask Flask. If you import accounts with funds into Flask, you do so at your own risk.
-:::
+These features appear in the documentation with the **Flask** or **FLASK ONLY** tag. 
+You can also view Flask-specific features by looking for the **\[FLASK\]** label in the 
+[MetaMask Extension changelog](https://github.com/MetaMask/metamask-extension/blob/develop/CHANGELOG.md).

--- a/snaps/get-started/quickstart.mdx
+++ b/snaps/get-started/quickstart.mdx
@@ -1,16 +1,20 @@
 ---
-description: Get started quickly using the Snaps template.
+description: Get started quickly using the create-snap CLI.
 sidebar_position: 2
 ---
 
-import YoutubeEmbed from '@site/src/components/YoutubeEmbed'
+import ReactPlayer from 'react-player/lazy'
 
 # Snaps quickstart
 
-<YoutubeEmbed url="https://www.youtube.com/embed/qZRAryYwgdg?si=CeImIULgH3iD-FF0" />
+Get started creating your own Snap.
+Use the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap)
+to initialize a Snap monorepo project built with TypeScript and React.
+See the following video demo:
 
-Get started with Snaps using the [`@metamask/create-snap` CLI](https://github.com/MetaMask/snaps/tree/main/packages/create-snap).
-With the CLI, you can initialize a Snap monorepo project built with TypeScript and React.
+<p align="center">
+  <ReactPlayer url='https://www.youtube.com/embed/qZRAryYwgdg?si=CeImIULgH3iD-FF0' />
+</p>
 
 ## Prerequisites
 

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -3,14 +3,17 @@ title: Introduction
 ---
 
 import CardList from '@site/src/components/CardList'
-import YoutubeEmbed from '@site/src/components/YoutubeEmbed'
+import ReactPlayer from 'react-player/lazy'
 
 # Extend the functionality of MetaMask using Snaps
 
-<YoutubeEmbed url="https://www.youtube.com/embed/lmxKo4Qx7cM?si=zRJEUbH4_46MKbLL" />
-
 MetaMask Snaps is an open source system that allows anyone to safely extend the functionality of MetaMask,
 creating new web3 end user experiences.
+Learn more in this video:
+
+<p align="center">
+  <ReactPlayer url='https://www.youtube.com/embed/lmxKo4Qx7cM?si=zRJEUbH4_46MKbLL' />
+</p>
 
 Want to build your own Snaps? Get started by [installing MetaMask Flask](get-started/install-flask.md).
 
@@ -30,7 +33,7 @@ Snaps have access to a limited set of capabilities, determined by the
 A Snap can add new API methods to MetaMask, add support for different blockchain protocols, or
 modify existing functionalities using the [Snaps JSON-RPC API](reference/rpc-api.md).
 
-Features include:
+The following Snaps features are available in the stable version of MetaMask:
 
 <CardList
   items={[
@@ -81,7 +84,15 @@ Features include:
       href: "reference/permissions#endowmentnetwork-access",
       title: "Network access",
       description: <>Make API calls using <code>fetch()</code>.</>
-    },
+    }
+  ]}
+/>
+
+The following Snaps features are only available in [MetaMask Flask](get-started/install-flask.md),
+the canary distribution of MetaMask:
+
+<CardList
+  items={[
     {
       icon: require("./assets/features/network.png").default,
       href: "concepts/keyring-api",


### PR DESCRIPTION
Cleans up Flask page for clarity, and makes minor improvements to intro pages. Matches video format to existing videos in the docs so they don't take up as much screen space. Fixes #1055.