### PR TITLE
Fix docs for security guidelines

### DIFF
--- a/snaps/concepts/security-guidelines.md
+++ b/snaps/concepts/security-guidelines.md
@@ -75,7 +75,7 @@ The following are guidelines for user notifications and authorizations:
     ```JavaScript
     const referrer = new URL(origin);
 
-    if(referrer.protocol === "https:" && referrer.host.endsWith("metamask.io")) { 
+    if(referrer.protocol === "https:" && referrer.host.endsWith(".metamask.io")) { 
       console.log("URL is valid"); 
     }
     else { 


### PR DESCRIPTION
Hey,
The code from the current guidelines:
```js
    const referrer = new URL(origin);

    if(referrer.protocol === "https:" && referrer.host.endsWith("metamask.io")) { 
      console.log("URL is valid"); 
    }
    else { 
      console.log("URL is NOT valid"); 
    }
```
will also end up matching the following URLs as valid URLs due to the functionality of .endsWith:
https://ametamask.io
https://abcdefgmetamask.io
The `.` is necessary before `metamask.io` to ensure the correct origin.
