### PR TITLE
Refer to important integration steps in SDK guides

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -183,16 +183,28 @@ const config = {
             to: "/wallet/how-to/display/icon",
           },
           {
-            from: "/wallet/how-to/use-3rd-party-integrations/js-infura-api",
-            to: "/wallet/how-to/make-read-only-requests",
-          },
-          {
             from: "/wallet/how-to/request-permissions",
             to: "/wallet/how-to/manage-permissions",
           },
           {
             from: ["/guide/mobile-getting-started", "/guide/site-compatibility-checklist", "/guide/mobile-best-practices", "/wallet/how-to/use-mobile", "/wallet/how-to/integrate-with-mobile", "/sdk"],
             to: "/wallet/how-to/use-sdk",
+          },
+          {
+            from: "/wallet/how-to/sign-data/connect-and-sign",
+            to: "/wallet/how-to/use-sdk/javascript/connect-and-sign",
+          },
+          {
+            from: ["/wallet/how-to/use-3rd-party-integrations/js-infura-api", "/wallet/how-to/make-read-only-requests"],
+            to: "/wallet/how-to/use-sdk/javascript/make-read-only-requests",
+          },
+          {
+            from: "/wallet/how-to/batch-json-rpc-requests",
+            to: "/wallet/how-to/use-sdk/javascript/batch-json-rpc-requests",
+          },
+          {
+            from: "/wallet/how-to/display/custom-modals",
+            to: "/wallet/how-to/use-sdk/javascript/display-custom-modals",
           },
           {
             from: "/wallet/how-to/use-3rd-party-integrations/unity-dweb",

--- a/wallet/concepts/sdk/index.md
+++ b/wallet/concepts/sdk/index.md
@@ -38,10 +38,10 @@ Most of these features are not available if you only integrate your dapp directl
 | Connect from a web dapp to the MetaMask extension                                             |        ✅        |      ✅       |
 | Connect from a web dapp to MetaMask Mobile                                                    |        ❌        |      ✅       |
 | Connect from desktop, mobile, and gaming dapps to MetaMask Mobile                             |        ❌        |      ✅       |
-| Use custom RPC methods such as [`connectAndSign`](../../how-to/sign-data/connect-and-sign.md) |        ❌        |      ✅       |
-| [Display custom modals](../../how-to/display/custom-modals.md) in MetaMask                    |        ❌        |      ✅       |
-| [Make read-only requests](../../how-to/make-read-only-requests.md) using the Infura API                 |        ❌        |      ✅       |
-| [Batch multiple RPC requests](../../how-to/batch-json-rpc-requests.md)                        |        ❌        |      ✅       |
+| Use custom RPC methods such as [`connectAndSign`](../../how-to/use-sdk/javascript/connect-and-sign.md) |        ❌        |      ✅       |
+| [Display custom modals](../../how-to/use-sdk/javascript/display-custom-modals.md) in MetaMask                    |        ❌        |      ✅       |
+| [Make read-only requests](../../how-to/use-sdk/javascript/make-read-only-requests.md) using the Infura API                 |        ❌        |      ✅       |
+| [Batch multiple RPC requests](../../how-to/use-sdk/javascript/batch-json-rpc-requests.md)                        |        ❌        |      ✅       |
 
 ## User experience
 

--- a/wallet/how-to/onboard-users.md
+++ b/wallet/how-to/onboard-users.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Onboard users
 description: Simplify the MetaMask onboarding experience for your users.
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 import Tabs from '@theme/Tabs';

--- a/wallet/how-to/run-devnet.md
+++ b/wallet/how-to/run-devnet.md
@@ -1,6 +1,6 @@
 ---
 description: Configure and connect to a Ganache development network.
-sidebar_position: 11
+sidebar_position: 9
 ---
 
 # Run a development network

--- a/wallet/how-to/secure-dapp.md
+++ b/wallet/how-to/secure-dapp.md
@@ -1,6 +1,6 @@
 ---
 description: Secure your dapp using HTTPS and CSP.
-sidebar_position: 12
+sidebar_position: 10
 ---
 
 # Secure your dapp

--- a/wallet/how-to/use-sdk/3rd-party-libraries/wagmi.md
+++ b/wallet/how-to/use-sdk/3rd-party-libraries/wagmi.md
@@ -19,7 +19,7 @@ the MetaMask browser extension and MetaMask Mobile.
 
 - Ensure you have a basic understanding of Ethereum smart contracts and React Hooks.
 - Set up a project with [Wagmi](https://wagmi.sh/react/getting-started).
-- Create an Infura API key and allowlist to [make read-only requests](../../make-read-only-requests.md).
+- Create an Infura API key and allowlist to [make read-only requests](../javascript/make-read-only-requests.md).
 
 ## Steps
 
@@ -75,7 +75,7 @@ This option is required when configuring the MetaMask connector with Wagmi.
 #### Infura API key
 
 We recommend specifying the [`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey)
-option to [make read-only requests](../../make-read-only-requests.md) using the Infura API.
+option to [make read-only requests](../javascript/make-read-only-requests.md) using the Infura API.
 Read more about the [benefits of using the Infura API with Wagmi](#benefits-of-using-the-infura-api-with-wagmi).
 
 #### Universal links

--- a/wallet/how-to/use-sdk/gaming/unity/connect-and-sign.md
+++ b/wallet/how-to/use-sdk/gaming/unity/connect-and-sign.md
@@ -7,7 +7,7 @@ tags:
 
 # Connect and sign in Unity
 
-You can [connect and sign](../../../sign-data/connect-and-sign.md) in a single interaction from your Unity game.
+You can [connect and sign](../../javascript/connect-and-sign.md) in a single interaction from your Unity game.
 
 ## Prerequisites
 

--- a/wallet/how-to/use-sdk/javascript/batch-json-rpc-requests.md
+++ b/wallet/how-to/use-sdk/javascript/batch-json-rpc-requests.md
@@ -7,7 +7,7 @@ tags:
 
 # Batch JSON-RPC requests
 
-You can batch multiple JSON-RPC requests using [MetaMask SDK](../concepts/sdk/index.md).
+You can batch multiple JSON-RPC requests using [MetaMask SDK](../../../concepts/sdk/index.md).
 
 The SDK's `metamask_batch` method enables you to batch multiple JSON-RPC requests in a single call,
 providing a streamlined approach for dapps to interact with EVM networks, and enabling complex
@@ -29,7 +29,7 @@ enhancing the user experience and operational efficiency.
 
 ## Prerequisites
 
-[Set up MetaMask SDK](../how-to/use-sdk/javascript/index.md) in your JavaScript dapp.
+[Set up MetaMask SDK](index.md) in your JavaScript dapp.
 
 ## Use the `metamask_batch` method
 
@@ -53,28 +53,28 @@ The following is an example of using `metamask_batch` to batch
 import { metamask_batch } from "metamask-sdk";
 
 function MyComponent() {
-  const handleBatchRequest = async () => {
-    const batchRequests = [
-      { method: "personal_sign", params: ["message", "address"] },
-      {
-        method: "eth_sendTransaction",
-        params: [
-          {
-            /* transaction parameters */
-          },
-        ],
-      },
-    ];
+    const handleBatchRequest = async () => {
+        const batchRequests = [
+            { method: "personal_sign", params: ["message", "address"] },
+            {
+                method: "eth_sendTransaction",
+                params: [
+                    {
+                        /* transaction parameters */
+                    },
+                ],
+            },
+        ];
+    
+        try {
+            const results = await metamask_batch(batchRequests);
+            console.log(results); // Process results
+        } catch (error) {
+            console.error("Batch request failed", error);
+        }
+    };
 
-    try {
-      const results = await metamask_batch(batchRequests);
-      console.log(results); // Process results
-    } catch (error) {
-      console.error("Batch request failed", error);
-    }
-  };
-
-  return <button onClick={handleBatchRequest}>Send Batch Request</button>;
+    return <button onClick={handleBatchRequest}>Send Batch Request</button>;
 }
 ```
 
@@ -89,28 +89,28 @@ The following is an example of using `metamask_batch` to batch
 import { metamask_batch } from "metamask-sdk";
 
 export default {
-  methods: {
-    async sendBatchRequest() {
-      const batchRequests = [
-        { method: "personal_sign", params: ["message", "address"] },
-        {
-          method: "eth_sendTransaction",
-          params: [
-            {
-              /* transaction parameters */
-            },
-          ],
-        },
-      ];
-
-      try {
-        const results = await metamask_batch(batchRequests);
-        console.log(results);
-      } catch (error) {
-        console.error("Error in batch request", error);
-      }
+    methods: {
+        async sendBatchRequest() {
+            const batchRequests = [
+                { method: "personal_sign", params: ["message", "address"] },
+                {
+                    method: "eth_sendTransaction",
+                    params: [
+                        {
+                            /* transaction parameters */
+                        },
+                    ],
+                },
+            ];
+      
+            try {
+                const results = await metamask_batch(batchRequests);
+                console.log(results);
+            } catch (error) {
+                console.error("Error in batch request", error);
+            }
+        }
     }
-  }
 }
 </script>
 ```

--- a/wallet/how-to/use-sdk/javascript/connect-and-sign.md
+++ b/wallet/how-to/use-sdk/javascript/connect-and-sign.md
@@ -1,6 +1,6 @@
 ---
 description: Use MetaMask SDK to connect and sign in a single interaction.
-sidebar_position: 1
+sidebar_position: 7
 tags:
   - JavaScript SDK
   - iOS SDK
@@ -9,7 +9,7 @@ tags:
 # Connect and sign
 
 You can connect to MetaMask and sign data in a single interaction from your JavaScript, iOS,
-Android, or Unity dapp using [MetaMask SDK](../../concepts/sdk/index.md).
+Android, or Unity dapp using [MetaMask SDK](../../../concepts/sdk/index.md).
 
 The SDK's `connectAndSign` method provides a streamlined approach for dapps to interact with MetaMask.
 This method combines the [`eth_requestAccounts`] and [`personal_sign`] RPC methods, executing them sequentially.
@@ -28,11 +28,11 @@ This is useful for various purposes such as authentication and transaction verif
 </p>
 
 The following instructions describe how to connect and sign in JavaScript.
-You can also see the [Unity instructions](../use-sdk/gaming/unity/connect-and-sign.md).
+You can also see the [Unity instructions](../gaming/unity/connect-and-sign.md).
 
 ## Prerequisites
 
-- [MetaMask SDK set up](../use-sdk/javascript/index.md) in your JavaScript dapp.
+- [MetaMask SDK set up](index.md) in your JavaScript dapp.
 
 - MetaMask Mobile version 7.10 or later.
   Your users must have an updated version of MetaMask Mobile for this feature to work correctly.
@@ -50,7 +50,7 @@ const connectAndSign = async () => {
         });
         setResponse(signResult);
     } catch (err) {
-        console.warn(`failed to connect..`, err);
+        console.warn("failed to connect..", err);
     }
 };
 ```

--- a/wallet/how-to/use-sdk/javascript/display-custom-modals.md
+++ b/wallet/how-to/use-sdk/javascript/display-custom-modals.md
@@ -1,13 +1,13 @@
 ---
 description: Display custom modals using the JavaScript SDK.
-sidebar_position: 4
+sidebar_position: 10
 tags:
   - JavaScript SDK
 ---
 
 # Display custom modals
 
-You can use [MetaMask SDK](../../concepts/sdk/index.md) to display custom MetaMask modals.
+You can use [MetaMask SDK](../../../concepts/sdk/index.md) to display custom MetaMask modals.
 
 When integrating a web dapp with MetaMask, you can enhance the user experience by customizing the
 logic and user interface of the displayed modals, which initiate user interactions such as prompting
@@ -18,7 +18,7 @@ other web frameworks such as Vue.js or pure HTML/JavaScript.
 ## Prerequisites
 
 MetaMask SDK set up in your JavaScript dapp.
-This example uses the [MetaMask React SDK](../use-sdk/javascript/react/index.md).
+This example uses the [MetaMask React SDK](react/index.md).
 
 ## Steps
 
@@ -40,8 +40,8 @@ export default CustomModal;
 
 ### 2. Implement custom modal logic
 
-When initializing [`MetaMaskProvider`](../use-sdk/javascript/react/index.md#3-wrap-your-project-with-metamaskprovider),
-use the [`modals`](../../reference/sdk-js-options.md#modals) SDK option to set up custom behavior
+When initializing [`MetaMaskProvider`](react/index.md#3-wrap-your-project-with-metamaskprovider),
+use the [`modals`](../../../reference/sdk-js-options.md#modals) SDK option to set up custom behavior
 for scenarios such as when MetaMask isn't installed.
 For example:
 
@@ -99,7 +99,7 @@ MetaMask isn't installed.
 
 <p align="center">
 
-![Custom modal gif](../../assets/custom-modal.gif)
+![Custom modal gif](../../../assets/custom-modal.gif)
 
 </p>
 

--- a/wallet/how-to/use-sdk/javascript/index.md
+++ b/wallet/how-to/use-sdk/javascript/index.md
@@ -58,25 +58,24 @@ Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
 
 ```javascript
 const MMSDK = new MetaMaskSDK({
-  dappMetadata: {
-    name: "JavaScript example dapp",
-    url: window.location.href,
-  },
-  // Other options
+    dappMetadata: {
+        name: "JavaScript example dapp",
+        url: window.location.href,
+    },
+    infuraAPIKey: process.env.INFURA_API_KEY,
+    // Other options
 });
 
 // You can also access via window.ethereum
 const ethereum = MMSDK.getProvider();
 ```
 
-:::note Important SDK options
 - Use [`dappMetadata`](../../../reference/sdk-js-options.md#dappmetadata) to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../display/custom-modals.md).
 - Use [`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../make-read-only-requests.md) from your dapp.
-:::
+  [make read-only RPC requests](make-read-only-requests.md) from your dapp.
+- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
+  the displayed modals](display-custom-modals.md).
 
 ### 4. Use the SDK
 
@@ -89,6 +88,9 @@ prompts the installation or connection popup to appear.
 ethereum.request({ method: "eth_requestAccounts", params: [] });
 ```
 
+You can also call the SDK's [`connectAndSign`](connect-and-sign.md) method, and
+[batch multiple JSON-RPC requests](batch-json-rpc-requests.md) using the `metamask_batch` method.
+
 ## Example
 
 You can copy the full JavaScript example to get started:
@@ -97,17 +99,18 @@ You can copy the full JavaScript example to get started:
 import { MetaMaskSDK } from "@metamask/sdk";
 
 const MMSDK = new MetaMaskSDK({
-  dappMetadata: {
-    name: "Example JavaScript Dapp",
-    url: window.location.href,
-  },
-  // Other options
+    dappMetadata: {
+        name: "Example JavaScript Dapp",
+        url: window.location.href,
+    },
+    infuraAPIKey: process.env.INFURA_API_KEY,
+    // Other options
 });
 
 // You can also access via window.ethereum
 const ethereum = MMSDK.getProvider();
 
-ethereum.request({ method: 'eth_requestAccounts', params: [] });
+ethereum.request({ method: "eth_requestAccounts", params: [] });
 ```
 
 See the [example JavaScript dapps](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples)

--- a/wallet/how-to/use-sdk/javascript/make-read-only-requests.md
+++ b/wallet/how-to/use-sdk/javascript/make-read-only-requests.md
@@ -8,7 +8,7 @@ tags:
 # Make read-only requests
 
 You can use the [Infura API](https://docs.infura.io/) from your dapp with
-[MetaMask SDK](../concepts/sdk/index.md) installed to make direct, read-only JSON-RPC requests.
+[MetaMask SDK](../../../concepts/sdk/index.md) installed to make direct, read-only JSON-RPC requests.
 
 Direct, read-only JSON-RPC requests are blockchain requests that do not require user wallet interaction.
 Your dapp can directly call most [JSON-RPC API methods](/wallet/reference/json-rpc-api), bypassing
@@ -51,12 +51,12 @@ Configure your dapp to make read-only requests using the [Infura API](#use-the-i
   We recommend using all allowlist options to maximize the security of your API key and dapp.
   :::
 
-- [MetaMask SDK set up](use-sdk/javascript/index.md) in your JavaScript dapp.
+- [MetaMask SDK set up](index.md) in your JavaScript dapp.
 
 ## Use the Infura API
 
 To use the Infura API to make read-only requests, specify your Infura API key using the
-[`infuraAPIKey`](../reference/sdk-js-options.md#infuraapikey) option when instantiating the SDK
+[`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) option when instantiating the SDK
 in your dapp.
 
 ```javascript
@@ -67,7 +67,7 @@ infuraAPIKey: "YOUR-API-KEY"
 
 To use your own node (for example, with [Hardhat](https://hardhat.org/)) to make read-only requests,
 specify your node's chain ID and RPC URL using the
-[`readonlyRPCMap`](../reference/sdk-js-options.md#readonlyrpcmap) option when instantiating the
+[`readonlyRPCMap`](../../../reference/sdk-js-options.md#readonlyrpcmap) option when instantiating the
 SDK in your dapp.
 
 ```javascript
@@ -81,8 +81,8 @@ In this example, chain ID `0x539` maps to the custom node's RPC URL.
 ## Use the Infura API and custom nodes
 
 You can use both the Infura API and custom nodes to make read-only requests by specifying both the
-[`infuraAPIKey`](../reference/sdk-js-options.md#infuraapikey) and
-[`readonlyRPCMap`](../reference/sdk-js-options.md#readonlyrpcmap) options when instantiating the
+[`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) and
+[`readonlyRPCMap`](../../../reference/sdk-js-options.md#readonlyrpcmap) options when instantiating the
 SDK in your dapp.
 
 ```javascript
@@ -124,5 +124,5 @@ sdkOptions={{
 
 In this example, read-only requests to Mainnet (chain ID `0x1`) use the Infura API, while read-only
 requests to the local testnet (chain ID `0x539`) use the custom node.
-[`defaultReadOnlyChainId`](../reference/sdk-js-options.md#defaultreadonlychainid) enables making
+[`defaultReadOnlyChainId`](../../../reference/sdk-js-options.md#defaultreadonlychainid) enables making
 read-only requests before the user connects to MetaMask, and specifies to make those requests to Mainnet.

--- a/wallet/how-to/use-sdk/javascript/nodejs.md
+++ b/wallet/how-to/use-sdk/javascript/nodejs.md
@@ -46,6 +46,7 @@ const MMSDK = new MetaMaskSDK({
         name: "Example Node.js Dapp",
         url: window.location.href,
     },
+    infuraAPIKey: process.env.INFURA_API_KEY,
     // Other options
 });
 
@@ -53,14 +54,12 @@ const MMSDK = new MetaMaskSDK({
 const ethereum = MMSDK.getProvider();
 ```
 
-:::note Important SDK options
 - Use [`dappMetadata`](../../../reference/sdk-js-options.md#dappmetadata) to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../display/custom-modals.md).
 - Use [`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../make-read-only-requests.md) from your dapp.
-:::
+  [make read-only RPC requests](make-read-only-requests.md) from your dapp.
+- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
+  the displayed modals](display-custom-modals.md).
 
 ### 4. Use the SDK
 
@@ -72,6 +71,9 @@ prompts the installation or connection popup to appear.
 ```javascript
 ethereum.request({ method: "eth_requestAccounts", params: [] });
 ```
+
+You can also call the SDK's [`connectAndSign`](connect-and-sign.md) method, and
+[batch multiple JSON-RPC requests](batch-json-rpc-requests.md) using the `metamask_batch` method.
 
 ## Example
 
@@ -85,6 +87,7 @@ const MMSDK = new MetaMaskSDK({
         name: "Example Node.js Dapp",
         url: window.location.href,
     },
+    infuraAPIKey: process.env.INFURA_API_KEY,
     // Other options
 });
 

--- a/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
+++ b/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
@@ -47,6 +47,7 @@ const MMSDK = new MetaMaskSDK(
         name: "Example JavaScript Dapp",
         url: window.location.href,
     },
+    infuraAPIKey: process.env.INFURA_API_KEY,
     // Other options
 );
 
@@ -54,14 +55,12 @@ const MMSDK = new MetaMaskSDK(
 const ethereum = MMSDK.getProvider();
 ```
 
-:::note Important SDK options
 - Use [`dappMetadata`](../../../reference/sdk-js-options.md#dappmetadata) to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../display/custom-modals.md).
 - Use [`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../make-read-only-requests.md) from your dapp.
-:::
+  [make read-only RPC requests](make-read-only-requests.md) from your dapp.
+- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
+  the displayed modals](display-custom-modals.md).
 
 ### 4. Use the SDK
 
@@ -73,6 +72,9 @@ prompts the installation or connection popup to appear.
 ```javascript
 ethereum.request({ method: "eth_requestAccounts", params: [] });
 ```
+
+You can also call the SDK's [`connectAndSign`](connect-and-sign.md) method, and
+[batch multiple JSON-RPC requests](batch-json-rpc-requests.md) using the `metamask_batch` method.
 
 ## Example
 
@@ -86,6 +88,7 @@ const MMSDK = new MetaMaskSDK(
         name: "Example JavaScript Dapp",
         url: window.location.href,
     },
+    infuraAPIKey: process.env.INFURA_API_KEY,
     // Other options
 );
 

--- a/wallet/how-to/use-sdk/javascript/pure-js.md
+++ b/wallet/how-to/use-sdk/javascript/pure-js.md
@@ -24,6 +24,7 @@ To import, instantiate, and use the SDK, you can insert a script in the head sec
                 name: "Example Pure JS Dapp",
                 url: window.location.href,
             },
+            infuraAPIKey: process.env.INFURA_API_KEY,
             // Other options
         )
         // Because the init process of MetaMask SDK is async.
@@ -38,20 +39,22 @@ To import, instantiate, and use the SDK, you can insert a script in the head sec
 </head>
 ```
 
-You can configure the SDK using any [options](../../../reference/sdk-js-options.md) and call any
-[provider API methods](../../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) using
-[`request()`](../../../reference/provider-api.md#request) first,
-since it prompts the installation or connection popup to appear.
+You can configure the SDK using any [options](../../../reference/sdk-js-options.md):
 
-:::note Important SDK options
 - Use [`dappMetadata`](../../../reference/sdk-js-options.md#dappmetadata) to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../display/custom-modals.md).
 - Use [`infuraAPIKey`](../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../make-read-only-requests.md) from your dapp.
-:::
+  [make read-only RPC requests](make-read-only-requests.md) from your dapp.
+- Use [`modals`](../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
+  the displayed modals](display-custom-modals.md).
+
+You can call any [provider API methods](../../../reference/provider-api.md) using the SDK.
+Always call [`eth_requestAccounts`](/wallet/reference/eth_requestaccounts) using
+[`request()`](../../../reference/provider-api.md#request) first, since it prompts the installation
+or connection popup to appear.
+
+You can also call the SDK's [`connectAndSign`](connect-and-sign.md) method, and
+[batch multiple JSON-RPC requests](batch-json-rpc-requests.md) using the `metamask_batch` method.
 
 ## Example
 

--- a/wallet/how-to/use-sdk/javascript/react/index.md
+++ b/wallet/how-to/use-sdk/javascript/react/index.md
@@ -69,6 +69,7 @@ root.render(
                     name: "Example React Dapp",
                     url: window.location.href,
                 },
+                infuraAPIKey: process.env.INFURA_API_KEY,
                 // Other options
             }}
         >
@@ -81,15 +82,14 @@ root.render(
 When initializing `MetaMaskProvider`, set `debug` to `true` to activate debug mode.
 For the full list of options you can set for `sdkOptions`, see the
 [JavaScript SDK options reference](../../../../reference/sdk-js-options.md).
+Important options include:
 
-:::note Important SDK options
-- Use [`dappMetadata`](../../../../reference/sdk-js-options.md#dappmetadata) to display information
+- [`dappMetadata`](../../../../reference/sdk-js-options.md#dappmetadata) - Use this to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../../display/custom-modals.md).
-- Use [`infuraAPIKey`](../../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../../make-read-only-requests.md) from your dapp.
-:::
+- [`infuraAPIKey`](../../../../reference/sdk-js-options.md#infuraapikey) - Use this to
+  [make read-only RPC requests](../make-read-only-requests.md) from your dapp.
+- [`modals`](../../../../reference/sdk-js-options.md#modals) - Use this to [customize the logic and UI of
+  the displayed modals](../display-custom-modals.md).
 
 ### 4. Use the SDK
 
@@ -145,21 +145,26 @@ export const App = () => {
 </p>
 </details>
 
-The `sdk.connect()` method initiates a connection to MetaMask and returns an array of connected accounts:
+The `connect` method initiates a connection to MetaMask and returns an array of connected accounts.
 
-```javascript
-const connect = async () => {
+You can also [use the `connectAndSign` method](../connect-and-sign.md) to
+connect to MetaMask and sign data in a single interaction:
+
+```js
+const connectAndSign = async () => {
     try {
-        const accounts = await sdk?.connect();
-        setAccount(accounts?.[0]);
+        const signResult = await sdk?.connectAndSign({
+            msg: "Connect + Sign message",
+        });
+        setResponse(signResult);
     } catch (err) {
-        console.warn(`failed to connect..`, err);
+        console.warn("failed to connect..", err);
     }
 };
 ```
 
-You can also [use the `connectAndSign` method](../../../sign-data/connect-and-sign.md) to
-connect to MetaMask and sign data in a single interaction.
+You can also [batch multiple JSON-RPC requests](../batch-json-rpc-requests.md) using the
+`metamask_batch` method.
 
 ## Example
 
@@ -187,6 +192,7 @@ root.render(
                     name: "Example React Dapp",
                     url: window.location.href,
                 },
+                infuraAPIKey: process.env.INFURA_API_KEY,
                 // Other options
             }}
         >

--- a/wallet/how-to/use-sdk/javascript/react/react-ui.md
+++ b/wallet/how-to/use-sdk/javascript/react/react-ui.md
@@ -70,6 +70,7 @@ root.render(
                     name: "Example React UI Dapp",
                     url: window.location.href,
                 },
+                infuraAPIKey: process.env.INFURA_API_KEY,
                 // Other options
             }}
         >
@@ -81,15 +82,14 @@ root.render(
 
 For the full list of options you can set for `sdkOptions`, see the
 [JavaScript SDK options reference](../../../../reference/sdk-js-options.md).
+Important options include:
 
-:::note Important SDK options
-- Use [`dappMetadata`](../../../../reference/sdk-js-options.md#dappmetadata) to display information
+- [`dappMetadata`](../../../../reference/sdk-js-options.md#dappmetadata) - Use this to display information
   about your dapp in the MetaMask connection modal.
-- Use [`modals`](../../../../reference/sdk-js-options.md#modals) to [customize the logic and UI of
-  the displayed modals](../../../display/custom-modals.md).
-- Use [`infuraAPIKey`](../../../../reference/sdk-js-options.md#infuraapikey) to
-  [make read-only RPC requests](../../../make-read-only-requests.md) from your dapp.
-:::
+- [`infuraAPIKey`](../../../../reference/sdk-js-options.md#infuraapikey) - Use this to
+  [make read-only RPC requests](../make-read-only-requests.md) from your dapp.
+- [`modals`](../../../../reference/sdk-js-options.md#modals) - Use this to [customize the logic and UI of
+  the displayed modals](../display-custom-modals.md).
 
 ### 4. Use the SDK
 
@@ -150,6 +150,7 @@ root.render(
                     name: "Example React UI Dapp",
                     url: window.location.href,
                 },
+                infuraAPIKey: process.env.INFURA_API_KEY,
                 // Other options
             }}
         >

--- a/wallet/reference/sdk-js-options.md
+++ b/wallet/reference/sdk-js-options.md
@@ -165,7 +165,7 @@ defaultReadOnlyChainId: "0x1"
 </TabItem>
 </Tabs>
 
-Enables sending [read-only RPC requests](../how-to/make-read-only-requests.md) to
+Enables sending [read-only RPC requests](../how-to/use-sdk/javascript/make-read-only-requests.md) to
 this chain ID before the user connects to MetaMask.
 The value is automatically updated to the chain ID used in MetaMask once connected.
 
@@ -234,7 +234,7 @@ infuraAPIKey: process.env.INFURA_API_KEY
 
 The [Infura API key](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/project-id) to
 use for RPC requests.
-Configure this option to [make read-only RPC requests from your dapp](../how-to/make-read-only-requests.md).
+Configure this option to [make read-only RPC requests from your dapp](../how-to/use-sdk/javascript/make-read-only-requests.md).
 
 :::caution important
 Use [Infura allowlists](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-an-allowlist)
@@ -282,7 +282,7 @@ modals: {
 </TabItem>
 </Tabs>
 
-An object that allows you to [customize the logic and UI of the displayed modals](../how-to/display/custom-modals.md).
+An object that allows you to [customize the logic and UI of the displayed modals](../how-to/use-sdk/javascript/display-custom-modals.md).
 This is useful if your dapp requires a custom way to handle connection and reconnection scenarios.
 
 ### `openDeeplink`
@@ -353,7 +353,7 @@ readonlyRPCMap: {
 </TabItem>
 </Tabs>
 
-A map of RPC URLs to use for [read-only RPC requests](../how-to/make-read-only-requests.md).
+A map of RPC URLs to use for [read-only RPC requests](../how-to/use-sdk/javascript/make-read-only-requests.md).
 
 ### `shouldShimWeb3`
 


### PR DESCRIPTION
This PR:

- Consolidates SDK-specific guides into the "Use SDK" category (Connect and sign, Make read-only requests, Batch RPC requests, and display custom modals)
- Updates all applicable SDK guides to refer to important integration steps (Infura API key, connect and sign, etc.), and updates examples.

For example: https://docs.metamask.io/1212-sdk-integration/wallet/how-to/use-sdk/javascript/

Fixes #1212 