### PR TITLE
Update tabs syntax to Docusaurus default in snaps

### DIFF
--- a/services/gas-api/api-reference/gasprices-type2.md
+++ b/services/gas-api/api-reference/gasprices-type2.md
@@ -2,6 +2,9 @@
 description: Get the estimated gas prices for a chain.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Get EIP-1559 gas prices
 
 Returns the estimated [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) gas fees for the specified

--- a/snaps/how-to/debug-a-snap/common-issues.md
+++ b/snaps/how-to/debug-a-snap/common-issues.md
@@ -210,9 +210,9 @@ fetch('https://api.github.com/users/MetaMask')
   .then((json) => console.log(json))
   .catch((err) => console.error(err));
 ```
+
 </TabItem>
 </Tabs>
-
 
 For more information, see how to
 [replace axios with a simple custom fetch wrapper](https://kentcdodds.com/blog/replace-axios-with-a-simple-custom-fetch-wrapper).

--- a/snaps/how-to/debug-a-snap/common-issues.md
+++ b/snaps/how-to/debug-a-snap/common-issues.md
@@ -3,6 +3,9 @@ description: Solve common issues.
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Troubleshoot common issues
 
 This page describes common issues you may encounter when developing a Snap, and how to resolve them.
@@ -169,9 +172,8 @@ The following is an example of how you can rewrite your dependency to use `fetch
 In a production environment this may be a large task depending on the usage of `axios`.
 :::
 
-<!--tabs-->
-
-# axios
+<Tabs>
+<TabItem value="axios">
 
 ```javascript
 const instance = axios.create({
@@ -194,7 +196,8 @@ instance
   });
 ```
 
-# fetch
+</TabItem>
+<TabItem value="fetch">
 
 ```javascript
 fetch('https://api.github.com/users/MetaMask')
@@ -207,8 +210,9 @@ fetch('https://api.github.com/users/MetaMask')
   .then((json) => console.log(json))
   .catch((err) => console.error(err));
 ```
+</TabItem>
+</Tabs>
 
-<!--/tabs-->
 
 For more information, see how to
 [replace axios with a simple custom fetch wrapper](https://kentcdodds.com/blog/replace-axios-with-a-simple-custom-fetch-wrapper).

--- a/snaps/reference/cli/subcommands.md
+++ b/snaps/reference/cli/subcommands.md
@@ -19,21 +19,22 @@ yarn mm-snap [SUBCOMMAND] [OPTIONS]
 
 ## b, build
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap build [options]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap b -s lib/index.js -d out -n snap.js
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 Builds a Snap from source.
 
@@ -41,21 +42,22 @@ Builds a Snap from source.
 
 ## e, eval
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap eval [options]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap e -b out/snap.js
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 Attempts to evaluate the Snap bundle in SES.
 
@@ -63,21 +65,22 @@ Attempts to evaluate the Snap bundle in SES.
 
 ## i, init
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap init [directory]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap i my-snap
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 Initializes a Snap project in the specified directory.
 If no directory is specified, the Snap project is initialized in the current directory.
@@ -86,21 +89,22 @@ If no directory is specified, the Snap project is initialized in the current dir
 
 ## m, manifest
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap manifest [options]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap m --fix false
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 Validates the Snap [manifest file](../../learn/about-snaps/files.md#manifest-file).
 
@@ -108,21 +112,23 @@ Validates the Snap [manifest file](../../learn/about-snaps/files.md#manifest-fil
 
 ## s, serve
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap serve [options]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap s -r out -p 9000
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
+
 
 Locally serves Snap files for testing.
 
@@ -130,21 +136,22 @@ Locally serves Snap files for testing.
 
 ## w, watch
 
-<!--tabs-->
-
-# Syntax
+<Tabs>
+<TabItem value="Syntax">
 
 ```bash
 yarn mm-snap watch [options]
 ```
 
-# Example
+</TabItem>
+<TabItem value="Example">
 
 ```bash
 yarn mm-snap w -s lib/index.js -d out
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 Rebuilds a Snap from source upon changes to the files in the parent and child directories of the
 source directory.

--- a/snaps/reference/cli/subcommands.md
+++ b/snaps/reference/cli/subcommands.md
@@ -129,7 +129,6 @@ yarn mm-snap s -r out -p 9000
 </TabItem>
 </Tabs>
 
-
 Locally serves Snap files for testing.
 
 `s` is an alias for `serve`.

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -2,6 +2,9 @@
 description: See the Snaps entry points reference.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Snaps entry points
 
 Snaps can expose the following entry points.
@@ -30,9 +33,8 @@ A promise containing the return of the implemented method.
 
 #### Example
 
-<!--tabs-->
-
-# TypeScript
+<Tabs>
+<TabItem value="TypeScript">
 
 ```typescript
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
@@ -50,8 +52,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
   }
 };
 ```
-
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 module.exports.onRpcRequest = async ({ origin, request }) => {
@@ -64,8 +66,8 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
   }
 };
 ```
-
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `onTransaction`
 
@@ -97,7 +99,8 @@ for the transaction that `onTransaction` was called with.
 
 #### Example
 
-<!--tabs-->
+<Tabs>
+<TabItem value="TypeScript">
 
 # TypeScript
 
@@ -121,7 +124,8 @@ export const onTransaction: OnTransactionHandler = async ({
 };
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 import { panel, heading, text } from '@metamask/snaps-ui';
@@ -142,7 +146,8 @@ module.exports.onTransaction = async ({
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ### Transaction severity level
 
@@ -154,7 +159,8 @@ MetaMask shows a modal with the warning before the user can confirm the transact
 Using the previous example for `onTransaction`, the following code adds a single line to return an
 insight with the severity level `critical`: 
 
-<!--tabs-->
+<Tabs>
+<TabItem value="TypeScript">
 
 # TypeScript
 
@@ -180,7 +186,9 @@ export const onTransaction: OnTransactionHandler = async ({
 };
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
+
 
 ```js
 import { panel, heading, text } from '@metamask/snaps-ui';
@@ -203,7 +211,8 @@ module.exports.onTransaction = async ({
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `onCronjob`
 
@@ -237,7 +246,8 @@ An object containing an RPC request specified in the `endowment:cronjob` permiss
 
 #### Example
 
-<!--tabs-->
+<Tabs>
+<TabItem value="TypeScript">
 
 # TypeScript
 
@@ -261,7 +271,8 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
 };
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 module.exports.onCronjob = async ({ request }) => {
@@ -281,7 +292,8 @@ module.exports.onCronjob = async ({ request }) => {
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `onInstall`
 
@@ -300,7 +312,8 @@ None.
 
 #### Example
 
-<!--tabs-->
+<Tabs>
+<TabItem value="TypeScript">
 
 # TypeScript
 
@@ -324,7 +337,8 @@ export const onInstall: OnInstallHandler = async () => {
 };
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 import { heading, panel, text } from '@metamask/snaps-sdk';
@@ -345,7 +359,8 @@ module.exports.onInstall = async () => {
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `onUpdate`
 
@@ -364,9 +379,8 @@ None.
 
 #### Example
 
-<!--tabs-->
-
-# TypeScript
+<Tabs>
+<TabItem value="TypeScript">
 
 ```typescript
 import type { OnUpdateHandler } from '@metamask/snaps-sdk';
@@ -390,8 +404,8 @@ export const onUpdate: OnUpdateHandler = async () => {
   });
 };
 ```
-
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 import { heading, panel, text } from '@metamask/snaps-sdk';
@@ -415,7 +429,8 @@ module.exports.onUpdate = async () => {
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `onHomePage`
 
@@ -441,9 +456,8 @@ A content object displayed using [custom UI](../features/custom-ui.md).
 
 #### Example
 
-<!--tabs-->
-
-# TypeScript
+<Tabs>
+<TabItem value="TypeScript">
 
 ```typescript
 import type { OnHomePageHandler } from '@metamask/snaps-sdk';
@@ -459,7 +473,8 @@ export const onHomePage: OnHomePageHandler = async () => {
 };
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```js
 import { panel, text, heading } from '@metamask/snaps-sdk';
@@ -474,4 +489,5 @@ module.exports.onHomePage = async () => {
 };
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -52,6 +52,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
   }
 };
 ```
+
 </TabItem>
 <TabItem value="JavaScript">
 
@@ -66,6 +67,7 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
   }
 };
 ```
+
 </TabItem>
 </Tabs>
 
@@ -188,7 +190,6 @@ export const onTransaction: OnTransactionHandler = async ({
 
 </TabItem>
 <TabItem value="JavaScript">
-
 
 ```js
 import { panel, heading, text } from '@metamask/snaps-ui';
@@ -404,6 +405,7 @@ export const onUpdate: OnUpdateHandler = async () => {
   });
 };
 ```
+
 </TabItem>
 <TabItem value="JavaScript">
 

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -3,6 +3,9 @@ description: See the Snaps API reference.
 toc_max_heading_level: 2
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Snaps API
 
 Snaps can communicate with and modify the functionality of MetaMask using the [Snaps API](../learn/about-snaps/apis.md#snaps-api).
@@ -165,9 +168,8 @@ its corresponding key material:
 
 ### Example
 
-<!--tabs-->
-
-# Manifest file
+<Tabs>
+<TabItem value="manifest" label="Manifest file" default>
 
 ```json
 "initialPermissions": {
@@ -180,7 +182,8 @@ its corresponding key material:
 }
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```javascript
 import { SLIP10Node } from '@metamask/key-tree';
@@ -207,7 +210,8 @@ const accountKey1 = await dogecoinSlip10Node.derive(["bip32:1'"]);
 // Now, you can ask the user to sign transactions, etc.
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `snap_getBip32PublicKey`
 
@@ -233,9 +237,8 @@ The public key as hexadecimal string.
 
 ### Example
 
-<!--tabs-->
-
-# Manifest file
+<Tabs>
+<TabItem value="manifest" label="Manifest file" default>
 
 ```json
 "initialPermissions": {
@@ -248,7 +251,8 @@ The public key as hexadecimal string.
 }
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```javascript
 // This example uses Dogecoin, which has a derivation path starting with `m/44'/3'`.
@@ -266,7 +270,8 @@ const dogecoinPublicKey = await snap.request({
 console.log(dogecoinPublicKey);
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `snap_getBip44Entropy`
 
@@ -317,9 +322,8 @@ and containing its corresponding key material:
 
 ### Example
 
-<!--tabs-->
-
-# Manifest file
+<Tabs>
+<TabItem value="manifest" label="Manifest file" default>
 
 ```json
 "initialPermissions": {
@@ -331,7 +335,8 @@ and containing its corresponding key material:
 }
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```javascript
 import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
@@ -360,7 +365,8 @@ const addressKey1 = await deriveDogecoinAddress(1);
 // Now, you can ask the user to sign transactions, etc.
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `snap_getClientStatus`
 
@@ -426,9 +432,8 @@ The entropy as a hexadecimal string.
 
 ### Example
 
-<!--tabs-->
-
-# Manifest file
+<Tabs>
+<TabItem value="manifest" label="Manifest file" default>
 
 ```json
 "initialPermissions": {
@@ -436,7 +441,8 @@ The entropy as a hexadecimal string.
 }
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```javascript
 const entropy = await snap.request({
@@ -451,7 +457,8 @@ const entropy = await snap.request({
 console.log(entropy);
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `snap_getFile`
 
@@ -471,9 +478,8 @@ The file content as a string in the requested encoding.
 
 ### Example
 
-<!--tabs-->
-
-# Manifest file
+<Tabs>
+<TabItem value="manifest" label="Manifest file" default>
 
 ```json
 "source": {
@@ -487,7 +493,8 @@ The file content as a string in the requested encoding.
 }
 ```
 
-# JavaScript
+</TabItem>
+<TabItem value="JavaScript">
 
 ```javascript
 const contents = await snap.request({
@@ -502,7 +509,8 @@ const contents = await snap.request({
 console.log(contents);
 ```
 
-<!--/tabs-->
+</TabItem>
+</Tabs>
 
 ## `snap_getLocale`
 

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -169,7 +169,7 @@ its corresponding key material:
 ### Example
 
 <Tabs>
-<TabItem value="manifest" label="Manifest file" default>
+<TabItem value="Manifest file">
 
 ```json
 "initialPermissions": {
@@ -238,7 +238,7 @@ The public key as hexadecimal string.
 ### Example
 
 <Tabs>
-<TabItem value="manifest" label="Manifest file" default>
+<TabItem value="Manifest file">
 
 ```json
 "initialPermissions": {
@@ -323,7 +323,7 @@ and containing its corresponding key material:
 ### Example
 
 <Tabs>
-<TabItem value="manifest" label="Manifest file" default>
+<TabItem value="Manifest file">
 
 ```json
 "initialPermissions": {
@@ -433,7 +433,7 @@ The entropy as a hexadecimal string.
 ### Example
 
 <Tabs>
-<TabItem value="manifest" label="Manifest file" default>
+<TabItem value="Manifest file">
 
 ```json
 "initialPermissions": {
@@ -479,7 +479,7 @@ The file content as a string in the requested encoding.
 ### Example
 
 <Tabs>
-<TabItem value="manifest" label="Manifest file" default>
+<TabItem value="Manifest file">
 
 ```json
 "source": {


### PR DESCRIPTION
Part of #1100 

This PR is focused on the snaps folder to limit the number of files changed. Additionally, it includes Tabs and TabItem imports in gas-api/eip1559, which were previously missing, causing tabs not to render.