### PR TITLE
Remove broken links

### DIFF
--- a/snaps/concepts/apis.md
+++ b/snaps/concepts/apis.md
@@ -44,12 +44,12 @@ await snap.request({
 Dapps can install and communicate with Snaps using the following
 [MetaMask JSON-RPC API](/wallet/reference/json-rpc-api) methods:
 
-- [`wallet_getSnap`](/wallet/reference/wallet_getsnap) - Gets the dapp's permitted Snaps.
-- [`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps) - Requests permission to
+- `wallet_getSnap` - Gets the dapp's permitted Snaps.
+- `wallet_requestSnaps` - Requests permission to
   communicate with the specified Snaps.
-- [`wallet_snap`](/wallet/reference/wallet_snap) - (Restricted) Calls the specified custom JSON-RPC
+- `wallet_snap` - (Restricted) Calls the specified custom JSON-RPC
   API method of the specified Snap.
-- [`wallet_invokeSnap`](/wallet/reference/wallet_invokesnap) - (Restricted) Synonymous with `wallet_snap`.
+- `wallet_invokeSnap` - (Restricted) Synonymous with `wallet_snap`.
 
 A dapp must first request permission to communicate with a Snap using `wallet_requestSnaps`.
 The dapp can then call `wallet_snap` or `wallet_invokeSnap` on the permitted Snap.

--- a/snaps/concepts/security-guidelines.md
+++ b/snaps/concepts/security-guidelines.md
@@ -174,7 +174,7 @@ The following are guidelines for validating RPC parameters and handling values:
 
 Avoid using the following deprecated methods:
 
-- `wallet_enable`, which is deprecated in favor of [`wallet_requestSnaps`](../reference/snaps-api.md#wallet_requestsnaps).
+- `wallet_enable`, which is deprecated in favor of `wallet_requestSnaps`.
 
 - `snap_confirm`, which is deprecated in favor of [`snap_dialog`](../reference/snaps-api.md#snap_dialog).
 

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -55,7 +55,7 @@ See the [`eth_accounts` dynamic permission](../reference/permissions.md#eth_acco
 ## Request permissions from a dapp
 
 Dapps that communicate with Snaps must request permission to do so by calling the
-[`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps) MetaMask JSON-RPC API method.
+`wallet_requestSnaps` MetaMask JSON-RPC API method.
 
 For example, to request permission to connect to the `hello-snap` Snap:
 

--- a/snaps/how-to/use-3rd-party-snaps.md
+++ b/snaps/how-to/use-3rd-party-snaps.md
@@ -11,7 +11,7 @@ This is possible because Snaps can expose a [custom JSON-RPC API](../concepts/ap
 
 ## Connect to a Snap
 
-Connect to a Snap by calling the [`wallet_requestSnaps`](../reference/snaps-api.md#wallet_requestsnaps)
+Connect to a Snap by calling the `wallet_requestSnaps`
 method from your dapp.
 If a user doesn't have the Snap installed in their MetaMask wallet, MetaMask prompts the user to
 install the Snap.
@@ -58,7 +58,7 @@ Do not assume that data stored by a Snap is unique to your dapp.
 
 ## Determine whether a Snap is installed
 
-Determine whether a Snap is installed by calling the [`wallet_getSnaps`](../reference/snaps-api.md#wallet_getsnaps)
+Determine whether a Snap is installed by calling the `wallet_getSnaps`
 method from your dapp.
 This method returns a list of only those Snaps that are connected to your current dapp.
 
@@ -96,7 +96,7 @@ to work with that version.
 At any time, a user can open their MetaMask Snaps settings menu and see all the dapps connected to a Snap.
 From that menu they can revoke a dapp connection.
 If your dapp loses the connection to a Snap, you can reconnect by calling
-[`wallet_requestSnaps`](../reference/snaps-api.md#wallet_requestsnaps).
+`wallet_requestSnaps`.
 Since the Snap is already installed, this returns a success response without MetaMask showing a pop-up.
 However, if the user has disabled the Snap, the response has `enabled` set to `false` for your `SNAP_ID`:
 


### PR DESCRIPTION
Remove links to Snaps wallet methods (temporarily, until the API reference is updated).