### PR TITLE
Update VSCode shared settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.codeActionsOnSave.mode": "all",
   "editor.tabSize": 2,


### PR DESCRIPTION
Since VSCode 1.85 `true` has to be `"explicit"` instead.