### PR TITLE
Update security-guidelines.md

### DIFF
--- a/snaps/concepts/security-guidelines.md
+++ b/snaps/concepts/security-guidelines.md
@@ -75,7 +75,9 @@ The following are guidelines for user notifications and authorizations:
     ```JavaScript
     const referrer = new URL(origin);
 
-    if(referrer.protocol === "https:" && referrer.host.endsWith(".metamask.io")) { 
+    if(referrer.protocol === "https:" && 
+       (referrer.host.endsWith(".metamask.io") || 
+        referrer.host === "metamask.io")) { 
       console.log("URL is valid"); 
     }
     else { 


### PR DESCRIPTION
The URL matching code had an error for matching the domain name without any subdomain. The extra check on line 80 is needed to match https://metamask.io.

This fixes an error in the previous PR #1085 