### PR TITLE
Add "Wallet API" terminology

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,8 +220,8 @@ const config = {
             to: "/wallet/concepts",
           },
           {
-            from: ["/guide/provider-migration", "/wallet/concepts/provider-api", "/wallet/concepts/rpc-api", "/wallet/how-to/migrate-api"],
-            to: "/wallet/concepts/apis",
+            from: ["/guide/provider-migration", "/wallet/concepts/provider-api", "/wallet/concepts/rpc-api", "/wallet/how-to/migrate-api", "/wallet/concepts/apis"],
+            to: "/wallet/concepts/wallet-api",
           },
           {
             from: "/wallet/category/tutorials",

--- a/src/components/WalletSection.tsx
+++ b/src/components/WalletSection.tsx
@@ -17,10 +17,10 @@ const CardList: CardItem[] = [
     </>),
   },
   {
-    title: "🌐 MetaMask JSON-RPC API",
+    title: "🌐 Wallet API",
     link: "/wallet/reference/json-rpc-api",
     description: (<>
-      Use the MetaMask JSON-RPC API to interact with your users&apos; Ethereum accounts.
+      Use the JSON-RPC methods of MetaMask&apos;s Wallet API to interact with your users&apos; Ethereum accounts.
     </>),
   },
 ];

--- a/wallet/concepts/architecture.md
+++ b/wallet/concepts/architecture.md
@@ -11,6 +11,6 @@ The following diagram outlines the high-level architecture of the MetaMask web3 
 
 Using [MetaMask SDK](sdk/index.md), dapps built on multiple platforms can connect to their users' Ethereum
 accounts through the MetaMask browser extension and MetaMask Mobile.
-Dapps can send [Wallet API](wallet-api.md) calls to the users' MetaMask wallet clients.
+Dapps can send [Wallet API](wallet-api.md) requests to the users' MetaMask wallet clients.
 MetaMask then responds to these requests directly or uses [Infura](https://www.infura.io/) (or
 another user-configured node provider) when the call requires access to information on a blockchain network.

--- a/wallet/concepts/architecture.md
+++ b/wallet/concepts/architecture.md
@@ -11,6 +11,6 @@ The following diagram outlines the high-level architecture of the MetaMask web3 
 
 Using [MetaMask SDK](sdk/index.md), dapps built on multiple platforms can connect to their users' Ethereum
 accounts through the MetaMask browser extension and MetaMask Mobile.
-Dapps can send [JSON-RPC API](apis.md#json-rpc-api) calls to the users' MetaMask wallet clients.
+Dapps can send [Wallet API](wallet-api.md) calls to the users' MetaMask wallet clients.
 MetaMask then responds to these requests directly or uses [Infura](https://www.infura.io/) (or
 another user-configured node provider) when the call requires access to information on a blockchain network.

--- a/wallet/concepts/convenience-libraries.md
+++ b/wallet/concepts/convenience-libraries.md
@@ -10,8 +10,8 @@ Some of them simplify the creation of specific user interface elements, some ent
 user account onboarding, and others give you a variety of methods for interacting with smart
 contracts, for a variety of API preferences (for example, promises, callbacks, and strong types).
 
-The [MetaMask Ethereum provider API](apis.md#ethereum-provider-api) is very simple, and wraps
-[Ethereum JSON-RPC](apis.md#json-rpc-api) formatted messages, which is why
+The [MetaMask Ethereum provider API](wallet-api.md#ethereum-provider-api) is very simple, and wraps
+[Ethereum JSON-RPC](wallet-api.md#json-rpc-api) formatted messages, which is why
 some developers use a convenience library for interacting with the provider, such as
 [Ethers](https://www.npmjs.com/package/ethers), [web3.js](https://www.npmjs.com/package/web3), and
 [Embark](https://framework.embarklabs.io/).
@@ -20,8 +20,7 @@ You can refer to those tools' documentation to use them.
 You can [use MetaMask SDK](../how-to/use-sdk/index.md), which provides a reliable, secure, and
 seamless connection from your dapp to MetaMask.
 It onboards users smoothly from multiple dapp platforms using the MetaMask browser extension or
-MetaMask Mobile, and your dapp can call any [provider API method](../reference/provider-api.md)
-with the SDK installed.
+MetaMask Mobile, and your dapp can call any [Wallet API](wallet-api.md) method with the SDK installed.
 
 You can also [use Web3-Onboard with MetaMask SDK](../how-to/use-3rd-party-integrations/web3-onboard.md)
 in your JavaScript dapp.

--- a/wallet/concepts/convenience-libraries.md
+++ b/wallet/concepts/convenience-libraries.md
@@ -20,7 +20,7 @@ You can refer to those tools' documentation to use them.
 You can [use MetaMask SDK](../how-to/use-sdk/index.md), which provides a reliable, secure, and
 seamless connection from your dapp to MetaMask.
 It onboards users smoothly from multiple dapp platforms using the MetaMask browser extension or
-MetaMask Mobile, and your dapp can call any [Wallet API](wallet-api.md) method with the SDK installed.
+MetaMask Mobile, and your dapp can call any [Wallet API](wallet-api.md) methods with the SDK installed.
 
 You can also [use Web3-Onboard with MetaMask SDK](../how-to/use-3rd-party-integrations/web3-onboard.md)
 in your JavaScript dapp.

--- a/wallet/concepts/sdk/index.md
+++ b/wallet/concepts/sdk/index.md
@@ -12,8 +12,8 @@ tags:
 
 MetaMask SDK is a library that provides a reliable, secure, and seamless connection from your dapp
 to the MetaMask browser extension and MetaMask Mobile.
-You can install the SDK in existing dapps, and call any
-[provider API methods](../../reference/provider-api.md) from your dapp.
+You can install the SDK in existing dapps, and call any [Wallet API](../wallet-api.md) methods from
+your dapp.
 Get started [using the SDK](../../how-to/use-sdk/index.md).
 
 ## Benefits of MetaMask SDK
@@ -22,22 +22,22 @@ MetaMask SDK enables your dapp to provide a seamless user experience for MetaMas
 multiple dapp platforms, without relying on third-party libraries.
 By integrating your dapp using the SDK, millions of MetaMask Mobile users can connect to their
 preferred MetaMask client.
-The SDK uses the [Ethereum provider](../apis.md#ethereum-provider-api), so existing dapps work out
-of the box with the SDK.
+The SDK uses the [MetaMask Ethereum provider](../wallet-api.md#ethereum-provider-api), so existing
+dapps work out of the box with the SDK.
 
 The following table outlines some of the features available when you integrate your dapp with
 MetaMask using the SDK.
-Most of these features are not available if you only integrate your dapp directly using the MetaMask
-provider API.
+Most of these features are not available if you only integrate your dapp directly using the
+[Wallet API](../wallet-api.md).
 
-| Feature                                                                                                  | MetaMask provider API only | MetaMask SDK |
-|----------------------------------------------------------------------------------------------------------|:--------------------------:|:------------:|
-| Connect from a web dapp to the MetaMask extension                                                        |             ✅              |      ✅       |
-| Connect from a web dapp to MetaMask Mobile                                                               |             ❌              |      ✅       |
-| Connect from desktop, mobile, and gaming dapps to MetaMask Mobile                                        |             ❌              |      ✅       |
-| Use custom RPC methods such as [`connectAndSign`](../../how-to/sign-data/connect-and-sign.md)            |             ❌              |      ✅       |
-| [Batch multiple RPC requests](../../how-to/batch-json-rpc-requests.md)                                   |             ❌              |      ✅       |
-| [Make read-only requests](../../how-to/use-3rd-party-integrations/js-infura-api.md) using the Infura API |             ❌              |      ✅       |
+| Feature                                                                                                  | Wallet API only | MetaMask SDK |
+|----------------------------------------------------------------------------------------------------------|:---------------:|:------------:|
+| Connect from a web dapp to the MetaMask extension                                                        |        ✅        |      ✅       |
+| Connect from a web dapp to MetaMask Mobile                                                               |        ❌        |      ✅       |
+| Connect from desktop, mobile, and gaming dapps to MetaMask Mobile                                        |        ❌        |      ✅       |
+| Use custom RPC methods such as [`connectAndSign`](../../how-to/sign-data/connect-and-sign.md)            |        ❌        |      ✅       |
+| [Batch multiple RPC requests](../../how-to/batch-json-rpc-requests.md)                                   |        ❌        |      ✅       |
+| [Make read-only requests](../../how-to/use-3rd-party-integrations/js-infura-api.md) using the Infura API |        ❌        |      ✅       |
 
 ## User experience
 

--- a/wallet/concepts/wallet-api.md
+++ b/wallet/concepts/wallet-api.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 description: Learn about the MetaMask Ethereum provider API.
 ---
 
-# About the MetaMask APIs
+# About the Wallet API
 
 MetaMask supports an [Ethereum provider API](#ethereum-provider-api), which wraps a [JSON-RPC API](#json-rpc-api).
 

--- a/wallet/concepts/wallet-api.md
+++ b/wallet/concepts/wallet-api.md
@@ -5,7 +5,8 @@ description: Learn about the MetaMask Ethereum provider API.
 
 # About the Wallet API
 
-MetaMask supports an [Ethereum provider API](#ethereum-provider-api), which wraps a [JSON-RPC API](#json-rpc-api).
+MetaMask's Wallet API consists of an [Ethereum provider API](#ethereum-provider-api), which wraps
+a [JSON-RPC API](#json-rpc-api).
 
 :::tip API documentation
 The API methods are documented in the following references:

--- a/wallet/concepts/wallet-api.md
+++ b/wallet/concepts/wallet-api.md
@@ -51,16 +51,6 @@ method of the [provider API](#ethereum-provider-api) to wrap a JSON-RPC API.
 The JSON-RPC API contains standard Ethereum JSON-RPC API methods and MetaMask-specific methods.
 
 The RPC methods are documented in the interactive [JSON-RPC API reference](/wallet/reference/json-rpc-api).
-Methods in the API playground may have the following tags:
-
-- **MetaMask** - These methods behave in ways specific to MetaMask, and may or may not be supported
-  by other wallets.
-- **Restricted** - These methods are [restricted](#restricted-methods), which require requesting
-  permission using [`wallet_requestPermissions`](/wallet/reference/wallet_requestpermissions).
-- **Mobile** - These methods are only available on MetaMask Mobile.
-- **Ethereum API** - These are standard Ethereum JSON-RPC API methods.
-  See the [Ethereum wiki](https://eth.wiki/json-rpc/API#json-rpc-methods) for more information on
-  these methods.
 
 :::note
 All RPC method requests can return errors.

--- a/wallet/concepts/wallet-interoperabilty.md
+++ b/wallet/concepts/wallet-interoperabilty.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 
 A web dapp can integrate with multiple wallets simultaneously by adding support for
 [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963), which introduces an alternative discovery
-mechanism to the [`window.ethereum`](apis.md#ethereum-provider-api) injected provider.
+mechanism to the [`window.ethereum`](wallet-api.md#ethereum-provider-api) injected provider.
 This discovery is enabled by using the standardized events and interfaces defined by EIP-6963.
 
 The following is a visual demo of the user experience, showing the data provided from each installed wallet:

--- a/wallet/index.mdx
+++ b/wallet/index.mdx
@@ -6,7 +6,7 @@ import CardList from '@site/src/components/CardList'
 
 # Integrate your dapp with the MetaMask wallet
 
-Integrate your dapp with the MetaMask wallet using the [MetaMask APIs](concepts/apis.md).
+Integrate your dapp with the MetaMask wallet using the [Wallet API](concepts/wallet-api.md).
 You can interact with your users' Ethereum accounts, performing tasks such as the following:
 
 <CardList
@@ -75,9 +75,9 @@ If you're new integrating dapps with MetaMask, check out the following topics:
       description: "Learn about the high-level MetaMask architecture.",
     },
     {
-      href: "concepts/apis",
-      title: "🌐 About the APIs",
-      description: "Learn about the MetaMask Ethereum provider API and JSON-RPC API.",
+      href: "concepts/wallet-api",
+      title: "🌐 About the Wallet API",
+      description: "Learn about the MetaMask Wallet API and its components.",
     },
     {
       href: "concepts/sdk",

--- a/wallet/index.mdx
+++ b/wallet/index.mdx
@@ -6,7 +6,7 @@ import CardList from '@site/src/components/CardList'
 
 # Integrate your dapp with the MetaMask wallet
 
-Integrate your dapp with the MetaMask wallet using the [Wallet API](concepts/wallet-api.md).
+Integrate your dapp with the MetaMask wallet using the [Wallet API](reference/json-rpc-api).
 You can interact with your users' Ethereum accounts, performing tasks such as the following:
 
 <CardList
@@ -77,7 +77,7 @@ If you're new integrating dapps with MetaMask, check out the following topics:
     {
       href: "concepts/wallet-api",
       title: "🌐 About the Wallet API",
-      description: "Learn about the MetaMask Wallet API and its components.",
+      description: "Learn about MetaMask's Wallet API and its components.",
     },
     {
       href: "concepts/sdk",

--- a/wallet/quickstart/javascript.md
+++ b/wallet/quickstart/javascript.md
@@ -10,14 +10,13 @@ JavaScript dapp.
 You can:
 
 - [Connect to the MetaMask browser extension](#connect-to-the-metamask-browser-extension) directly
-  using the MetaMask APIs.
+  using the Wallet API.
 - [Connect to the MetaMask extension and MetaMask Mobile](#connect-to-the-metamask-extension-and-metamask-mobile)
-  using the SDK.
+  using MetaMask SDK.
 
 ## Connect to the MetaMask browser extension
 
-Connect to the MetaMask browser extension directly using the
-[MetaMask Ethereum provider API](../concepts/apis.md).
+Connect to the MetaMask browser extension directly using the [Wallet API](../concepts/wallet-api.md).
 You must [detect MetaMask](/wallet/how-to/detect-wallet) in the user's browser, then
 [access the user's accounts](../how-to/access-accounts.md) by prompting them to connect to MetaMask.
 
@@ -81,9 +80,9 @@ By integrating your dapp using the SDK, millions of MetaMask Mobile users can co
 preferred MetaMask client.
 
 :::info note
-The SDK uses the [Ethereum provider](../concepts/apis.md#ethereum-provider-api), so you can use the
-SDK as a wrapper around an existing JavaScript dapp and call
-[MetaMask Ethereum provider API methods](../reference/provider-api.md) from your dapp as normal.
+The SDK uses the [MetaMask Ethereum provider](../concepts/wallet-api.md#ethereum-provider-api), so
+you can use the SDK as a wrapper around an existing JavaScript dapp and call Wallet API methods from
+your dapp as normal.
 :::
 
 1. Install the [MetaMask JavaScript SDK](../how-to/use-sdk/javascript/index.md) in your project directory:

--- a/wallet/quickstart/react.md
+++ b/wallet/quickstart/react.md
@@ -10,14 +10,13 @@ React dapp.
 You can:
 
 - [Connect to the MetaMask browser extension](#connect-to-the-metamask-browser-extension)
-  directly using the MetaMask APIs.
+  directly using the Wallet API.
 - [Connect to the MetaMask extension and MetaMask mobile](#connect-to-the-metamask-extension-and-metamask-mobile)
-  using the SDK.
+  using MetaMask SDK.
 
 ## Connect to the MetaMask browser extension
 
-Connect to the MetaMask browser extension directly using the
-[MetaMask Ethereum provider API](../concepts/apis.md).
+Connect to the MetaMask browser extension directly using the [Wallet API](../concepts/wallet-api.md).
 This example uses the [Vite](https://v3.vitejs.dev/guide/) build tool with React and Typescript, so
 you can get started quickly with an optimized dapp.
 
@@ -81,9 +80,9 @@ By integrating your dapp using the SDK, millions of MetaMask Mobile users can co
 preferred MetaMask client.
 
 :::info note
-The SDK uses the [Ethereum provider](../concepts/apis.md#ethereum-provider-api), so you can use the
-SDK as a wrapper around an existing JavaScript dapp and call
-[MetaMask Ethereum provider API methods](../reference/provider-api.md) from your dapp as normal.
+The SDK uses the [MetaMask Ethereum provider](../concepts/wallet-api.md#ethereum-provider-api), so
+you can use the SDK as a wrapper around an existing JavaScript dapp and call Wallet API methods from
+your dapp as normal.
 :::
 
 1. Install the [MetaMask React SDK](../how-to/use-sdk/javascript/react/index.md) in your project directory:

--- a/wallet/reference/provider-api.md
+++ b/wallet/reference/provider-api.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Ethereum provider API
 
-MetaMask injects the [provider API](../concepts/apis.md#ethereum-provider-api) into websites visited
+MetaMask injects the [provider API](../concepts/wallet-api.md#ethereum-provider-api) into websites visited
 by its users using the `window.ethereum` provider object.
 You can use the provider [properties](#properties), [methods](#methods), and [events](#events) in
 your dapp.

--- a/wallet/reference/provider-api.md
+++ b/wallet/reference/provider-api.md
@@ -5,10 +5,9 @@ sidebar_position: 3
 
 # Ethereum provider API
 
-MetaMask injects the [provider API](../concepts/wallet-api.md#ethereum-provider-api) into websites visited
-by its users using the `window.ethereum` provider object.
-You can use the provider [properties](#properties), [methods](#methods), and [events](#events) in
-your dapp.
+This section provides a reference for the the Ethereum provider API of MetaMask's [Wallet API](../concepts/wallet-api.md).
+MetaMask injects the provider API into websites visited by its users using the `window.ethereum` provider object.
+You can use the provider [properties](#properties), [methods](#methods), and [events](#events) in your dapp.
 
 ## Properties
 


### PR DESCRIPTION
Add "Wallet API" terminology. Fixes #1120.

This PR is conjunction with https://github.com/MetaMask/api-specs/pull/185, which updates the JSON-RPC reference index page to mention the Wallet API.

Preview: https://docs.metamask.io/1120-wallet-api/