### PR TITLE
Remove object syntax for specifying cronjobs

### DIFF
--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -37,13 +37,7 @@ Specify this permission in the manifest file as follows:
     "endowment:cronjob": {
       "jobs": [
         {
-          "expression": {
-            "minute": "*",
-            "hour": "*",
-            "dayOfMonth": "*",
-            "month": "*",
-            "dayOfWeek": "*"
-          },
+          "expression": "* * * * *",
           "request": {
             "method": "exampleMethodOne",
             "params": {
@@ -52,7 +46,7 @@ Specify this permission in the manifest file as follows:
           }
         },
         {
-          "expression": "* * * * *",
+          "expression": "*/2 * * * *",
           "request": {
             "method": "exampleMethodTwo",
             "params": {


### PR DESCRIPTION
This PR will remove object-like syntax for specifying Cronjob permissions.

Related PR: https://github.com/MetaMask/snaps/pull/2057

Related ticket: https://github.com/MetaMask/snaps/issues/1390
