### PR TITLE
Replace deprecated instances with `metamask/snaps-sdk`

### DIFF
--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -262,4 +262,4 @@ name of the method for showing gas fee estimates.
 If you change the method name in `/packages/site/src/pages/index.tsx`, ensure you change the method name in `/packages/snap/src/index.ts` to match.
 
 After you have made all necessary changes, you can
-[publish your Snap to npm](../../how-to/publish-a-snap.md#publish-your-snap).
+[publish your Snap to npm](../../how-to/publish-a-snap.md).

--- a/snaps/learn/tutorials/transaction-insights.md
+++ b/snaps/learn/tutorials/transaction-insights.md
@@ -147,9 +147,9 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
 ```
 
 :::tip
-If you have previously developed a decentralized app (dApp), you're likely familiar with 
-accessing the Ethereum provider using `window.ethereum`. In a Snap, the `window` object is not available.
-Instead when you request the `endowment:ethereum-provider` permission, your Snap is granted access to the `ethereum` global object. 
+If you have previously developed a dapp, you're likely familiar with accessing the Ethereum provider using `window.ethereum`.
+In a Snap, the `window` object is not available.
+Instead, when you request the `endowment:ethereum-provider` permission, your Snap is granted access to the [`ethereum` global object](../about-snaps/apis.md#snap-requests).
 :::
 
 ### 4. Build and test the Snap

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -106,8 +106,8 @@ for the transaction that `onTransaction` was called with.
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnTransactionHandler } from '@metamask/snaps-types';
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { OnTransactionHandler } from '@metamask/snaps-sdk';
+import { panel, heading, text } from '@metamask/snaps-sdk';
 
 export const onTransaction: OnTransactionHandler = async ({
   transaction,
@@ -129,7 +129,7 @@ export const onTransaction: OnTransactionHandler = async ({
 <TabItem value="JavaScript">
 
 ```js
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { panel, heading, text } from '@metamask/snaps-sdk';
 
 module.exports.onTransaction = async ({
   transaction,
@@ -164,8 +164,8 @@ insight with the severity level `critical`:
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnTransactionHandler } from '@metamask/snaps-types';
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { OnTransactionHandler } from '@metamask/snaps-sdk';
+import { panel, heading, text } from '@metamask/snaps-sdk';
 
 export const onTransaction: OnTransactionHandler = async ({
   transaction,
@@ -189,7 +189,7 @@ export const onTransaction: OnTransactionHandler = async ({
 <TabItem value="JavaScript">
 
 ```js
-import { panel, heading, text } from '@metamask/snaps-ui';
+import { panel, heading, text } from '@metamask/snaps-sdk';
 
 module.exports.onTransaction = async ({
   transaction,

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -106,7 +106,7 @@ for the transaction that `onTransaction` was called with.
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnTransactionHandler } from '@metamask/snaps-sdk';
+import type { OnTransactionHandler } from '@metamask/snaps-sdk';
 import { panel, heading, text } from '@metamask/snaps-sdk';
 
 export const onTransaction: OnTransactionHandler = async ({

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -38,7 +38,7 @@ A promise containing the return of the implemented method.
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnRpcRequestHandler } from '@metamask/snaps-types';
+import { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 export const onRpcRequest: OnRpcRequestHandler = async ({
   origin,
@@ -248,7 +248,7 @@ An object containing an RPC request specified in the `endowment:cronjob` permiss
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnCronjobHandler } from '@metamask/snaps-types';
+import { OnCronjobHandler } from '@metamask/sdk';
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
   switch (request.method) {

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -38,7 +38,7 @@ A promise containing the return of the implemented method.
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 export const onRpcRequest: OnRpcRequestHandler = async ({
   origin,
@@ -164,7 +164,7 @@ insight with the severity level `critical`:
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnTransactionHandler } from '@metamask/snaps-sdk';
+import type { OnTransactionHandler } from '@metamask/snaps-sdk';
 import { panel, heading, text } from '@metamask/snaps-sdk';
 
 export const onTransaction: OnTransactionHandler = async ({
@@ -248,7 +248,7 @@ An object containing an RPC request specified in the `endowment:cronjob` permiss
 <TabItem value="TypeScript">
 
 ```typescript
-import { OnCronjobHandler } from '@metamask/sdk';
+import type { OnCronjobHandler } from '@metamask/sdk';
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
   switch (request.method) {

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -37,7 +37,7 @@ An object containing the contents of the alert dialog:
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from '@metamask/snaps-sdk';
 
 await snap.request({
   method: 'snap_dialog',
@@ -71,7 +71,7 @@ An object containing the contents of the confirmation dialog:
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from '@metamask/snaps-sdk';
 
 const result = await snap.request({
   method: 'snap_dialog',
@@ -108,7 +108,7 @@ The text entered by the user if the prompt was submitted or `null` if the prompt
 #### Example
 
 ```javascript
-import { panel, text, heading } from '@metamask/snaps-ui';
+import { panel, text, heading } from '@metamask/snaps-sdk';
 
 const walletAddress = await snap.request({
   method: 'snap_dialog',
@@ -524,7 +524,7 @@ The user's locale setting as a [language code](https://github.com/MetaMask/metam
 ### Example
 
 ```javascript
-import { panel, text } from '@metamask/snaps-ui';
+import { panel, text } from '@metamask/snaps-sdk';
 
 const locale = await snap.request({ method: 'snap_getLocale' });
 


### PR DESCRIPTION
Closes #1211 

I believe the following are deprecated:
- `metamask/snaps-types`
- `metamask/snaps-ui`

We should remove instances and replaces with `metamask/snaps-sdk`

@Montoya 