### PR TITLE
WIP: Clean up Snaps code samples

### DIFF
--- a/snaps/features/custom-evm-accounts/create-account-snap.md
+++ b/snaps/features/custom-evm-accounts/create-account-snap.md
@@ -16,11 +16,15 @@ Create an account management Snap to connect to custom EVM accounts.
 :::
 
 :::tip see also
+<<<<<<< Updated upstream:snaps/features/custom-evm-accounts/create-account-snap.md
 - [About custom EVM accounts](index.md)
+=======
+
+>>>>>>> Stashed changes:snaps/how-to/use-keyring-api/create-account-snap.md
 - [Create an account management companion dapp](create-companion-dapp.md)
 - [Account management Snap security guidelines](security.md)
 - [Keyring API reference](../../reference/keyring-api/index.md)
-:::
+  :::
 
 ## Prerequisites
 
@@ -136,48 +140,49 @@ Notify MetaMask when the following events take place, using the `emitSnapKeyring
 
 - An account is created:
 
-   ```typescript
-   try {
-     emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, { account });
-     // Update your Snap's state...
-   } catch (error) {
-     // Handle the error...
-   }
-   ```
+  ```typescript
+  try {
+    emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, { account });
+    // Update your Snap's state...
+  } catch (error) {
+    // Handle the error...
+  }
+  ```
 
-   MetaMask returns an error if the account already exists or the account object is invalid.
+  MetaMask returns an error if the account already exists or the account object is invalid.
 
 - An account is updated:
 
-   ```typescript
-   try {
-     emitSnapKeyringEvent(snap, KeyringEvent.AccountUpdated, { account });
-     // Update your Snap's state...
-   } catch (error) {
-     // Handle the error...
-   }
-   ```
-  
-   MetaMask returns an error if the account does not exist, the account object is invalid, or the
-   account address changes.
+  ```typescript
+  try {
+    emitSnapKeyringEvent(snap, KeyringEvent.AccountUpdated, { account });
+    // Update your Snap's state...
+  } catch (error) {
+    // Handle the error...
+  }
+  ```
+
+  MetaMask returns an error if the account does not exist, the account object is invalid, or the
+  account address changes.
 
 - An account is deleted:
 
-   ```typescript
-   try {
-     emitSnapKeyringEvent(snap, KeyringEvent.AccountDeleted, {
-       id: account.id,
-     });
-     // Update your Snap's state...
-   } catch (error) {
-     // Handle the error...
-   }
-   ```
-  
-   The delete event is idempotent, so it is safe to emit even if the account does not exist.
+  ```typescript
+  try {
+    emitSnapKeyringEvent(snap, KeyringEvent.AccountDeleted, {
+      id: account.id,
+    });
+    // Update your Snap's state...
+  } catch (error) {
+    // Handle the error...
+  }
+  ```
+
+  The delete event is idempotent, so it is safe to emit even if the account does not exist.
 
 - A request is approved:
 
+<<<<<<< Updated upstream:snaps/features/custom-evm-accounts/create-account-snap.md
    ```typescript
    try {
      emitSnapKeyringEvent(snap, KeyringEvent.RequestApproved, {
@@ -210,6 +215,40 @@ Notify MetaMask when the following events take place, using the `emitSnapKeyring
    MetaMask returns an error if the request does not exist.
    This event only applies to Snaps that implement the
    [asynchronous transaction flow](index.md#asynchronous-transaction-flow).
+=======
+  ```typescript
+  try {
+    emitSnapKeyringEvent(snap, KeyringEvent.RequestApproved, {
+      id: request.id,
+      result,
+    });
+    // Update your Snap's state...
+  } catch (error) {
+    // Handle the error...
+  }
+  ```
+
+  MetaMask returns an error if the request does not exist.
+  This event only applies to Snaps that implement the
+  [asynchronous transaction flow](../../concepts/keyring-api.md#asynchronous-transaction-flow).
+
+- A request is rejected:
+
+  ```typescript
+  try {
+    emitSnapKeyringEvent(snap, KeyringEvent.RequestRejected, {
+      id: request.id,
+    });
+    // Update your Snap's state...
+  } catch (error) {
+    // Handle the error...
+  }
+  ```
+
+  MetaMask returns an error if the request does not exist.
+  This event only applies to Snaps that implement the
+  [asynchronous transaction flow](../../concepts/keyring-api.md#asynchronous-transaction-flow).
+>>>>>>> Stashed changes:snaps/how-to/use-keyring-api/create-account-snap.md
 
 ### 6. Expose the Keyring API
 

--- a/snaps/features/custom-evm-accounts/create-companion-dapp.md
+++ b/snaps/features/custom-evm-accounts/create-companion-dapp.md
@@ -17,10 +17,14 @@ EVM accounts.
 :::
 
 :::tip see also
+<<<<<<< Updated upstream:snaps/features/custom-evm-accounts/create-companion-dapp.md
 - [About custom EVM accounts](index.md)
+=======
+
+>>>>>>> Stashed changes:snaps/how-to/use-keyring-api/create-companion-dapp.md
 - [Create an account management Snap](create-account-snap.md)
 - [Keyring API reference](../../reference/keyring-api/index.md)
-:::
+  :::
 
 ## Prerequisites
 
@@ -48,7 +52,7 @@ Create the [`KeyringSnapRpcClient`](../../reference/keyring-api/classes/KeyringS
 
 ```ts
 import { KeyringSnapRpcClient } from "@metamask/keyring-api";
-import { defaultSnapOrigin as snapId } from '../config';
+import { defaultSnapOrigin as snapId } from "../config";
 
 let client = new KeyringSnapRpcClient(snapId, window.ethereum);
 ```

--- a/snaps/features/custom-evm-accounts/index.md
+++ b/snaps/features/custom-evm-accounts/index.md
@@ -26,11 +26,20 @@ to enable users to create and interact with the custom accounts.
 :::
 
 :::tip see also
+<<<<<<< Updated upstream:snaps/features/custom-evm-accounts/index.md
 - [Create an account management Snap](create-account-snap.md)
 - [Create an account management companion dapp](create-companion-dapp.md)
 - [Account management Snap security guidelines](security.md)
 - [Keyring API reference](../../reference/keyring-api/index.md)
 :::
+=======
+
+- [Create an account management Snap](../how-to/use-keyring-api/create-account-snap.md)
+- [Create an account management companion dapp](../how-to/use-keyring-api/create-companion-dapp.md)
+- [Account management Snap security guidelines](../how-to/use-keyring-api/security.md)
+- [Keyring API reference](../reference/keyring-api/index.md)
+  :::
+>>>>>>> Stashed changes:snaps/concepts/keyring-api.md
 
 ## System context diagram
 

--- a/snaps/features/custom-evm-accounts/security.md
+++ b/snaps/features/custom-evm-accounts/security.md
@@ -14,11 +14,15 @@ Refer to the following security guidelines when [creating an account management 
 :::
 
 :::tip see also
+<<<<<<< Updated upstream:snaps/features/custom-evm-accounts/security.md
 - [About custom EVM accounts](index.md)
+=======
+
+>>>>>>> Stashed changes:snaps/how-to/use-keyring-api/security.md
 - [Create an account management Snap](create-account-snap.md)
 - [Create an account management companion dapp](create-companion-dapp.md)
 - [Keyring API reference](../../reference/keyring-api/index.md)
-:::
+  :::
 
 ## Do not add secret information to account objects
 
@@ -29,41 +33,41 @@ For example:
 
 - ❌ **Do NOT do this:**
 
-    ```ts
-    const account: KeyringAccount = {
-      id: uuid(),
-      options: {
-        privateKey: '0x01234...78', // !!! DO NOT DO THIS !!!
-      },
-      address,
-      methods: [
-        EthMethod.PersonalSign,
-        EthMethod.Sign,
-        EthMethod.SignTransaction,
-        EthMethod.SignTypedDataV1,
-        EthMethod.SignTypedDataV3,
-        EthMethod.SignTypedDataV4,
-      ],
-      type: EthAccountType.Eoa,
-    };
-    ```
+  ```ts
+  const account: KeyringAccount = {
+    id: uuid(),
+    options: {
+      privateKey: "0x01234...78", // !!! DO NOT DO THIS !!!
+    },
+    address,
+    methods: [
+      EthMethod.PersonalSign,
+      EthMethod.Sign,
+      EthMethod.SignTransaction,
+      EthMethod.SignTypedDataV1,
+      EthMethod.SignTypedDataV3,
+      EthMethod.SignTypedDataV4,
+    ],
+    type: EthAccountType.Eoa,
+  };
+  ```
 
 - ✅ **Do this instead:**
 
-    *Store any secret information that you need in the Snap's state:*
-    
-    ```ts
-    await snap.request({
-      method: 'snap_manageState',
-      params: {
-        operation: 'update',
-        newState: {
-          // Your Snap's state here...
-          privateKey: '0x01234...78',
-        },
+  _Store any secret information that you need in the Snap's state:_
+
+  ```ts
+  await snap.request({
+    method: "snap_manageState",
+    params: {
+      operation: "update",
+      newState: {
+        // Your Snap's state here...
+        privateKey: "0x01234...78",
       },
-    });
-    ```
+    },
+  });
+  ```
 
 ## Limit the methods exposed to dapps
 
@@ -71,7 +75,7 @@ By default, MetaMask enforces the following restrictions on calling Keyring API 
 based on the caller origin:
 
 | Method                        |  MetaMask origin   |    Dapp origin     |
-|:------------------------------|:------------------:|:------------------:|
+| :---------------------------- | :----------------: | :----------------: |
 | `keyring_listAccounts`        | :white_check_mark: | :white_check_mark: |
 | `keyring_getAccount`          | :white_check_mark: | :white_check_mark: |
 | `keyring_createAccount`       |        :x:         | :white_check_mark: |
@@ -103,15 +107,15 @@ The following is an example of implementing such logic:
 
 ```ts
 const permissions: Record<string, string[]> = {
-  'https://<Dapp 1 domain>': [
+  "https://<Dapp 1 domain>": [
     // List of allowed methods for Dapp 1.
   ],
-  'https://<Dapp 2 domain>': [
+  "https://<Dapp 2 domain>": [
     // List of allowed methods for Dapp 2.
   ],
 };
 
-if (origin !== 'metamask' && !permissions[origin]?.includes(request.method)) {
+if (origin !== "metamask" && !permissions[origin]?.includes(request.method)) {
   // Reject the request.
 }
 ```
@@ -175,7 +179,7 @@ For example:
     const privateKey = toBuffer(inputSecretValue);
     // Use `privateKey` here...
   } catch (error) {
-    throw new Error('Invalid private key');
+    throw new Error("Invalid private key");
   }
   ```
 

--- a/snaps/features/custom-ui.md
+++ b/snaps/features/custom-ui.md
@@ -20,13 +20,13 @@ package and build your UI with them.
 For example:
 
 ```javascript
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { panel, heading, text } from "@metamask/snaps-ui";
 
 // ...
 
 const content = panel([
-  heading('Alert heading'),
-  text('Something happened in the system.'),
+  heading("Alert heading"),
+  text("Something happened in the system."),
 ]);
 
 return content;
@@ -41,11 +41,11 @@ The `NodeType` enum exported by `@metamask/snaps-ui` details the available compo
 Outputs a read-only text field with a copy-to-clipboard shortcut.
 
 ```javascript
-import { copyable } from '@metamask/snaps-ui';
+import { copyable } from "@metamask/snaps-ui";
 
 // ...
 
-const content = copyable('Text to be copied');
+const content = copyable("Text to be copied");
 ```
 
 ### `divider`
@@ -53,14 +53,14 @@ const content = copyable('Text to be copied');
 Outputs a horizontal divider.
 
 ```javascript
-import { panel, divider, text } from '@metamask/snaps-ui';
+import { panel, divider, text } from "@metamask/snaps-ui";
 
 // ...
 
 const content = panel([
-  text('Text before the divider'),
+  text("Text before the divider"),
   divider(),
-  text('Text after the divider'),
+  text("Text after the divider"),
 ]);
 ```
 
@@ -70,30 +70,32 @@ Outputs a heading.
 This is useful for [panel](#panel) titles.
 
 ```javascript
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { panel, heading, text } from "@metamask/snaps-ui";
 
 // ...
 
 const content = panel([
-  heading('Title of the panel'),
-  text('Text of the panel'),
+  heading("Title of the panel"),
+  text("Text of the panel"),
 ]);
 ```
 
 ### `image`
 
-Outputs an image. 
-This component takes an inline SVG. 
-It does not support remote URLs. 
-You can embed JPG or PNG in SVG using data URIs. 
+Outputs an image.
+This component takes an inline SVG.
+It does not support remote URLs.
+You can embed JPG or PNG in SVG using data URIs.
 The SVG is rendered within an \<img\> tag, which prevents JavaScript or interaction events from being supported.
 
 ```javascript
-import { image } from '@metamask/snaps-ui';
+import { image } from "@metamask/snaps-ui";
 
 // ...
 
-const content = image('<svg width="400" height="400" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m2.514 17.874 9 5c.021.011.043.016.064.026s.051.021.078.031a.892.892 0 0 0 .688 0c.027-.01.052-.019.078-.031s.043-.015.064-.026l9-5A1 1 0 0 0 22 16.9L21 7V2a1 1 0 0 0-1.625-.781L14.649 5h-5.3L4.625 1.219A1 1 0 0 0 3 2v4.9l-1 10a1 1 0 0 0 .514.974ZM5 7V4.081l3.375 2.7A1 1 0 0 0 9 7h6a1 1 0 0 0 .625-.219L19 4.079V7.1l.934 9.345L13 20.3v-2.967l1.42-.946A1.3 1.3 0 0 0 15 15.3a1.3 1.3 0 0 0-1.3-1.3h-3.4A1.3 1.3 0 0 0 9 15.3a1.3 1.3 0 0 0 .58 1.084l1.42.946v2.97l-6.94-3.855Zm3.5 6a2 2 0 1 1 2-2 2 2 0 0 1-2 2Zm5-2a2 2 0 1 1 2 2 2 2 0 0 1-2-2Z"/></svg>');
+const content = image(
+  '<svg width="400" height="400" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m2.514 17.874 9 5c.021.011.043.016.064.026s.051.021.078.031a.892.892 0 0 0 .688 0c.027-.01.052-.019.078-.031s.043-.015.064-.026l9-5A1 1 0 0 0 22 16.9L21 7V2a1 1 0 0 0-1.625-.781L14.649 5h-5.3L4.625 1.219A1 1 0 0 0 3 2v4.9l-1 10a1 1 0 0 0 .514.974ZM5 7V4.081l3.375 2.7A1 1 0 0 0 9 7h6a1 1 0 0 0 .625-.219L19 4.079V7.1l.934 9.345L13 20.3v-2.967l1.42-.946A1.3 1.3 0 0 0 15 15.3a1.3 1.3 0 0 0-1.3-1.3h-3.4A1.3 1.3 0 0 0 9 15.3a1.3 1.3 0 0 0 .58 1.084l1.42.946v2.97l-6.94-3.855Zm3.5 6a2 2 0 1 1 2-2 2 2 0 0 1-2 2Zm5-2a2 2 0 1 1 2 2 2 2 0 0 1-2-2Z"/></svg>'
+);
 ```
 
 ### `panel`
@@ -101,7 +103,7 @@ const content = image('<svg width="400" height="400" viewBox="0 0 24 24" xmlns="
 Outputs a panel, which can be used as a container for other components.
 
 ```javascript
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { panel, heading, text } from "@metamask/snaps-ui";
 
 // ...
 
@@ -109,7 +111,7 @@ const insights = [
   /*...*/
 ];
 const content = panel([
-  heading('Here are the transaction insights'),
+  heading("Here are the transaction insights"),
   ...insights.map((insight) => text(insight.description)),
 ]);
 ```
@@ -119,11 +121,11 @@ const content = panel([
 Outputs a loading indicator.
 
 ```javascript
-import { panel, heading, spinner } from '@metamask/snaps-ui';
+import { panel, heading, spinner } from "@metamask/snaps-ui";
 
 // ...
 
-const content = panel([heading('Please wait...'), spinner()]);
+const content = panel([heading("Please wait..."), spinner()]);
 ```
 
 ### `text`
@@ -131,11 +133,11 @@ const content = panel([heading('Please wait...'), spinner()]);
 Outputs text.
 
 ```javascript
-import { text } from '@metamask/snaps-ui';
+import { text } from "@metamask/snaps-ui";
 
 // ...
 
-const content = text('This is a simple text UI');
+const content = text("This is a simple text UI");
 ```
 
 ## Markdown

--- a/snaps/features/localization.md
+++ b/snaps/features/localization.md
@@ -50,13 +50,13 @@ You can then use these files in a localization module.
 The following is an example module:
 
 ```ts
-import da from '../locales/da.json';
-import en from '../locales/en.json';
-import nl from '../locales/nl.json';
+import da from "../locales/da.json";
+import en from "../locales/en.json";
+import nl from "../locales/nl.json";
 
 // Default language, to be used if there is not a valid translation in
 // the requested locale.
-const FALLBACK_LANGUAGE: Locale = 'en';
+const FALLBACK_LANGUAGE: Locale = "en";
 
 export const locales = {
   da: da.messages,
@@ -67,7 +67,7 @@ export const locales = {
 export type Locale = keyof typeof locales;
 
 export async function getMessage(id: keyof (typeof locales)[Locale]) {
-  const locale = (await snap.request({ method: 'snap_getLocale' })) as Locale;
+  const locale = (await snap.request({ method: "snap_getLocale" })) as Locale;
   const { message } = locales[locale]?.[id] ?? locales[FALLBACK_LANGUAGE][id];
 
   return message;
@@ -80,15 +80,15 @@ English as the default if the user's locale isn't available.
 The following is an example of using `getMessage` in a Snap's RPC request handler:
 
 ```ts
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { rpcErrors } from "@metamask/rpc-errors";
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
 
-import { getMessage } from './locales';
+import { getMessage } from "./locales";
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
-    case 'hello':
-      return await getMessage('hello');
+    case "hello":
+      return await getMessage("hello");
 
     default:
       throw rpcErrors.methodNotFound({
@@ -98,7 +98,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 };
 ```
 
-###  3. Localize the Snap's manifest file
+### 3. Localize the Snap's manifest file
 
 The Snap [manifest file](../learn/about-snaps/files.md#manifest-file) contains textual metadata such as
 `proposedName` and `description` that you can localize to display in the user's language.
@@ -112,11 +112,7 @@ The following is an example of a localized manifest file:
   "proposedName": "{{ name }}",
   "source": {
     "shasum": "XXX",
-    "locales": [
-      "locales/da.json",
-      "locales/en.json",
-      "locales/nl.json"
-    ]
+    "locales": ["locales/da.json", "locales/en.json", "locales/nl.json"]
   },
   "initialPermissions": {
     "snap_getLocale": {}

--- a/snaps/features/non-evm-networks.md
+++ b/snaps/features/non-evm-networks.md
@@ -45,15 +45,15 @@ The general rule is: **Don't create a situation where your users can lose assets
 To derive a user's private keys:
 
 1. Choose between the BIP-32 or BIP-44 specifications to derive the user's private keys.
-    If the keys you want to derive conform to the
-    [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) structure, use
-    [`snap_getBip44Entropy`](../reference/snaps-api.md#snap_getbip44entropy) to derive them.
-    Otherwise, use [`snap_getBip32Entropy`](../reference/snaps-api.md#snap_getbip32entropy).
+   If the keys you want to derive conform to the
+   [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) structure, use
+   [`snap_getBip44Entropy`](../reference/snaps-api.md#snap_getbip44entropy) to derive them.
+   Otherwise, use [`snap_getBip32Entropy`](../reference/snaps-api.md#snap_getbip32entropy).
 2. Add the required permission to your manifest file.
 3. Find out the derivation path to use.
-    This is dependent on the application you're building.
+   This is dependent on the application you're building.
 4. Use the [`@metamask/key-tree`](https://github.com/MetaMask/key-tree) module to derive the keys.
-    Any additional code, for example, to derive addresses from keys, is application-specific.
+   Any additional code, for example, to derive addresses from keys, is application-specific.
 
 ### Dogecoin example
 
@@ -84,11 +84,11 @@ For example, to derive Dogecoin keys:
    To get the second Dogecoin account, add the following code to your Snap:
 
    ```javascript
-   import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+   import { getBIP44AddressKeyDeriver } from "@metamask/key-tree";
 
    // Get the Dogecoin node, corresponding to the path m/44'/3'.
    const dogecoinNode = await snap.request({
-     method: 'snap_getBip44Entropy',
+     method: "snap_getBip44Entropy",
      params: {
        coinType: 3,
      },
@@ -103,7 +103,7 @@ For example, to derive Dogecoin keys:
    // Derive the second Dogecoin address, which has index 1.
    const secondAccount = deriveDogecoinAddress(1);
    ```
-   
+
 ## Examples
 
 The following are examples of existing Snaps that manage accounts and keys:

--- a/snaps/get-started/install-flask.md
+++ b/snaps/get-started/install-flask.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 # Install MetaMask Flask
 
 To get started building your own Snaps, install the MetaMask Flask browser extension on
-[Google Chrome](https://chromewebstore.google.com/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk) 
-or 
+[Google Chrome](https://chromewebstore.google.com/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk)
+or
 [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/metamask-flask/).
 
 Install Flask in a new browser profile, or disable any existing installed versions of MetaMask
@@ -28,7 +28,7 @@ If you import accounts with funds into Flask, you do so at your own risk.
 
 MetaMask Flask is an experimental playground that provides developers access to upcoming MetaMask features.
 While a small set of audited Snaps are allowlisted in the stable version of the MetaMask browser extension, MetaMask Flask is intended for developers building and testing Snaps locally or from npm.
-Also, new Snaps API features are enabled in Flask for testing and developer feedback before they're enabled in MetaMask stable. 
-These features appear in the documentation with the **Flask** or **FLASK ONLY** tag. 
-You can also view Flask-specific features by looking for the **\[FLASK\]** label in the 
+Also, new Snaps API features are enabled in Flask for testing and developer feedback before they're enabled in MetaMask stable.
+These features appear in the documentation with the **Flask** or **FLASK ONLY** tag.
+You can also view Flask-specific features by looking for the **\[FLASK\]** label in the
 [MetaMask Extension changelog](https://github.com/MetaMask/metamask-extension/blob/develop/CHANGELOG.md).

--- a/snaps/how-to/communicate-errors.md
+++ b/snaps/how-to/communicate-errors.md
@@ -17,13 +17,13 @@ then throw them where needed.
 For example:
 
 ```typescript
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { MethodNotFoundError } from '@metamask/snaps-sdk';
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { MethodNotFoundError } from "@metamask/snaps-sdk";
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
-    case 'hello':
-      return 'Hello World!';
+    case "hello":
+      return "Hello World!";
     default:
       // Throw a known error to avoid crashing the Snap
       throw new MethodNotFoundError();
@@ -37,7 +37,7 @@ The error class constructors exported by `@metamask/snaps-sdk` have the followin
 
 ```typescript
 class SnapJsonRpcError extends SnapError {
-  new (message?: string, data?: Record<string, Json>)
+  new(message?: string, data?: Record<string, Json>);
 }
 ```
 

--- a/snaps/how-to/connect-to-a-snap.md
+++ b/snaps/how-to/connect-to-a-snap.md
@@ -75,15 +75,15 @@ with the following shape:
 
 ```json
 {
-    "SNAP_ID": {
-        "blocked": false,
-        "enabled": true,
-        "id": "SNAP_ID",
-        "initialPermissions": {
-            // ...all the permissions in the Snap's manifest
-        },
-        "version": "SNAP_VERSION"
-    }
+  "SNAP_ID": {
+    "blocked": false,
+    "enabled": true,
+    "id": "SNAP_ID",
+    "initialPermissions": {
+      // ...all the permissions in the Snap's manifest
+    },
+    "version": "SNAP_VERSION"
+  }
 }
 ```
 
@@ -96,7 +96,7 @@ new installation of the Snap, but the user won't see a confirmation pop-up askin
 Snaps are installed into the MetaMask instance of each user.
 If a Snap stores data, that data is specific to that user's MetaMask instance.
 However, that data can be shared with multiple dapps.
-Do not assume that data stored by a Snap is unique to your dapp. 
+Do not assume that data stored by a Snap is unique to your dapp.
 :::
 
 ## Determine whether a Snap is installed
@@ -110,17 +110,17 @@ Each value is a nested object with additional information, such as the version o
 
 :::note
 `wallet_getSnaps` only returns the Snaps that are connected to your dapp.
-The user may have other Snaps installed that your dapp is not aware of. 
+The user may have other Snaps installed that your dapp is not aware of.
 :::
 
 The following example verifies whether a Snap with ID `npm:super-snap` is installed:
 
 ```ts
 const snaps = await ethereum.request({
-  method: 'wallet_getSnaps'
+  method: "wallet_getSnaps",
 });
 
-const isMySnapInstalled = Object.keys(snaps).includes('npm:super-snap');
+const isMySnapInstalled = Object.keys(snaps).includes("npm:super-snap");
 ```
 
 If you need to work with a specific version of a Snap, you can instead iterate over
@@ -145,14 +145,14 @@ However, if the user has disabled the Snap, the response has `enabled` set to `f
 
 ```json
 {
-    "SNAP_ID": {
-        "blocked": false,
-        "enabled": false,
-        "id": "SNAP_ID",
-        "initialPermissions": {
-            // ...all the permissions in the Snap's manifest
-        },
-        "version": "SNAP_VERSION"
-    }
+  "SNAP_ID": {
+    "blocked": false,
+    "enabled": false,
+    "id": "SNAP_ID",
+    "initialPermissions": {
+      // ...all the permissions in the Snap's manifest
+    },
+    "version": "SNAP_VERSION"
+  }
 }
 ```

--- a/snaps/how-to/debug-a-snap/common-issues.md
+++ b/snaps/how-to/debug-a-snap/common-issues.md
@@ -175,14 +175,14 @@ In a production environment this may be a large task depending on the usage of `
 
 ```javascript
 const instance = axios.create({
-  baseURL: 'https://api.github.com/',
+  baseURL: "https://api.github.com/",
 });
 
 instance
-  .get('users/MetaMask')
+  .get("users/MetaMask")
   .then((res) => {
     if (res.status >= 400) {
-      throw new Error('Bad response from server');
+      throw new Error("Bad response from server");
     }
     return res.data;
   })
@@ -197,10 +197,10 @@ instance
 # fetch
 
 ```javascript
-fetch('https://api.github.com/users/MetaMask')
+fetch("https://api.github.com/users/MetaMask")
   .then((res) => {
     if (!res.ok) {
-      throw new Error('Bad response from server');
+      throw new Error("Bad response from server");
     }
     return res.json();
   })

--- a/snaps/how-to/design-a-snap.md
+++ b/snaps/how-to/design-a-snap.md
@@ -79,8 +79,8 @@ Use conversational language when describing your Snap.
 If you need to use a technical term, briefly define it first.
 For example:
 
-| Don't do this                                                                                                                                                              | Do this instead                                                                  |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| Don't do this                                                                                                                                                               | Do this instead                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | ❌ _Allow the Snap to perform actions that run periodically at fixed times, dates, or intervals. This can be used to trigger time-sensitive interactions or notifications._ | ✅ _Let this Snap schedule and run recurring tasks or notifications._             |
 | ❌ _Allow this Snap to display notifications regarding your ENS expiration._                                                                                                | ✅ _Let this Snap notify you when your Ethereum Name Service is about to expire._ |
 
@@ -109,8 +109,8 @@ Your Snap's avatar should fit in a **32px circular frame in SVG format**.
 Avoid using images with small details, as they won't be impactful in the allotted space.
 Use something bold, simple, and easily understood.
 
-The avatar must be a valid SVG. 
-It should be clearly visible on both light and dark backgrounds. 
+The avatar must be a valid SVG.
+It should be clearly visible on both light and dark backgrounds.
 It should also be square, or else it will be stretched or cropped.
 
 You can use [SVGviewer.dev](https://www.svgviewer.dev/) to validate and optimize your SVG.
@@ -129,8 +129,8 @@ For example:
 
 <p>
 
-| Don't do this                | Do this instead     |
-|------------------------------|---------------------|
+| Don't do this                 | Do this instead      |
+| ----------------------------- | -------------------- |
 | ❌ _Solana Snap_              | ✅ _Solana Manager_  |
 | ❌ _Snap for Filecoin_        | ✅ _Filecoin Wallet_ |
 | ❌ _Best manager for Bitcoin_ | ✅ _Bitcoin Helper_  |
@@ -163,8 +163,8 @@ There might be certain situations where passive voice is the better option, but 
 active voice.
 For example:
 
-| Don't do this                         | Do this instead                     |
-|---------------------------------------|-------------------------------------|
+| Don't do this                          | Do this instead                      |
+| -------------------------------------- | ------------------------------------ |
 | ❌ _The problem is being investigated_ | ✅ _We're investigating the problem_ |
 
 ## Design for all users

--- a/snaps/how-to/develop-a-snap.md
+++ b/snaps/how-to/develop-a-snap.md
@@ -1,0 +1,124 @@
+---
+description: Develop, test, and publish a Snap.
+sidebar_position: 1
+---
+
+# Develop a Snap
+
+A Snap can integrate with and extend the functionality of MetaMask using the
+[Snaps entry points](../reference/entry-points.md), [Snaps API](../reference/snaps-api.md), and
+[permissions](request-permissions.md).
+
+:::caution important
+Before developing a Snap, make sure you understand the following concepts and guidelines:
+
+- [Snaps overview](../concepts/overview.md)
+- [Snaps APIs](../concepts/apis.md)
+- [Snaps files](../concepts/files.md)
+- [Snaps design guidelines](../concepts/design-guidelines.md)
+- [Snaps security guidelines](../concepts/security-guidelines.md)
+  :::
+
+You can get started by [creating a new Snap project](../get-started/quickstart.mdx) or following a
+[tutorial](/snaps/tutorials).
+This page describes additional important steps when developing a Snap.
+
+## Detect the user's MetaMask version
+
+When developing a dapp that depends on [MetaMask Flask](../get-started/install-flask.md#install-metamask-flask),
+you first need to know whether the user has it installed.
+
+The following example uses the
+[`@metamask/detect-provider`](https://npmjs.com/package/@metamask/detect-provider) package to get
+the provider object from MetaMask first:
+
+```js
+import detectEthereumProvider from "@metamask/detect-provider";
+
+// This resolves to the value of window.ethereum or null
+const provider = await detectEthereumProvider();
+
+// web3_clientVersion returns the installed MetaMask version as a string
+const isFlask = (
+  await provider?.request({ method: "web3_clientVersion" })
+)?.includes("flask");
+
+if (provider && isFlask) {
+  console.log("MetaMask Flask successfully detected!");
+
+  // Now you can use Snaps!
+} else {
+  console.error("Please install MetaMask Flask!", error);
+}
+```
+
+## Test your Snap
+
+Test your Snap by hosting it locally using `yarn start`, installing it in Flask, and calling its
+API methods from a dapp.
+
+For end-to-end Snap testing, [use the `@metamask/snaps-jest` package](test-a-snap.md).
+
+## Debug your Snap
+
+To debug your Snap, use `console.log` and inspect the MetaMask background process.
+You can add your log statements in your source code and build your Snap, or add them directly
+to your Snap bundle and use [`yarn mm-snap manifest --fix`](../reference/cli/subcommands.md#m-manifest)
+to update the `shasum` in your Snap manifest file.
+The manifest `shasum` must match the contents of your bundle at the time MetaMask fetches your Snap.
+
+:::note
+Because adding logs modifies the Snap source code, you must re-install the Snap whenever you add a
+log statement.
+:::
+
+The Snap log output is only visible in the extension background process console.
+If you're using a Chromium browser, use the following steps to inspect the background process and
+view its console:
+
+1. Go to `chrome://extensions`.
+2. Toggle **Developer mode** on in the top right corner.
+3. Find MetaMask Flask, and select **Details**.
+4. Under **Inspect views**, select `background.html`.
+
+The log output displays in the console that pops up.
+
+## Publish your Snap
+
+Snaps are npm packages, so publishing a Snap is as simple as publishing an npm package.
+Refer to the [npm CLI documentation](https://docs.npmjs.com/cli/v8/commands/npm-publish) for details
+on publishing to the public registry.
+The following details are specific to Snaps:
+
+- The version in `package.json` and `snap.manifest.json` should match.
+- The `repository.url` field in `package.json` should match the correct repository for your Snap.
+- The `source.location.npm.packageName` in `snap.manifest.json` should match the name in `package.json`.
+- The `proposedName` in `snap.manifest.json` should be a human-readable name and should not include
+  the words "MetaMask" or "Snap."
+- The image specified in `iconPath` in the manifest file is used as the icon displayed when
+  installing the Snap, in custom dialogs, and in the settings menu.
+  - This icon should be a valid SVG.
+  - The icon will be cropped in a circle when displayed in MetaMask; you do not need to make the icon circular.
+
+After publishing the Snap, any dapp can connect to the Snap by using the Snap ID `npm:[packageName]`.
+
+:::caution
+If you are using the Snap monorepo project generated in the [quickstart](../get-started/quickstart.mdx),
+make sure to only publish the Snap package in `/packages/snap`.
+You can use the [Snaps Simulator](https://metamask.github.io/snaps/snaps-simulator/staging/#/manifest) to verify
+that your Snap was published correctly &mdash; just select **localhost** in the top right corner and change the
+Snap location to **npm** and the ID of your Snap.
+
+Also, make sure to update the manifest file, icon file, and README to differentiate your Snap from the template.
+:::
+
+## Distribute your Snap
+
+You should deploy a dapp where users can learn about your Snap and install it, or integrate with your existing dapp.
+
+If your Snap is designed to communicate with dapps, you can encourage other dapp developers to [integrate your Snap](use-3rd-party-snaps.md).
+
+## Resources
+
+See the full list of [Snaps resources](../reference/resources.md) for more information on developer
+tools, example Snaps, and more.

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -61,9 +61,9 @@ For example, to request permission to connect to the `hello-snap` Snap:
 
 ```js title="index.js"
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
+  method: "wallet_requestSnaps",
   params: {
-    'npm:hello-snap': {},
+    "npm:hello-snap": {},
   },
 });
 ```

--- a/snaps/how-to/secure-a-snap.md
+++ b/snaps/how-to/secure-a-snap.md
@@ -51,6 +51,7 @@ The following are guidelines for user notifications and authorizations:
 
 - **Transparent and consentful actions** - Before performing any of the following actions, provide a
   prompt that displays detailed information about the action and asks the user to reject or accept it:
+
   - **Modifying or reading state.** (In general, notify the user about any state changes.)
   - **Switching networks or accounts.**
   - **Deriving or generating key pairs, accounts, or smart contracts.**
@@ -65,34 +66,33 @@ The following are guidelines for user notifications and authorizations:
 - **Limit access to sensitive methods** - When building a Snap with sensitive RPC methods,
   use a companion dapp as an "admin interface" to interact with your Snap's sensitive methods.
   There are two ways to do this:
-  
+
   1. Restrict the [`endowment:rpc`](../reference/permissions.md#endowmentrpc) permission to specific
      URLs using the `allowedOrigins` caveat.
-  
   2. Filter specific methods to specific URLs using the built-in [URL
-     library](https://developer.mozilla.org/en-US/docs/Web/API/URL): 
+     library](https://developer.mozilla.org/en-US/docs/Web/API/URL):
 
-    ```JavaScript
-    const referrer = new URL(origin);
+  ```JavaScript
+  const referrer = new URL(origin);
 
-    if(referrer.protocol === "https:" && 
-       (referrer.host.endsWith(".metamask.io") || 
-        referrer.host === "metamask.io")) { 
-      console.log("URL is valid"); 
-    }
-    else { 
-      console.log("URL is NOT valid"); 
-    }
-    ```
-    
-    In this example, the RPC method can be restricted when the origin matches `https://metamask.io`
-    or any subdomain.
-    This check can be used on any RPC method that should not be callable by all sites.
+  if(referrer.protocol === "https:" &&
+     (referrer.host.endsWith(".metamask.io") ||
+      referrer.host === "metamask.io")) {
+    console.log("URL is valid");
+  }
+  else {
+    console.log("URL is NOT valid");
+  }
+  ```
 
-    :::note
-    Avoid using regular expressions or string matching to filter URLs.
-    The URL library provides a much more reliable interface for matching URLs.
-    :::
+  In this example, the RPC method can be restricted when the origin matches `https://metamask.io`
+  or any subdomain.
+  This check can be used on any RPC method that should not be callable by all sites.
+
+  :::note
+  Avoid using regular expressions or string matching to filter URLs.
+  The URL library provides a much more reliable interface for matching URLs.
+  :::
 
 ## Secure sensitive information
 
@@ -146,7 +146,7 @@ The following are guidelines for validating RPC parameters and handling values:
   interface component instead of `text`.
   When using dialogs, the input may contain special characters that render as Markdown and can
   mislead the user.
-  For example: 
+  For example:
 
   ![Example not using copyable with Markdown rendering](../assets/copyable-example-1.png)
 

--- a/snaps/how-to/test-a-snap.md
+++ b/snaps/how-to/test-a-snap.md
@@ -36,7 +36,7 @@ In the `jest.config.js` file, add the following:
 
 ```js title="jest.config.js"
 module.exports = {
-  preset: '@metamask/snaps-jest',
+  preset: "@metamask/snaps-jest",
 };
 ```
 
@@ -56,8 +56,8 @@ environment and matchers to your Jest configuration manually:
 
 ```js title="jest.config.js"
 module.exports = {
-  testEnvironment: '@metamask/snaps-jest',
-  setupFilesAfterEnv: ['@metamask/snaps-jest/dist/cjs/setup.js'],
+  testEnvironment: "@metamask/snaps-jest",
+  setupFilesAfterEnv: ["@metamask/snaps-jest/dist/cjs/setup.js"],
 };
 ```
 
@@ -67,7 +67,7 @@ For example:
 
 ```js title="jest.config.js"
 module.exports = {
-  preset: '@metamask/snaps-jest',
+  preset: "@metamask/snaps-jest",
   testEnvironmentOptions: {
     // Options go here
   },

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -2,8 +2,8 @@
 title: Introduction
 ---
 
-import CardList from '@site/src/components/CardList'
-import YoutubeEmbed from '@site/src/components/YoutubeEmbed'
+import CardList from "@site/src/components/CardList";
+import YoutubeEmbed from "@site/src/components/YoutubeEmbed";
 
 # Extend the functionality of MetaMask using Snaps
 
@@ -18,7 +18,7 @@ modify existing functionalities using the [Snaps API](reference/snaps-api.md).
 Learn more in this video:
 
 <YoutubeEmbed url="https://www.youtube.com/embed/lmxKo4Qx7cM?si=zRJEUbH4_46MKbLL" />
-<br/>
+<br />
 
 The following Snaps features are available in the stable version of MetaMask:
 
@@ -28,66 +28,81 @@ The following Snaps features are available in the stable version of MetaMask:
       icon: require("./assets/features/dialog.png").default,
       href: "reference/snaps-api#snap_dialog",
       title: "Dialogs",
-      description: "Display custom alert, confirmation, or prompt screens in MetaMask."
+      description:
+        "Display custom alert, confirmation, or prompt screens in MetaMask.",
     },
     {
       icon: require("./assets/features/notifications.png").default,
       href: "reference/snaps-api#snap_notify",
       title: "Notifications",
-      description: "Notify users directly in MetaMask, or in their OS."
+      description: "Notify users directly in MetaMask, or in their OS.",
     },
     {
       icon: require("./assets/features/state.png").default,
       href: "reference/snaps-api#snap_managestate",
       title: "Encrypted storage",
-      description: "Securely store and manage data on the user's device."
+      description: "Securely store and manage data on the user's device.",
     },
     {
       icon: require("./assets/features/state.png").default,
       href: "reference/snaps-api#snap_managestate",
       title: "Unencrypted storage",
-      description: "Store non-sensitive data and access it while MetaMask is locked."
+      description:
+        "Store non-sensitive data and access it while MetaMask is locked.",
     },
     {
       icon: require("./assets/features/manage-keys.png").default,
+<<<<<<< Updated upstream
       href: "features/non-evm-networks",
       title: "Non-EVM networks",
       description: "Manage non-EVM accounts and assets in MetaMask."
+=======
+      href: "how-to/manage-keys",
+      title: "Non-EVM chain support",
+      description: "Control non-EVM accounts and assets in MetaMask.",
+>>>>>>> Stashed changes
     },
     {
       icon: require("./assets/features/insights.png").default,
       href: "reference/entry-points#ontransaction",
       title: "Transaction insights",
-      description: "Provide transaction insights in MetaMask's pre-transaction window."
+      description:
+        "Provide transaction insights in MetaMask's pre-transaction window.",
     },
     {
       icon: require("./assets/features/cronjob.png").default,
       href: "reference/entry-points#oncronjob",
       title: "Cron jobs",
-      description: "Schedule periodic actions for your users."
+      description: "Schedule periodic actions for your users.",
     },
     {
       icon: require("./assets/features/custom-ui.png").default,
       href: "features/custom-ui",
       title: "Custom UI",
-      description: "Display custom UI in MetaMask using a set of pre-defined components."
+      description:
+        "Display custom UI in MetaMask using a set of pre-defined components.",
     },
     {
       icon: require("./assets/features/network.png").default,
       href: "reference/permissions#endowmentnetwork-access",
       title: "Network access",
-      description: <>Make API calls using <code>fetch()</code>.</>
+      description: (
+        <>
+          Make API calls using <code>fetch()</code>.
+        </>
+      ),
     },
     {
       icon: require("./assets/features/locale.png").default,
       href: "features/localization",
       title: "Localization",
-      description: "Translate your Snap UI based on the user's locale."
+      description: "Translate your Snap UI based on the user's locale.",
     },
     {
       icon: require("./assets/features/lifecycle-hooks.png").default,
       href: "reference/permissions#endowmentlifecycle-hooks",
       title: "Lifecycle hooks",
+<<<<<<< Updated upstream
       description: "Call an action when your Snap is installed or updated."
     },
     {
@@ -96,6 +111,10 @@ The following Snaps features are available in the stable version of MetaMask:
       title: "Static files",
       description: "Lazy-load static files such as Wasm modules or ZK circuits."
     }
+=======
+      description: "Call an action when your Snap is installed or updated.",
+    },
+>>>>>>> Stashed changes
   ]}
 />
 
@@ -109,22 +128,23 @@ the canary distribution of MetaMask:
       href: "features/custom-evm-accounts",
       title: "Custom EVM accounts",
       description: "Connect to custom EVM accounts in MetaMask.",
-      flaskOnly: true
+      flaskOnly: true,
     },
     {
       icon: require("./assets/features/tx-severity.png").default,
       href: "reference/entry-points/#transaction-severity-level",
       title: "Transaction severity",
-      description: "Add extra friction to the transaction flow if a transaction looks risky.",
-      flaskOnly: true
+      description:
+        "Add extra friction to the transaction flow if a transaction looks risky.",
+      flaskOnly: true,
     },
     {
       icon: require("./assets/features/homepage.png").default,
       href: "reference/permissions#endowmentpage-home",
       title: "Home pages",
       description: "Present a dedicated UI page in MetaMask for your Snap.",
-      flaskOnly: true
-    }
+      flaskOnly: true,
+    },
   ]}
 />
 
@@ -142,18 +162,21 @@ If you're new to Snaps, get started learning with the following topics:
     {
       href: "learn/about-snaps/apis",
       title: "About the Snaps APIs",
-      description: "Learn about how Snaps, dapps, and MetaMask communicate with each other.",
+      description:
+        "Learn about how Snaps, dapps, and MetaMask communicate with each other.",
     },
     {
       href: "learn/about-snaps/files",
       title: "Snaps files",
-      description: "Learn about the Snaps manifest, configuration, and bundle files.",
+      description:
+        "Learn about the Snaps manifest, configuration, and bundle files.",
     },
     {
       href: "learn/tutorials/gas-estimation",
       title: "Gas estimation Snap tutorial",
-      description: "Follow an end-to-end tutorial to create a Snap that estimates gas fees.",
-    }
+      description:
+        "Follow an end-to-end tutorial to create a Snap that estimates gas fees.",
+    },
   ]}
 />
 

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -30,10 +30,10 @@ Your Snap can then call `snap_notify` in its source code:
 
 ```typescript title="index.ts"
 await snap.request({
-  method: 'snap_notify',
+  method: "snap_notify",
   params: {
-    type: 'inApp',
-    message: 'Hello, world!',
+    type: "inApp",
+    message: "Hello, world!",
   },
 });
 ```
@@ -59,16 +59,16 @@ For example, to call `wallet_snap`:
 ```js title="index.js"
 // Request permission to connect to the Snap.
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
+  method: "wallet_requestSnaps",
   params: {
-    'npm:hello-snap': {},
+    "npm:hello-snap": {},
   },
 });
 
 // Call the 'hello' method of the Snap using wallet_snap.
 const response = await window.ethereum.request({
-  method: 'wallet_snap',
-  params: { snapId: 'npm:hello-snap', request: { method: 'hello' } },
+  method: "wallet_snap",
+  params: { snapId: "npm:hello-snap", request: { method: "hello" } },
 });
 
 console.log(response); // 'world!'
@@ -94,7 +94,7 @@ Your Snap can then call `eth_requestAccounts` in its source code:
 
 ```typescript title="index.ts"
 await ethereum.request({
-  "method": "eth_requestAccounts"
+  method: "eth_requestAccounts",
 });
 ```
 
@@ -149,11 +149,11 @@ Your Snap can then implement and expose a custom API using the `onRpcRequest` fu
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     // Expose a 'hello' JSON-RPC method to dapps.
-    case 'hello':
-      return 'world!';
+    case "hello":
+      return "world!";
 
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -164,17 +164,17 @@ A dapp can then install the Snap and call the exposed method:
 // Request permission to connect to the Snap.
 // If the Snap is not already installed, the user will be prompted to install it.
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
+  method: "wallet_requestSnaps",
   params: {
     // Assuming the Snap is published to npm using the package name 'hello-snap'.
-    'npm:hello-snap': {},
+    "npm:hello-snap": {},
   },
 });
 
 // Invoke the 'hello' JSON-RPC method exposed by the Snap.
 const response = await window.ethereum.request({
-  method: 'wallet_invokeSnap',
-  params: { snapId: 'npm:hello-snap', request: { method: 'hello' } },
+  method: "wallet_invokeSnap",
+  params: { snapId: "npm:hello-snap", request: { method: "hello" } },
 });
 
 console.log(response); // 'world!'

--- a/snaps/learn/about-snaps/files.md
+++ b/snaps/learn/about-snaps/files.md
@@ -98,12 +98,12 @@ them in the `config` object of the configuration file.
 For example:
 
 ```ts
-import { resolve } from 'path';
-import type { SnapConfig } from '@metamask/snaps-cli';
+import { resolve } from "path";
+import type { SnapConfig } from "@metamask/snaps-cli";
 
 const config: SnapConfig = {
-  bundler: 'webpack',
-  input: resolve(__dirname, 'src/index.ts'),
+  bundler: "webpack",
+  input: resolve(__dirname, "src/index.ts"),
   server: {
     port: 8080,
   },

--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -80,7 +80,7 @@ adding `"endowment:network-access": {}` to the `initialPermissions` object in `s
   "endowment:rpc": {
     "dapps": true,
     "snaps": false
-  }, 
+  },
   "endowment:network-access": {}
 },
 "manifestVersion": "0.1"
@@ -96,11 +96,11 @@ To get a gas fee estimate, use the public API endpoint provided by
 Add the following `getFees()` function to the top of the file:
 
 ```typescript title="index.ts"
-import { OnRpcRequestHandler } from '@metamask/snaps-types';
-import { panel, text } from '@metamask/snaps-ui';
+import { OnRpcRequestHandler } from "@metamask/snaps-types";
+import { panel, text } from "@metamask/snaps-ui";
 
 async function getFees() {
-  const response = await fetch('https://beaconcha.in/api/v1/execution/gasnow'); 
+  const response = await fetch("https://beaconcha.in/api/v1/execution/gasnow");
   return response.text();
 }
 ```
@@ -117,21 +117,21 @@ Rewrite the `hello` method with the following code:
 ```typescript title="index.ts"
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
-    case 'hello':
-      return getFees().then(fees => {
+    case "hello":
+      return getFees().then((fees) => {
         return snap.request({
-          method: 'snap_dialog',
+          method: "snap_dialog",
           params: {
-            type: 'alert',
+            type: "alert",
             content: panel([
               text(`Hello, **${origin}**!`),
               text(`Current gas fee estimates: ${fees}`),
             ]),
-          }
+          },
         });
       });
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -141,30 +141,34 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
 To build and test your Snap:
 
 1. Open `package.json` in the root directory of the project, and increase the `"version"` (if the `"version"` is
-    `0.1.0`, increase it to `0.2.0`).
+   `0.1.0`, increase it to `0.2.0`).
 
 2. From the command line, run `yarn start`.
-    In the terminal, at the bottom of the message log, you see the browser URL:
+   In the terminal, at the bottom of the message log, you see the browser URL:
 
-    ```bash
-    You can now view site in the browser.
-    
-      http://localhost:8000/
-    ```
+   ```bash
+   You can now view site in the browser.
+
+     http://localhost:8000/
+   ```
 
 3. Open [`localhost:8000`](http://localhost:8000/) in your browser (with MetaMask Flask installed).
-    A page like the following displays:
+   A page like the following displays:
 
+<<<<<<< Updated upstream:snaps/learn/tutorials/gas-estimation.md
     <img src={require('../../assets/template-snap.png').default} alt="Test dapp with template Snap" style={{border: '1px solid gray'}} />
+=======
+   <img src={require('../assets/template-snap.png').default} alt="Test dapp with template Snap" style={{border: '1px solid gray'}} />
+>>>>>>> Stashed changes:snaps/tutorials/gas-estimation.md
 
-    This is a boilerplate test dapp for installing and testing your Snap.
+   This is a boilerplate test dapp for installing and testing your Snap.
 
 4. Select **Connect** to connect Flask to the dapp.
-    After connecting, you're prompted to install the Snap with the following permissions:
+   After connecting, you're prompted to install the Snap with the following permissions:
 
-    - **Allow dapps to communicate directly with this Snap.**
-    - **Access the internet.**
-    - **Display dialog windows in MetaMask.**
+   - **Allow dapps to communicate directly with this Snap.**
+   - **Access the internet.**
+   - **Display dialog windows in MetaMask.**
 
 5. Select **Approve & install**.
 

--- a/snaps/learn/tutorials/transaction-insights.md
+++ b/snaps/learn/tutorials/transaction-insights.md
@@ -83,30 +83,29 @@ To calculate and display the gas fees a user would pay as a percentage of their 
 replace the code in `/packages/snap/src/index.ts` with the following:
 
 ```typescript title="index.ts"
-import { OnTransactionHandler } from '@metamask/snaps-types';
-import { heading, panel, text } from '@metamask/snaps-ui';
+import { OnTransactionHandler } from "@metamask/snaps-types";
+import { heading, panel, text } from "@metamask/snaps-ui";
 
 // Handle outgoing transactions.
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
-
   // Use the window.ethereum global provider to fetch the gas price.
   const currentGasPrice = await window.ethereum.request({
-    method: 'eth_gasPrice',
+    method: "eth_gasPrice",
   });
 
   // Get fields from the transaction object.
   const transactionGas = parseInt(transaction.gas as string, 16);
-  const currentGasPriceInWei = parseInt(currentGasPrice ?? '', 16);
+  const currentGasPriceInWei = parseInt(currentGasPrice ?? "", 16);
   const maxFeePerGasInWei = parseInt(transaction.maxFeePerGas as string, 16);
   const maxPriorityFeePerGasInWei = parseInt(
     transaction.maxPriorityFeePerGas as string,
-    16,
+    16
   );
 
   // Calculate gas fees the user would pay.
   const gasFees = Math.min(
     maxFeePerGasInWei * transactionGas,
-    (currentGasPriceInWei + maxPriorityFeePerGasInWei) * transactionGas,
+    (currentGasPriceInWei + maxPriorityFeePerGasInWei) * transactionGas
   );
 
   // Calculate gas fees as percentage of transaction.
@@ -116,11 +115,11 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   // Display percentage of gas fees in the transaction insights UI.
   return {
     content: panel([
-      heading('Transaction insights Snap'),
+      heading("Transaction insights Snap"),
       text(
         `As set up, you are paying **${gasFeesPercentage.toFixed(
-          2,
-        )}%** in gas fees for this transaction.`,
+          2
+        )}%** in gas fees for this transaction.`
       ),
     ]),
   };
@@ -132,31 +131,36 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
 To build and test your Snap:
 
 1. From the command line, run `yarn start` in the root of your project.
-    This starts two development servers: one for watching and compiling the Snap, and another for the
-    React site.
-    The Snap bundle is served from `localhost:8080`, and the site is served from `localhost:8000`.
-    You should get a message that includes:
+   This starts two development servers: one for watching and compiling the Snap, and another for the
+   React site.
+   The Snap bundle is served from `localhost:8080`, and the site is served from `localhost:8000`.
+   You should get a message that includes:
 
-    ```bash
-    You can now view site in the browser.
+   ```bash
+   You can now view site in the browser.
 
-      http://localhost:8000/
-    ```
+     http://localhost:8000/
+   ```
 
 2. Open [`localhost:8000`](http://localhost:8000) in your browser (with MetaMask Flask installed).
 
 3. Select **Connect**, and accept the permission request.
 
 4. After connecting, you're prompted to install the Snap with the **Fetch and display transaction
-    insights** and **Access the Ethereum provider** permissions.
-    Select **Approve & install**.
+   insights** and **Access the Ethereum provider** permissions.
+   Select **Approve & install**.
 
 5. From MetaMask Flask, create a new testnet ETH transfer.
-    You can set up multiple accounts to transfer between your accounts.
+   You can set up multiple accounts to transfer between your accounts.
 
 6. On the confirmation window, switch to the tab named **TYPESCRIPT EXAMPLE SNAP**.
+<<<<<<< Updated upstream:snaps/learn/tutorials/transaction-insights.md
     Switching to the tab activates the [`onTransaction`](../../reference/entry-points.md#ontransaction)
     entry point of your Snap and displays the percentage of gas fees in the transaction insights UI:
+=======
+   Switching to the tab activates the [`onTransaction`](../reference/entry-points.md#ontransaction)
+   entry point of your Snap and displays the percentage of gas fees in the transaction insights UI:
+>>>>>>> Stashed changes:snaps/tutorials/transaction-insights.md
 
 <p align="center">
 <img src={require('../../assets/transaction-insights.png').default} alt="Transaction insights UI" style={{border: '1px solid gray'}} />
@@ -169,12 +173,12 @@ For contract interactions, it should display a UI that conveys that message.
 Add the following code to the beginning of the `onTransaction` entry point:
 
 ```typescript
-if (typeof transaction.data === 'string' && transaction.data !== '0x') {
+if (typeof transaction.data === "string" && transaction.data !== "0x") {
   return {
     content: panel([
-      heading('Percent Snap'),
+      heading("Percent Snap"),
       text(
-        'This Snap only provides transaction insights for simple ETH transfers.',
+        "This Snap only provides transaction insights for simple ETH transfers."
       ),
     ]),
   };

--- a/snaps/reference/cli/options.md
+++ b/snaps/reference/cli/options.md
@@ -44,7 +44,7 @@ You can specify options:
 # Configuration file
 
 ```js
-bundle: 'out/bundle.js' 
+bundle: "out/bundle.js";
 ```
 
 <!--/tabs-->
@@ -75,7 +75,7 @@ You can use this option with the [`eval`](subcommands.md#e-eval) subcommand.
 # Configuration file
 
 ```js
-dist: 'out'
+dist: "out";
 ```
 
 <!--/tabs-->
@@ -107,7 +107,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-depsToTranspile: ['dep1','dep2']
+depsToTranspile: ["dep1", "dep2"];
 ```
 
 <!--/tabs-->
@@ -137,7 +137,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-eval: false
+eval: false;
 ```
 
 <!--/tabs-->
@@ -169,7 +169,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-fix: false
+fix: false;
 ```
 
 <!--/tabs-->
@@ -211,7 +211,7 @@ You can use this option with `mm-snap` or any [subcommand](subcommands.md).
 # Configuration file
 
 ```js
-manifest: false
+manifest: false;
 ```
 
 <!--/tabs-->
@@ -243,7 +243,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-outfileName: 'snap.js'
+outfileName: "snap.js";
 ```
 
 <!--/tabs-->
@@ -275,7 +275,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-port: 9000
+port: 9000;
 ```
 
 <!--/tabs-->
@@ -307,7 +307,7 @@ You can use this option with the [`serve`](subcommands.md#s-serve) and
 # Configuration file
 
 ```js
-root: 'out'
+root: "out";
 ```
 
 <!--/tabs-->
@@ -339,7 +339,7 @@ You can use this option with the [`serve`](subcommands.md#s-serve) and
 # Configuration file
 
 ```js
-src: 'lib/index.js'
+src: "lib/index.js";
 ```
 
 <!--/tabs-->
@@ -371,7 +371,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-sourceMaps: true
+sourceMaps: true;
 ```
 
 <!--/tabs-->
@@ -401,7 +401,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-strip: false
+strip: false;
 ```
 
 <!--/tabs-->
@@ -433,7 +433,7 @@ You can use this option with the [`build`](subcommands.md#b-build) and
 # Configuration file
 
 ```js
-suppressWarnings: true
+suppressWarnings: true;
 ```
 
 <!--/tabs-->
@@ -462,7 +462,7 @@ You can use this option with any [subcommand](subcommands.md).
 # Configuration file
 
 ```js
-transpilationMode: 'localAndDeps'
+transpilationMode: "localAndDeps";
 ```
 
 <!--/tabs-->
@@ -499,7 +499,7 @@ For TypeScript Snaps, `--transpilationMode` must be set to either `localOnly` or
 # Configuration file
 
 ```js
-verboseErrors: false
+verboseErrors: false;
 ```
 
 <!--/tabs-->
@@ -507,7 +507,7 @@ verboseErrors: false
 Indicates whether to display original errors.
 The default is `true`.
 
-You can use this option with any [subcommand](subcommands.md). 
+You can use this option with any [subcommand](subcommands.md).
 
 ### version
 

--- a/snaps/reference/cli/subcommands.md
+++ b/snaps/reference/cli/subcommands.md
@@ -157,6 +157,6 @@ All files in the parent and child directories of sthe source directory are watch
 - Any files named `test.js` or `test.ts`.
 - Files in the `dist` directory, or the directory specified using [`--dist`](options.md#d-dist).
 - Dotfiles.
-:::
-  
+  :::
+
 `w` is an alias for `watch`.

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -35,18 +35,18 @@ A promise containing the return of the implemented method.
 # TypeScript
 
 ```typescript
-import { OnRpcRequestHandler } from '@metamask/snaps-types';
+import { OnRpcRequestHandler } from "@metamask/snaps-types";
 
 export const onRpcRequest: OnRpcRequestHandler = async ({
   origin,
   request,
 }) => {
   switch (request.method) {
-    case 'hello':
-      return 'world!';
+    case "hello":
+      return "world!";
 
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -56,11 +56,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
 ```js
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
-    case 'hello':
-      return 'world!';
+    case "hello":
+      return "world!";
 
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -152,7 +152,7 @@ module.exports.onTransaction = async ({
 This feature enables transaction insight Snaps to return an optional severity level of `critical`.
 MetaMask shows a modal with the warning before the user can confirm the transaction.
 Using the previous example for `onTransaction`, the following code adds a single line to return an
-insight with the severity level `critical`: 
+insight with the severity level `critical`:
 
 <!--tabs-->
 
@@ -242,21 +242,21 @@ An object containing an RPC request specified in the `endowment:cronjob` permiss
 # TypeScript
 
 ```typescript
-import { OnCronjobHandler } from '@metamask/snaps-types';
+import { OnCronjobHandler } from "@metamask/snaps-types";
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
   switch (request.method) {
-    case 'exampleMethodOne':
+    case "exampleMethodOne":
       return snap.request({
-        method: 'snap_notify',
+        method: "snap_notify",
         params: {
-          type: 'inApp',
+          type: "inApp",
           message: `Hello, world!`,
         },
       });
 
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -266,17 +266,17 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
 ```js
 module.exports.onCronjob = async ({ request }) => {
   switch (request.method) {
-    case 'exampleMethodOne':
+    case "exampleMethodOne":
       return snap.request({
-        method: 'snap_notify',
+        method: "snap_notify",
         params: {
-          type: 'inApp',
+          type: "inApp",
           message: `Hello, world!`,
         },
       });
 
     default:
-      throw new Error('Method not found.');
+      throw new Error("Method not found.");
   }
 };
 ```
@@ -286,7 +286,7 @@ module.exports.onCronjob = async ({ request }) => {
 ## `onInstall`
 
 To run an action on installation, a Snap must expose the `onInstall` entry point.
-MetaMask calls the `onInstall` handler method after the Snap is installed successfully. 
+MetaMask calls the `onInstall` handler method after the Snap is installed successfully.
 
 :::note
 For MetaMask to call the Snap's `onInstall` method, you must request the
@@ -297,7 +297,6 @@ For MetaMask to call the Snap's `onInstall` method, you must request the
 
 None.
 
-
 #### Example
 
 <!--tabs-->
@@ -305,18 +304,18 @@ None.
 # TypeScript
 
 ```typescript
-import type { OnInstallHandler } from '@metamask/snaps-sdk';
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import type { OnInstallHandler } from "@metamask/snaps-sdk";
+import { heading, panel, text } from "@metamask/snaps-sdk";
 
 export const onInstall: OnInstallHandler = async () => {
   await snap.request({
-    method: 'snap_dialog',
+    method: "snap_dialog",
     params: {
-      type: 'alert',
+      type: "alert",
       content: panel([
-        heading('Thank you for installing my Snap'),
+        heading("Thank you for installing my Snap"),
         text(
-          'To use this Snap, visit the companion dapp at [metamask.io](https://metamask.io).',
+          "To use this Snap, visit the companion dapp at [metamask.io](https://metamask.io)."
         ),
       ]),
     },
@@ -327,17 +326,17 @@ export const onInstall: OnInstallHandler = async () => {
 # JavaScript
 
 ```js
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import { heading, panel, text } from "@metamask/snaps-sdk";
 
 module.exports.onInstall = async () => {
   await snap.request({
-    method: 'snap_dialog',
+    method: "snap_dialog",
     params: {
-      type: 'alert',
+      type: "alert",
       content: panel([
-        heading('Thank you for installing my Snap'),
+        heading("Thank you for installing my Snap"),
         text(
-          'To use this Snap, visit the companion dapp at [metamask.io](https://metamask.io).',
+          "To use this Snap, visit the companion dapp at [metamask.io](https://metamask.io)."
         ),
       ]),
     },
@@ -350,7 +349,7 @@ module.exports.onInstall = async () => {
 ## `onUpdate`
 
 To run an action on update, a Snap must expose the `onUpdate` entry point.
-MetaMask calls the `onUpdate` handler method after the Snap is updated successfully. 
+MetaMask calls the `onUpdate` handler method after the Snap is updated successfully.
 
 :::note
 For MetaMask to call the Snap's `onUpdate` method, you must request the
@@ -361,7 +360,6 @@ For MetaMask to call the Snap's `onUpdate` method, you must request the
 
 None.
 
-
 #### Example
 
 <!--tabs-->
@@ -369,22 +367,18 @@ None.
 # TypeScript
 
 ```typescript
-import type { OnUpdateHandler } from '@metamask/snaps-sdk';
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import type { OnUpdateHandler } from "@metamask/snaps-sdk";
+import { heading, panel, text } from "@metamask/snaps-sdk";
 
 export const onUpdate: OnUpdateHandler = async () => {
   await snap.request({
-    method: 'snap_dialog',
+    method: "snap_dialog",
     params: {
-      type: 'alert',
+      type: "alert",
       content: panel([
-        heading('Thank you for updating my Snap'),
-        text(
-          'New features added in this version:',
-        ),
-        text(
-          'Added a dialog that appears when updating'
-        ), 
+        heading("Thank you for updating my Snap"),
+        text("New features added in this version:"),
+        text("Added a dialog that appears when updating"),
       ]),
     },
   });
@@ -394,21 +388,17 @@ export const onUpdate: OnUpdateHandler = async () => {
 # JavaScript
 
 ```js
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import { heading, panel, text } from "@metamask/snaps-sdk";
 
 module.exports.onUpdate = async () => {
   await snap.request({
-    method: 'snap_dialog',
+    method: "snap_dialog",
     params: {
-      type: 'alert',
+      type: "alert",
       content: panel([
-        heading('Thank you for updating my Snap'),
-        text(
-          'New features added in this version:',
-        ),
-        text(
-          'Added a dialog that appears when updating'
-        ), 
+        heading("Thank you for updating my Snap"),
+        text("New features added in this version:"),
+        text("Added a dialog that appears when updating"),
       ]),
     },
   });
@@ -423,7 +413,7 @@ module.exports.onUpdate = async () => {
 :::
 
 To build an embedded UI in MetaMask that any user can access through the Snaps menu, a Snap must
-expose the `onHomePage` entry point. 
+expose the `onHomePage` entry point.
 MetaMask calls the `onHomePage` handler method when the user selects the Snap name in the Snaps menu.
 
 :::note
@@ -446,14 +436,14 @@ A content object displayed using [custom UI](../features/custom-ui.md).
 # TypeScript
 
 ```typescript
-import type { OnHomePageHandler } from '@metamask/snaps-sdk';
-import { panel, text, heading } from '@metamask/snaps-sdk';
+import type { OnHomePageHandler } from "@metamask/snaps-sdk";
+import { panel, text, heading } from "@metamask/snaps-sdk";
 
 export const onHomePage: OnHomePageHandler = async () => {
   return {
     content: panel([
-      heading('Hello world!'),
-      text('Welcome to my Snap home page!'),
+      heading("Hello world!"),
+      text("Welcome to my Snap home page!"),
     ]),
   };
 };
@@ -462,13 +452,13 @@ export const onHomePage: OnHomePageHandler = async () => {
 # JavaScript
 
 ```js
-import { panel, text, heading } from '@metamask/snaps-sdk';
+import { panel, text, heading } from "@metamask/snaps-sdk";
 
 module.exports.onHomePage = async () => {
   return {
     content: panel([
-      heading('Hello world!'),
-      text('Welcome to my Snap home page!'),
+      heading("Hello world!"),
+      text("Welcome to my Snap home page!"),
     ]),
   };
 };

--- a/snaps/reference/jest.md
+++ b/snaps/reference/jest.md
@@ -27,10 +27,10 @@ An object with functions that can be used to interact with the Snap.
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should do something', async () => {
+describe("MySnap", () => {
+  it("should do something", async () => {
     await installSnap(/* optional Snap ID */);
     // ...
   });
@@ -53,22 +53,22 @@ which can be checked using [Jest matchers](#jest-matchers).
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should respond to foo with bar', async () => {
+describe("MySnap", () => {
+  it("should respond to foo with bar", async () => {
     const { request } = await installSnap(/* optional snap ID */);
     const response = await request({
-      origin: 'http://localhost:8080',
-      method: 'foo',
+      origin: "http://localhost:8080",
+      method: "foo",
       params: [],
     });
 
     /* Check the response using Jest matchers. Since the response
      * is a standard JSON-RPC response, you can use any standard
      * Jest matchers to check it, including snapshot matchers. */
-    expect(response).toRespondWith('bar');
-    expect(response).not.toRespondWithError('baz');
+    expect(response).toRespondWith("bar");
+    expect(response).not.toRespondWithError("baz");
     expect(response).toMatchSnapshot();
   });
 });
@@ -105,22 +105,22 @@ An object with the user interface that was shown by the Snap, in the
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
-import { panel, text } from '@metamask/snaps-sdk';
+import { installSnap } from "@metamask/snaps-jest";
+import { panel, text } from "@metamask/snaps-sdk";
 
-describe('MySnap', () => {
-  it('should return insights', async () => {
+describe("MySnap", () => {
+  it("should return insights", async () => {
     const { onTransaction } = await installSnap(/* optional Snap ID */);
     const response = await onTransaction({
-      value: '0x0',
-      data: '0x',
-      gasLimit: '0x5208',
-      maxFeePerGas: '0x5208',
-      maxPriorityFeePerGas: '0x5208',
-      nonce: '0x0',
+      value: "0x0",
+      data: "0x",
+      gasLimit: "0x5208",
+      maxFeePerGas: "0x5208",
+      maxPriorityFeePerGas: "0x5208",
+      nonce: "0x0",
     });
 
-    expect(response).toRender(panel([text('Hello, world!')]));
+    expect(response).toRender(panel([text("Hello, world!")]));
   });
 });
 ```
@@ -144,19 +144,19 @@ which can be checked using [Jest matchers](#jest-matchers).
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should end foo cronjobs with response bar', async () => {
+describe("MySnap", () => {
+  it("should end foo cronjobs with response bar", async () => {
     const { onCronjob } = await installSnap(/* optional snap ID */);
     const response = await onCronjob({
-      method: 'foo',
+      method: "foo",
       params: [],
     });
 
     // Check the response using Jest matchers
-    expect(response).toRespondWith('bar');
-    expect(response).not.toRespondWithError('baz');
+    expect(response).toRespondWith("bar");
+    expect(response).not.toRespondWithError("baz");
   });
 });
 ```
@@ -169,15 +169,15 @@ takes no arguments, and returns a promise that resolves to the response from the
 entry point.
 
 ```js
-import { installSnap } from '@metamask/snaps-jest';
-import { panel, text } from '@metamask/snaps-sdk';
+import { installSnap } from "@metamask/snaps-jest";
+import { panel, text } from "@metamask/snaps-sdk";
 
-describe('MySnap', () => {
-  it('should render the home page', async () => {
+describe("MySnap", () => {
+  it("should render the home page", async () => {
     const { onHomePage } = await installSnap(/* optional snap ID */);
     const response = await onHomePage();
 
-    expect(response).toRender(panel([text('Hello, world!')]));
+    expect(response).toRender(panel([text("Hello, world!")]));
   });
 });
 ```
@@ -196,32 +196,32 @@ be used to interact with the user interface.
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
-import { text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
+import { installSnap } from "@metamask/snaps-jest";
+import { text } from "@metamask/snaps-sdk";
+import { assert } from "@metamask/utils";
 
-describe('MySnap', () => {
-  it('should render an alert with hello world', async () => {
+describe("MySnap", () => {
+  it("should render an alert with hello world", async () => {
     const { request } = await installSnap(/* optional Snap ID */);
 
     // Note: You cannot resolve the promise yet!
     const response = request({
-      method: 'foo',
+      method: "foo",
     });
 
     const ui = await response.getInterface();
 
     // This is useful if you're using TypeScript, since it infers the type
     // of the user interface.
-    assert(ui.type === 'alert');
-    expect(ui).toRender(text('Hello, world!'));
+    assert(ui.type === "alert");
+    expect(ui).toRender(text("Hello, world!"));
 
     // "Click" the OK button.
     await ui.ok();
 
     // Now you can resolve the promise.
     const result = await response;
-    expect(result).toRespondWith('bar');
+    expect(result).toRespondWith("bar");
   });
 });
 ```
@@ -268,11 +268,11 @@ The server options are:
 
 ```javascript
 module.exports = {
-  preset: '@metamask/snaps-jest',
+  preset: "@metamask/snaps-jest",
   testEnvironmentOptions: {
     server: {
       port: 8080,
-      root: '/path/to/snap/files',
+      root: "/path/to/snap/files",
     },
   },
 };

--- a/snaps/reference/known-errors.md
+++ b/snaps/reference/known-errors.md
@@ -7,7 +7,7 @@ description: See the Snaps known errors reference
 Snaps can [communicate the following errors](../how-to/communicate-errors.md) without crashing the Snap:
 
 | Error                      | What the error indicates                                    | Error code |
-|----------------------------|-------------------------------------------------------------|:----------:|
+| -------------------------- | ----------------------------------------------------------- | :--------: |
 | `ChainDisconnectedError`   | The provider is disconnected from the requested chain.      |   `4901`   |
 | `DisconnectedError`        | The provider is disconnected.                               |   `4900`   |
 | `InternalError`            | An internal error has occurred.                             |  `-32603`  |

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -74,9 +74,15 @@ Specify this permission in the manifest file as follows:
 }
 ```
 
+<<<<<<< Updated upstream
 :::note 
 The `ethereum` global available to Snaps has fewer capabilities than `window.ethereum` for dapps. 
 See the [list of methods](../learn/about-snaps/apis.md#metamask-json-rpc-api) not available to Snaps.
+=======
+:::note
+The `ethereum` global available to Snaps has fewer capabilities than `window.ethereum` for dapps.
+See the [list of methods](../concepts/apis.md#metamask-json-rpc-api) not available to Snaps.
+>>>>>>> Stashed changes
 :::
 
 ### `endowment:page-home`
@@ -84,10 +90,15 @@ See the [list of methods](../learn/about-snaps/apis.md#metamask-json-rpc-api) no
 :::flaskOnly
 :::
 
-To present a dedicated UI within MetaMask, a Snap must request the `endowment:page-home` permission. 
+To present a dedicated UI within MetaMask, a Snap must request the `endowment:page-home` permission.
 This permission allows the Snap to specify a "home page" by exposing the
+<<<<<<< Updated upstream
 [`onHomePage`](../reference/entry-points.md#onhomepage) entry point. 
 You can use any [custom UI components](../features/custom-ui.md) to build an embedded home page accessible through the Snaps menu.
+=======
+[`onHomePage`](../reference/entry-points.md#onhomepage) entry point.
+You can use any [custom UI components](../how-to/use-custom-ui.md) to build an embedded home page accessible through the Snaps menu.
+>>>>>>> Stashed changes
 
 Specify this permission in the manifest file as follows:
 
@@ -120,9 +131,9 @@ Specify this permission in the manifest file as follows:
 ### `endowment:lifecycle-hooks`
 
 To run an action when the user installs or updates the Snap, a Snap must request the `endowment:lifecycle-hooks` permission.
-This permission allows the Snap to expose the 
-[`onInstall`](../reference/entry-points.md#oninstall) and 
-[`onUpdate`](../reference/entry-points.md#onupdate) 
+This permission allows the Snap to expose the
+[`onInstall`](../reference/entry-points.md#oninstall) and
+[`onUpdate`](../reference/entry-points.md#onupdate)
 entry points, which MetaMask calls after a successful installation or update, respectively.
 
 Specify this permission in the manifest file as follows:
@@ -182,25 +193,25 @@ Specify this permission in the manifest file as follows:
 }
 ```
 
-Alternatively, you can specify the caveat `allowedOrigins` to restrict requests to specific domains or Snap IDs. 
-Calls from any other origins are rejected. 
+Alternatively, you can specify the caveat `allowedOrigins` to restrict requests to specific domains or Snap IDs.
+Calls from any other origins are rejected.
 
-Specify this caveat in the manifest file as follows: 
+Specify this caveat in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:rpc": { 
+  "endowment:rpc": {
     "allowedOrigins": [
-      "metamask.io", 
+      "metamask.io",
       "consensys.io",
       "npm:@metamask/example-snap"
-    ] 
+    ]
   }
 }
 ```
 
 :::note
-If you specify `allowedOrigins`, you should not specify `dapps` or `snaps`. 
+If you specify `allowedOrigins`, you should not specify `dapps` or `snaps`.
 :::
 
 ### `endowment:transaction-insight`
@@ -261,7 +272,7 @@ Calling `eth_requestAccounts` requires the
 
 ```js
 await ethereum.request({
-  "method": "eth_requestAccounts"
+  method: "eth_requestAccounts",
 });
 ```
 

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -33,15 +33,15 @@ An object containing the contents of the alert dialog:
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from "@metamask/snaps-ui";
 
 await snap.request({
-  method: 'snap_dialog',
+  method: "snap_dialog",
   params: {
-    type: 'Alert',
+    type: "Alert",
     content: panel([
-      heading('Something happened in the system'),
-      text('The thing that happened is...'),
+      heading("Something happened in the system"),
+      text("The thing that happened is..."),
     ]),
   },
 });
@@ -67,15 +67,15 @@ An object containing the contents of the confirmation dialog:
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from "@metamask/snaps-ui";
 
 const result = await snap.request({
-  method: 'snap_dialog',
+  method: "snap_dialog",
   params: {
-    type: 'Confirmation',
+    type: "Confirmation",
     content: panel([
-      heading('Would you like to take the action?'),
-      text('The action is...'),
+      heading("Would you like to take the action?"),
+      text("The action is..."),
     ]),
   },
 });
@@ -104,17 +104,17 @@ The text entered by the user if the prompt was submitted or `null` if the prompt
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from "@metamask/snaps-ui";
 
 const walletAddress = await snap.request({
-  method: 'snap_dialog',
+  method: "snap_dialog",
   params: {
-    type: 'Prompt',
+    type: "Prompt",
     content: panel([
-      heading('What is the wallet address?'),
-      text('Please enter the wallet address to be monitored'),
+      heading("What is the wallet address?"),
+      text("Please enter the wallet address to be monitored"),
     ]),
-    placeholder: '0x123...',
+    placeholder: "0x123...",
   },
 });
 
@@ -183,15 +183,15 @@ its corresponding key material:
 # JavaScript
 
 ```javascript
-import { SLIP10Node } from '@metamask/key-tree';
+import { SLIP10Node } from "@metamask/key-tree";
 
 // This example uses Dogecoin, which has a derivation path starting with `m/44'/3'`.
 const dogecoinNode = await snap.request({
-  method: 'snap_getBip32Entropy',
+  method: "snap_getBip32Entropy",
   params: {
     // Must be specified exactly in the manifest
-    path: ['m', "44'", "3'"],
-    curve: 'secp256k1',
+    path: ["m", "44'", "3'"],
+    curve: "secp256k1",
   },
 });
 
@@ -253,11 +253,11 @@ The public key as hexadecimal string.
 ```javascript
 // This example uses Dogecoin, which has a derivation path starting with `m/44'/3'`.
 const dogecoinPublicKey = await snap.request({
-  method: 'snap_getBip32PublicKey',
+  method: "snap_getBip32PublicKey",
   params: {
     // The path and curve must be specified in the initial permissions.
-    path: ['m', "44'", "3'", "0'", '0', '0'],
-    curve: 'secp256k1',
+    path: ["m", "44'", "3'", "0'", "0", "0"],
+    curve: "secp256k1",
     compressed: false,
   },
 });
@@ -334,11 +334,11 @@ and containing its corresponding key material:
 # JavaScript
 
 ```javascript
-import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+import { getBIP44AddressKeyDeriver } from "@metamask/key-tree";
 
 // This example uses Dogecoin, which has `coin_type` 3.
 const dogecoinNode = await snap.request({
-  method: 'snap_getBip44Entropy',
+  method: "snap_getBip44Entropy",
   params: {
     coinType: 3,
   },
@@ -378,15 +378,15 @@ It is useful to check if MetaMask is locked in the following situations:
 ### Example
 
 ```typescript
-import type { OnCronjobHandler } from '@metamask/snaps-sdk';
-import { MethodNotFoundError } from '@metamask/snaps-sdk';
+import type { OnCronjobHandler } from "@metamask/snaps-sdk";
+import { MethodNotFoundError } from "@metamask/snaps-sdk";
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
   switch (request.method) {
-    case 'execute':
+    case "execute":
       // Find out if MetaMask is locked
       const { locked } = await snap.request({
-        method: 'snap_getClientStatus'
+        method: "snap_getClientStatus",
       });
 
       if (!locked) {
@@ -440,10 +440,10 @@ The entropy as a hexadecimal string.
 
 ```javascript
 const entropy = await snap.request({
-  method: 'snap_getEntropy',
+  method: "snap_getEntropy",
   params: {
     version: 1,
-    salt: 'foo', // Optional
+    salt: "foo", // Optional
   },
 });
 
@@ -518,22 +518,20 @@ The user's locale setting as a [language code](https://github.com/MetaMask/metam
 ### Example
 
 ```javascript
-import { panel, text } from '@metamask/snaps-ui';
+import { panel, text } from "@metamask/snaps-ui";
 
-const locale = await snap.request({ method: 'snap_getLocale' });
+const locale = await snap.request({ method: "snap_getLocale" });
 
-let greeting = 'Hello';
-if(locale === 'es') {
-  greeting = 'Hola';
+let greeting = "Hello";
+if (locale === "es") {
+  greeting = "Hola";
 }
 
 await snap.request({
-  method: 'snap_dialog',
+  method: "snap_dialog",
   params: {
-    type: 'Alert',
-    content: panel([
-      text(greeting),
-    ]),
+    type: "Alert",
+    content: panel([text(greeting)]),
   },
 });
 ```
@@ -572,41 +570,40 @@ This can be done using [`snap_manageState`](#snap_managestate).
 #### Example
 
 ```typescript
-import { Keyring, KeyringAccount } from '@metamask/keyring-api';
+import { Keyring, KeyringAccount } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
   // ... other methods
 
   async createAccount(
     name: string,
-    options: Record<string, Json> | null = null,
+    options: Record<string, Json> | null = null
   ): Promise<KeyringAccount> {
-
     const account: KeyringAccount = {
       id: uuid(),
       name,
       options,
       address,
       supportedMethods: [
-        'eth_sendTransaction',
-        'eth_sign',
-        'eth_signTransaction',
-        'eth_signTypedData_v1',
-        'eth_signTypedData_v2',
-        'eth_signTypedData_v3',
-        'eth_signTypedData_v4',
-        'eth_signTypedData',
-        'personal_sign',
+        "eth_sendTransaction",
+        "eth_sign",
+        "eth_signTransaction",
+        "eth_signTypedData_v1",
+        "eth_signTypedData_v2",
+        "eth_signTypedData_v3",
+        "eth_signTypedData_v4",
+        "eth_signTypedData",
+        "personal_sign",
       ],
-      type: 'eip155:eoa',
+      type: "eip155:eoa",
     };
 
     // Store the account in state
 
     await snap.request({
-      method: 'snap_manageAccounts',
+      method: "snap_manageAccounts",
       params: {
-        method: 'createAccount',
+        method: "createAccount",
         params: { account },
       },
     });
@@ -636,7 +633,7 @@ This can be done using [`snap_manageState`](#snap_managestate).
 #### Example
 
 ```typescript
-import { Keyring, KeyringAccount } from '@metamask/keyring-api';
+import { Keyring, KeyringAccount } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
   // ... other methods
@@ -645,9 +642,9 @@ class MyKeyring implements Keyring {
     // Store the new account details in state
 
     await snap.request({
-      method: 'snap_manageAccounts',
+      method: "snap_manageAccounts",
       params: {
-        method: 'updateAccount',
+        method: "updateAccount",
         params: { account },
       },
     });
@@ -675,7 +672,7 @@ This can be done using [`snap_manageState`](#snap_managestate).
 #### Example
 
 ```typescript
-import { Keyring } from '@metamask/keyring-api';
+import { Keyring } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
   // ... other methods
@@ -684,9 +681,9 @@ class MyKeyring implements Keyring {
     // Delete the account from state
 
     await snap.request({
-      method: 'snap_manageAccounts',
+      method: "snap_manageAccounts",
       params: {
-        method: 'deleteAccount',
+        method: "deleteAccount",
         params: { id },
       },
     });
@@ -747,8 +744,8 @@ This is usually called as part of the `approveRequest` method of the
 #### Example
 
 ```typescript
-import { Keyring } from '@metamask/keyring-api';
-import { Json } from '@metamask/utils';
+import { Keyring } from "@metamask/keyring-api";
+import { Json } from "@metamask/utils";
 
 class MyKeyring implements Keyring {
   // ... other methods
@@ -757,10 +754,10 @@ class MyKeyring implements Keyring {
     // Do any Snap-side logic to finish approving the request
 
     await snap.request({
-      method: 'snap_manageAccounts',
+      method: "snap_manageAccounts",
       params: {
-        method: 'submitResponse',
-        params: { id, result}
+        method: "submitResponse",
+        params: { id, result },
       },
     });
   }
@@ -802,14 +799,14 @@ The value stored in state if the operation is `get`, and `null` otherwise.
 ```javascript
 // Persist some data.
 await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'update', newState: { hello: 'world' } },
+  method: "snap_manageState",
+  params: { operation: "update", newState: { hello: "world" } },
 });
 
 // At a later time, get the data stored.
 const persistedData = await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'get' },
+  method: "snap_manageState",
+  params: { operation: "get" },
 });
 
 console.log(persistedData);
@@ -817,8 +814,8 @@ console.log(persistedData);
 
 // If there's no need to store data anymore, clear it out.
 await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'clear' },
+  method: "snap_manageState",
+  params: { operation: "clear" },
 });
 ```
 
@@ -842,10 +839,10 @@ An object containing the contents of the notification:
 
 ```javascript
 await snap.request({
-  method: 'snap_notify',
+  method: "snap_notify",
   params: {
-    type: 'inApp',
-    message: 'Hello, world!',
+    type: "inApp",
+    message: "Hello, world!",
   },
 });
 ```


### PR DESCRIPTION
Resolves: https://github.com/MetaMask/metamask-docs/issues/1144

This pull request attempts to ensure that the code samples in the docs follow some consistent style guideline. To accomplish this, the code samples were formatted using the Prettier formatter plugin and the following rules:

Double quotes preferred over single quotes
4-space indentation preferred over 2-space
Trailing commas preferred over no trailing commas
No metadata preferred over metadata