### PR TITLE
Homepage and getLocale is no longer flask-only

### DIFF
--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -101,6 +101,12 @@ The following Snaps features are available in the stable version of MetaMask:
       href: "features/custom-evm-accounts",
       title: "Custom EVM accounts",
       description: "Connect to custom EVM accounts in MetaMask."
+    },
+    {
+      icon: require("./assets/features/homepage.png").default,
+      href: "reference/permissions#endowmentpage-home",
+      title: "Home pages",
+      description: "Present a dedicated UI page in MetaMask for your Snap."
     }
   ]}
 />
@@ -115,13 +121,6 @@ the canary distribution of MetaMask:
       href: "reference/entry-points/#transaction-severity-level",
       title: "Transaction severity",
       description: "Add extra friction to the transaction flow if a transaction looks risky.",
-      flaskOnly: true
-    },
-    {
-      icon: require("./assets/features/homepage.png").default,
-      href: "reference/permissions#endowmentpage-home",
-      title: "Home pages",
-      description: "Present a dedicated UI page in MetaMask for your Snap.",
       flaskOnly: true
     },
     {

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -427,9 +427,6 @@ module.exports.onUpdate = async () => {
 
 ### `onHomePage`
 
-:::flaskOnly
-:::
-
 To build an embedded UI in MetaMask that any user can access through the Snaps menu, a Snap must
 expose the `onHomePage` entry point. 
 MetaMask calls the `onHomePage` handler method when the user selects the Snap name in the Snaps menu.

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -82,9 +82,6 @@ See the [list of methods](../learn/about-snaps/apis.md#metamask-json-rpc-api) no
 
 ### `endowment:page-home`
 
-:::flaskOnly
-:::
-
 To present a dedicated UI within MetaMask, a Snap must request the `endowment:page-home` permission. 
 This permission allows the Snap to specify a "home page" by exposing the
 [`onHomePage`](../reference/entry-points.md#onhomepage) entry point. 

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -515,9 +515,6 @@ console.log(contents);
 
 ## `snap_getLocale`
 
-:::flaskOnly
-:::
-
 Gets the user's locale setting. You can use this method to localize text in your snap.
 
 ### Returns


### PR DESCRIPTION
This removes the flask-only admonition from the home page endowment and entry point. 