### PR TITLE
Update Suggested Git Command in Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ To contribute changes:
    Push your changes to the remote origin.
 
     ```bash
-    git add *
+    git add .
     git commit -m "<COMMIT-MESSAGE>"
     git push origin
     ```


### PR DESCRIPTION
## Description:
The current contribution guidelines recommend using `git add *` to stage changes before committing. However, it's more conventional and safer to use `git add .` to stage changes in the current directory. The difference lies in the behavior of these commands, where `git add *` stages all changes in the current directory and its subdirectories, potentially including unintended files, while `git add .` stages changes only in the current directory without including untracked files.

## Solution:
Update the contribution guidelines to recommend using `git add .` instead of `git add *` for staging changes before committing. This will ensure consistency and help contributors avoid accidentally staging files they didn't intend to include in their commits.