### PR TITLE
Readd open graph

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -374,6 +374,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        { name: 'og:image', content: '/img/metamaskog.jpeg' },
+      ],
       navbar: {
         title: " │ ‎ Documentation",
         logo: {


### PR DESCRIPTION
I don't know what happened, but this change is missing from the repo and  now the OG image is not rendering . This PR aims to readd the Metamask open graph image., Originally added in this [PR](https://github.com/MetaMask/metamask-docs/pull/1102/files)