### PR TITLE
Remove "Flask" label on Keyring API docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -309,6 +309,10 @@ const config = {
             to: "/snaps/features/non-evm-networks",
           },
           {
+            from: "/snaps/concepts/keyring-api",
+            to: "/snaps/features/custom-evm-accounts",
+          },
+          {
             from: "/snaps/tutorials/custom-evm-accounts",
             to: "/snaps/features/custom-evm-accounts/create-account-snap",
           },

--- a/snaps-sidebar.js
+++ b/snaps-sidebar.js
@@ -93,9 +93,6 @@ const sidebar = {
             type: "doc",
             id: "reference/keyring-api/index",
           },
-          customProps: {
-            flask_only: true,
-          },
           items: require("./snaps/reference/keyring-api/typedoc-sidebar.cjs"),
         },
         {

--- a/snaps/features/custom-evm-accounts/create-account-snap.md
+++ b/snaps/features/custom-evm-accounts/create-account-snap.md
@@ -12,9 +12,6 @@ import TabItem from '@theme/TabItem';
 
 Create an account management Snap to connect to custom EVM accounts.
 
-:::flaskOnly
-:::
-
 :::tip see also
 - [About custom EVM accounts](index.md)
 - [Create an account management companion dapp](create-companion-dapp.md)

--- a/snaps/features/custom-evm-accounts/create-companion-dapp.md
+++ b/snaps/features/custom-evm-accounts/create-companion-dapp.md
@@ -13,9 +13,6 @@ Use the [`KeyringSnapRpcClient`](../../reference/keyring-api/classes/KeyringSnap
 call Keyring API methods from your companion dapp, enabling users to create and interact with custom
 EVM accounts.
 
-:::flaskOnly
-:::
-
 :::tip see also
 - [About custom EVM accounts](index.md)
 - [Create an account management Snap](create-account-snap.md)

--- a/snaps/features/custom-evm-accounts/index.md
+++ b/snaps/features/custom-evm-accounts/index.md
@@ -1,8 +1,6 @@
 ---
 description: Connect to custom EVM accounts using the Keyring API.
 sidebar_position: 4
-sidebar_custom_props:
-  flask_only: true
 tags:
   - Keyring API
 ---
@@ -21,9 +19,6 @@ To use the Keyring API, you first [implement the API in an account management Sn
 (also known as an "account Snap").
 You can then [call Keyring API methods from a companion dapp](create-companion-dapp.md)
 to enable users to create and interact with the custom accounts.
-
-:::flaskOnly
-:::
 
 :::tip see also
 - [Create an account management Snap](create-account-snap.md)

--- a/snaps/features/custom-evm-accounts/security.md
+++ b/snaps/features/custom-evm-accounts/security.md
@@ -10,9 +10,6 @@ tags:
 
 Refer to the following security guidelines when [creating an account management Snap](create-account-snap.md).
 
-:::flaskOnly
-:::
-
 :::tip see also
 - [About custom EVM accounts](index.md)
 - [Create an account management Snap](create-account-snap.md)

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -95,6 +95,12 @@ The following Snaps features are available in the stable version of MetaMask:
       href: "features/static-files",
       title: "Static files",
       description: "Lazy-load static files such as Wasm modules or ZK circuits."
+    },
+    {
+      icon: require("./assets/features/network.png").default,
+      href: "features/custom-evm-accounts",
+      title: "Custom EVM accounts",
+      description: "Connect to custom EVM accounts in MetaMask."
     }
   ]}
 />
@@ -104,13 +110,6 @@ the canary distribution of MetaMask:
 
 <CardList
   items={[
-    {
-      icon: require("./assets/features/network.png").default,
-      href: "features/custom-evm-accounts",
-      title: "Custom EVM accounts",
-      description: "Connect to custom EVM accounts in MetaMask.",
-      flaskOnly: true
-    },
     {
       icon: require("./assets/features/tx-severity.png").default,
       href: "reference/entry-points/#transaction-severity-level",

--- a/snaps/reference/keyring-api-index/index.md
+++ b/snaps/reference/keyring-api-index/index.md
@@ -9,12 +9,9 @@ tags:
 This section describes the Keyring API methods.
 See the left sidebar for the API categories and methods.
 
-:::flaskOnly
-:::
-
 :::tip See also
 - [Create an account management Snap](../../features/custom-evm-accounts/create-account-snap.md)
   - [Account management Snap security guidelines](../../features/custom-evm-accounts/security.md)
-- [Use the Keyring API from a dapp](../../features/custom-evm-accounts/create-companion-dapp.md)
+- [Create an account management companion dapp](../../features/custom-evm-accounts/create-companion-dapp.md)
 - [About the Keyring API](../../features/custom-evm-accounts/index.md)
 :::

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -99,9 +99,6 @@ Specify this permission in the manifest file as follows:
 
 ### `endowment:keyring`
 
-:::flaskOnly
-:::
-
 For a dapp to call [Keyring API](../features/custom-evm-accounts/index.md) methods on an account management Snap,
 the Snap must configure a list of allowed dapp URLs using the `endowment:keyring` permission.
 If a dapp hosted on a domain not listed in the `allowedOrigins` attempts to call a Keyring API method,

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -548,9 +548,6 @@ await snap.request({
 
 ## `snap_manageAccounts`
 
-:::flaskOnly
-:::
-
 Manages [account management Snap](../features/custom-evm-accounts/index.md) accounts.
 This method is organized into multiple sub-methods which each take their own parameters:
 


### PR DESCRIPTION
This PR removes the **Flask** label from the Keyring API guides and reference. Fixes #1154.

Preview: https://docs.metamask.io/1154-remove-flask-keyring/snaps/