### PR TITLE
Add full examples to SDK pages

### DIFF
--- a/wallet/how-to/connect/set-up-sdk/javascript/electron.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/electron.md
@@ -14,7 +14,7 @@ to easily connect to the MetaMask browser extension and MetaMask Mobile.
 On the frontend, see the instructions to [use the SDK with React](react/index.md).
 On the backend, see the instructions to [use the SDK with Node.js](nodejs.md).
 
-:::tip example
+## Example
+
 See the [example Electron dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/electronjs)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/javascript/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/index.md
@@ -21,11 +21,6 @@ You can also see instructions for the following JavaScript-based platforms:
 - [Node.js](nodejs.md)
 - [Electron](electron.md)
 
-:::tip Examples
-See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
-
 ## Prerequisites
 
 - An existing or [new project](../../../get-started-building/set-up-dev-environment.md) set up
@@ -62,7 +57,13 @@ import { MetaMaskSDK } from '@metamask/sdk';
 Instantiate the SDK using any [options](../../../../reference/sdk-js-options.md):
 
 ```javascript
-const MMSDK = new MetaMaskSDK(options);
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "JavaScript example dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
 
 const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
 ```
@@ -86,3 +87,26 @@ prompts the installation or connection popup to appear.
 ```javascript
 ethereum.request({ method: 'eth_requestAccounts', params: [] });
 ```
+
+## Example
+
+You can copy the full JavaScript example to get started:
+
+```javascript title="index.js"
+import { MetaMaskSDK } from '@metamask/sdk';
+
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "Example JavaScript Dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```
+
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/javascript/nodejs.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/nodejs.md
@@ -12,11 +12,6 @@ Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your Node.js dapp 
 to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for Node.js has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
-:::tip Example
-See the [example Node.js dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
-
 ## Steps
 
 ### 1. Install the SDK
@@ -46,7 +41,13 @@ import { MetaMaskSDK } from '@metamask/sdk';
 Instantiate the SDK using any [options](../../../../reference/sdk-js-options.md):
 
 ```javascript
-const MMSDK = new MetaMaskSDK(options);
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "Example Node.js Dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
 
 const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
 ```
@@ -70,3 +71,26 @@ prompts the installation or connection popup to appear.
 ```javascript
 ethereum.request({ method: 'eth_requestAccounts', params: [] });
 ```
+
+## Example
+
+You can copy the full Node.js example to get started:
+
+```javascript title="index.js"
+import { MetaMaskSDK } from '@metamask/sdk';
+
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "Example Node.js Dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```
+
+See the [example Node.js dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/nodejs)
+in the JavaScript SDK GitHub repository for advanced use cases.

--- a/wallet/how-to/connect/set-up-sdk/javascript/other-web-frameworks.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/other-web-frameworks.md
@@ -13,11 +13,6 @@ easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for other web frameworks has the [same prerequisites](index.md#prerequisites) as for
 standard JavaScript.
 
-:::tip Examples
-See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
-
 ## Steps
 
 ### 1. Install the SDK
@@ -47,7 +42,13 @@ import { MetaMaskSDK } from '@metamask/sdk';
 Instantiate the SDK using any [options](../../../../reference/sdk-js-options.md):
 
 ```javascript
-const MMSDK = new MetaMaskSDK(options);
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "Example JavaScript Dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
 
 const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
 ```
@@ -71,3 +72,26 @@ prompts the installation or connection popup to appear.
 ```javascript
 ethereum.request({ method: 'eth_requestAccounts', params: [] });
 ```
+
+## Example
+
+You can copy the full JavaScript example to get started:
+
+```javascript title="index.js"
+import { MetaMaskSDK } from '@metamask/sdk';
+
+const MMSDK = new MetaMaskSDK(
+  dappMetadata: {
+    name: "Example JavaScript Dapp",
+    url: window.location.host,
+  }
+  // Other options
+);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```
+
+See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/pure-js.md
@@ -12,31 +12,27 @@ Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your pure JavaScri
 your users to easily connect to the MetaMask browser extension and MetaMask Mobile.
 The SDK for pure JavaScript has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
-:::tip Example
-See the [example pure JavaScript dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/pure-javascript)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
-
 To import, instantiate, and use the SDK, you can insert a script in the head section of your website:
 
-```javascript
+```html title="index.html"
 <head>
 ...
-
 <script src="https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/cdn/metamask-sdk.js"></script>
-
 <script>
+  const MMSDK = new MetaMaskSDK.MetaMaskSDK(
+    dappMetadata: {
+      name: "Example Pure JS Dapp",
+      url: window.location.host,
+    }
+    // Other options
+  )
+  // Because init process of the MetaMaskSDK is async.
+  setTimeout(() => {
+    const ethereum = MMSDK.getProvider() // You can also access via window.ethereum
 
-    const MMSDK = new MetaMaskSDK.MetaMaskSDK()
-    // Because init process of the MetaMaskSDK is async.
-    setTimeout(() => {
-        const ethereum = MMSDK.getProvider() // You can also access via window.ethereum
-
-        ethereum.request({ method: 'eth_requestAccounts' })
-    }, 0)
-
+    ethereum.request({ method: 'eth_requestAccounts' })
+  }, 0)
 </script>
-
 ...
 </head>
 ```
@@ -55,3 +51,8 @@ since it prompts the installation or connection popup to appear.
 - Use [`infuraAPIKey`](../../../../reference/sdk-js-options.md#infuraapikey) to
   [make read-only RPC requests](../../../use-3rd-party-integrations/js-infura-api.md) from your dapp.
 :::
+
+## Example
+
+See the [example pure JavaScript dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/pure-javascript)
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react/index.md
@@ -6,6 +6,9 @@ tags:
   - JavaScript SDK
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Use MetaMask SDK with React
 
 Import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your users to
@@ -16,11 +19,6 @@ The SDK for React has the [same prerequisites](../index.md#prerequisites) as for
 This page provides instructions for using the standard `@metamask/sdk-react` package.
 Alternatively, you can use the [`@metamask/sdk-react-ui`](react-ui.md) package to easily use
 [wagmi](https://wagmi.sh/) hooks and a pre-styled UI button component for connecting to MetaMask.
-:::
-
-:::tip Examples
-See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-in the JavaScript SDK GitHub repository for advanced use cases.
 :::
 
 ## Steps
@@ -65,11 +63,11 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <MetaMaskProvider debug={false} sdkOptions={{
-      checkInstallationImmediately: false,
       dappMetadata: {
-        name: "Demo React App",
+        name: "Example React Dapp",
         url: window.location.host,
       }
+      // Other options
     }}>
       <App />
     </MetaMaskProvider>
@@ -160,5 +158,79 @@ const connect = async () => {
 You can also [use the `connectAndSign` method](../../../../sign-data/connect-and-sign.md) to
 connect to MetaMask and sign data in a single interaction.
 
-Refer to the [MetaMask JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-for advanced use cases.
+## Example
+
+You can copy the full React example to get started:
+
+<Tabs>
+<TabItem value="Root component">
+
+```javascript title="index.tsx"
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { MetaMaskProvider } from '@metamask/sdk-react';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
+  <React.StrictMode>
+    <MetaMaskProvider debug={false} sdkOptions={{
+      dappMetadata: {
+        name: "Example React Dapp",
+        url: window.location.host,
+      }
+      // Other options
+    }}>
+      <App />
+    </MetaMaskProvider>
+  </React.StrictMode>
+);
+```
+
+</TabItem>
+<TabItem value="React component">
+
+```javascript title="App.tsx"
+import { useSDK } from '@metamask/sdk-react';
+import React, { useState } from 'react';
+
+export const App = () => {
+  const [account, setAccount] = useState<string>();
+  const { sdk, connected, connecting, provider, chainId } = useSDK();
+
+  const connect = async () => {
+    try {
+      const accounts = await sdk?.connect();
+      setAccount(accounts?.[0]);
+    } catch(err) {
+      console.warn(`failed to connect..`, err);
+    }
+  };
+
+  return (
+    <div className="App">
+      <button style={{ padding: 10, margin: 10 }} onClick={connect}>
+        Connect
+      </button>
+      {connected && (
+        <div>
+          <>
+            {chainId && `Connected chain: ${chainId}`}
+            <p></p>
+            {account && `Connected account: ${account}`}
+          </>
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+</TabItem>
+</Tabs>
+
+See the [example React dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/create-react-app)
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/javascript/react/react-ui.md
+++ b/wallet/how-to/connect/set-up-sdk/javascript/react/react-ui.md
@@ -6,6 +6,9 @@ tags:
   - JavaScript SDK
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Use MetaMask SDK with React UI
 
 Import [MetaMask SDK](../../../../../concepts/sdk/index.md) into your React dapp to enable your
@@ -19,11 +22,6 @@ the core functionality and the pre-styled UI components to streamline the integr
 into your React dapp.
 
 The SDK for React has the [same prerequisites](../index.md#prerequisites) as for standard JavaScript.
-
-:::tip Examples
-See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-in the JavaScript SDK GitHub repository for advanced use cases.
-:::
 
 ## Steps
 
@@ -68,8 +66,10 @@ root.render(
   <React.StrictMode>
     <MetaMaskUIProvider sdkOptions={{
       dappMetadata: {
-        name: "Demo UI React App",
+        name: "Example React UI Dapp",
+        url: window.location.host,
       }
+      // Other options
     }}>
       <App />
     </MetaMaskUIProvider>
@@ -123,5 +123,93 @@ export const App = () => {
 </p>
 </details>
 
-Refer to the [MetaMask JavaScript SDK examples](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)
-for advanced use cases.
+## Example
+
+You can copy the full React UI example to get started:
+
+<Tabs>
+<TabItem value="Root component">
+
+```javascript title="index.js"
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { MetaMaskUIProvider } from '@metamask/sdk-react-ui';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
+  <React.StrictMode>
+    <MetaMaskUIProvider sdkOptions={{
+      dappMetadata: {
+        name: "Example React UI Dapp",
+        url: window.location.host,
+      }
+      // Other options
+    }}>
+      <App />
+    </MetaMaskUIProvider>
+  </React.StrictMode>
+);
+```
+
+</TabItem>
+<TabItem value="React component">
+
+```javascript title="App.js"
+import { MetaMaskButton, useAccount, useSDK, useSignMessage} from '@metamask/sdk-react-ui';
+import './App.css';
+
+function AppReady() {
+  const {
+    data: signData,
+    isError: isSignError,
+    isLoading: isSignLoading,
+    isSuccess: isSignSuccess,
+    signMessage,
+  } = useSignMessage({
+    message: 'gm wagmi frens',
+  });
+
+  const { isConnected } = useAccount();
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <MetaMaskButton theme={'light'} color="white"></MetaMaskButton>
+        {isConnected && (
+          <>
+            <div style={{ marginTop: 20 }}>
+              <button disabled={isSignLoading} onClick={() => signMessage()}>
+                Sign message
+              </button>
+              {isSignSuccess && <div>Signature: {signData}</div>}
+              {isSignError && <div>Error signing message</div>}
+            </div>
+          </>
+        )}
+      </header>
+    </div>
+  );
+}
+
+function App() {
+  const { ready } = useSDK();
+
+  if (!ready) {
+    return <div>Loading...</div>;
+  }
+
+  return <AppReady />;
+}
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
+See the [example React UI dapp](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/react-metamask-button)
+in the JavaScript SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/mobile/android.md
+++ b/wallet/how-to/connect/set-up-sdk/mobile/android.md
@@ -12,10 +12,8 @@ tags:
 Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native Android dapp to enable
 your users to easily connect with their MetaMask Mobile wallet.
 
-:::tip Learn more
-- See the [example Android dapp](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) in
-  the Android SDK GitHub repository for advanced use cases.
-- See more information about the [Android SDK architecture](../../../../concepts/sdk/android.md).
+:::tip See also
+- [Android SDK architecture](../../../../concepts/sdk/android.md)
 :::
 
 ## Prerequisites
@@ -311,3 +309,8 @@ private fun addEthereumChain(
     }
 }
 ```
+
+## Example
+
+See the [example Android dapp](https://github.com/MetaMask/metamask-android-sdk/tree/main/app) in
+the Android SDK GitHub repository for more information.

--- a/wallet/how-to/connect/set-up-sdk/mobile/ios.md
+++ b/wallet/how-to/connect/set-up-sdk/mobile/ios.md
@@ -7,15 +7,13 @@ tags:
   - iOS SDK
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Use MetaMask SDK with iOS
 
 Import [MetaMask SDK](../../../../concepts/sdk/index.md) into your native iOS dapp to enable your
 users to easily connect with their MetaMask Mobile wallet.
-
-:::tip Example
-See the [example iOS dapp](https://github.com/MetaMask/metamask-ios-sdk/tree/main/Example) in the
-iOS SDK GitHub repository for advanced use cases.
-:::
 
 ## Prerequisites
 
@@ -33,7 +31,8 @@ iOS SDK GitHub repository for advanced use cases.
 
 ### 1. Install the SDK
 
-#### CocoaPods
+<Tabs>
+<TabItem value="CocoaPods">
 
 To add the SDK as a CocoaPods dependency to your project, add the following entry to our Podfile:
 
@@ -47,7 +46,8 @@ Run the following command:
 pod install
 ```
 
-#### Swift Package Manager
+</TabItem>
+<TabItem value="Swift Package Manager">
 
 To add the SDK as a Swift Package Manager (SPM) package to your project, in Xcode, select
 **File > Swift Packages > Add Package Dependency**.
@@ -63,6 +63,9 @@ dependencies: [
     )
 ]
 ```
+
+</TabItem>
+</Tabs>
 
 ### 2. Import the SDK
 
@@ -213,3 +216,8 @@ let result = await metamaskSDK.request(transactionRequest)
 ```
 
 <!--/tabs-->
+
+## Example
+
+See the [example iOS dapp](https://github.com/MetaMask/metamask-ios-sdk/tree/main/Example) in the
+iOS SDK GitHub repository for more information.


### PR DESCRIPTION
Add "example" sections to SDK pages, include full copy and paste examples where applicable. Minor edits to related content. Fixes #1056.

Preview: https://docs.metamask.io/1056-sdk-examples/wallet/how-to/connect/set-up-sdk/javascript/