### PR TITLE
Clarify SDK EIP-6963 functionality

### DIFF
--- a/wallet/concepts/wallet-interoperabilty.md
+++ b/wallet/concepts/wallet-interoperabilty.md
@@ -18,16 +18,22 @@ We recommend using this new mechanism for provider discovery.
   </video>
 </p>
 
-You can add support for EIP-6963 in one of the following ways:
+You can add support for connecting to the MetaMask browser extension via EIP-6963 in the following ways:
 
 - [Set up MetaMask SDK](../how-to/connect/set-up-sdk/javascript/index.md) in your dapp.
-  The SDK supports EIP-6963 by default, and we recommend using this method.
+  The SDK connects to the MetaMask extension via EIP-6963 by default, and we recommend using this method.
 - [Directly update your dapp code](../how-to/discover-multiple-wallets.md) to support EIP-6963.
 - Use third-party libraries that support EIP-6963.
 
 Alternatively, you can use [convenience libraries](convenience-libraries.md) that support wallet
 interoperability.
 We recommend using the SDK for the best MetaMask user experience.
+
+:::note
+MetaMask SDK doesn't support connecting to non-MetaMask wallets via EIP-6963.
+If you intend to support discovery of other wallets, we recommend using other methods of adding
+EIP-6963 support.
+:::
 
 ## Community support
 

--- a/wallet/how-to/discover-multiple-wallets.md
+++ b/wallet/how-to/discover-multiple-wallets.md
@@ -9,9 +9,10 @@ If a user has multiple wallet browser extensions installed, your web dapp can su
 [wallet interoperability](../concepts/wallet-interoperabilty.md) by adding support for
 [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963), which enables your dapp to discover and connect
 to multiple installed wallets.
-We recommend [setting up MetaMask SDK](connect/set-up-sdk/javascript/index.md) in your dapp, which supports
-EIP-6963 by default.
 
-If you don't have the SDK set up, you can directly update your dapp code to support EIP-6963.
+We recommend [setting up MetaMask SDK](connect/set-up-sdk/javascript/index.md) in your dapp, which
+connects to the MetaMask extension via EIP-6963 by default.
+
+You can also directly update your dapp code to connect to non-MetaMask wallets via EIP-6963.
 See the [test dapp source code](https://github.com/MetaMask/test-dapp) for an example of how to
 implement this.


### PR DESCRIPTION
Edit EIP-6963 pages to clarify that the SDK only connects to MetaMask via EIP-6963. Fixes #1065 

Preview: https://docs.metamask.io/1065-clarify-eip-6963/wallet/concepts/wallet-interoperabilty/