### PR TITLE
Update multiple-wallets.md

### DIFF
--- a/wallet/how-to/detect-wallet/multiple-wallets.md
+++ b/wallet/how-to/detect-wallet/multiple-wallets.md
@@ -31,6 +31,7 @@ You can add support for EIP-6963 by using the following third-party libraries:
 - [Web3Modal 3+](https://docs.walletconnect.com/web3modal/about)
 
 - [MIPD Store](https://github.com/wevm/mipd)
+
 - [RainbowKit](https://www.rainbowkit.com/)
 
 ## Implement EIP-6963

--- a/wallet/how-to/detect-wallet/multiple-wallets.md
+++ b/wallet/how-to/detect-wallet/multiple-wallets.md
@@ -31,6 +31,7 @@ You can add support for EIP-6963 by using the following third-party libraries:
 - [Web3Modal 3+](https://docs.walletconnect.com/web3modal/about)
 
 - [MIPD Store](https://github.com/wevm/mipd)
+- [RainbowKit](https://www.rainbowkit.com/)
 
 ## Implement EIP-6963
 


### PR DESCRIPTION
Adding the RainbowKit to the List of libraries with EIP-6963 support . This is a solution to issue: Update pages that reference libraries with EIP-6963 support #1141