### PR TITLE
Update Snaps code samples

### DIFF
--- a/snaps/features/custom-evm-accounts/create-account-snap.md
+++ b/snaps/features/custom-evm-accounts/create-account-snap.md
@@ -158,7 +158,7 @@ export const onKeyringRequest: OnKeyringRequestHandler = async ({
     origin,
     request,
 }) => {
-    // Your custom logic here.
+    // Add custom logic here.
     return handleKeyringRequest(keyring, request);
 };
 ```

--- a/snaps/features/custom-evm-accounts/create-account-snap.md
+++ b/snaps/features/custom-evm-accounts/create-account-snap.md
@@ -48,16 +48,16 @@ Specify the following [permissions](../../how-to/request-permissions.md) in your
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:keyring": {
-    "allowedOrigins": [
-      "https://<dapp domain>"
-    ]
-  },
-  "endowment:rpc": {
-    "dapps": true
-  },
-  "snap_manageAccounts": {},
-  "snap_manageState": {}
+    "endowment:keyring": {
+        "allowedOrigins": [
+            "https://<dapp domain>"
+        ]
+    },
+    "endowment:rpc": {
+        "dapps": true
+    },
+    "snap_manageAccounts": {},
+    "snap_manageState": {}
 },
 ```
 
@@ -71,7 +71,7 @@ Make sure to [limit the methods exposed to dapps](security.md#limit-the-methods-
 
 ```typescript
 class MySnapKeyring implements Keyring {
-  // Implement the required methods here...
+    // Implement the required methods here.
 }
 ```
 
@@ -87,16 +87,16 @@ The following is an example of a `personal_sign` request:
 
 ```json
 {
-  "id": "d6e23af6-4bea-48dd-aeb0-7d3c30ea67f9",
-  "scope": "",
-  "account": "69438371-bef3-4957-9f91-c3f22c1d75f3",
-  "request": {
-    "method": "personal_sign",
-    "params": [
-      "0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765",
-      "0x5874174dcf1ab6F7Efd8496f4f09404CD1c5bA84"
-    ]
-  }
+    "id": "d6e23af6-4bea-48dd-aeb0-7d3c30ea67f9",
+    "scope": "",
+    "account": "69438371-bef3-4957-9f91-c3f22c1d75f3",
+    "request": {
+        "method": "personal_sign",
+        "params": [
+            "0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765",
+            "0x5874174dcf1ab6F7Efd8496f4f09404CD1c5bA84"
+        ]
+    }
 }
 ```
 
@@ -140,9 +140,9 @@ For example, when an account is created:
 ```typescript
 try {
     emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, { account });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```
 
@@ -155,11 +155,11 @@ to MetaMask and your dapp:
 
 ```typescript
 export const onKeyringRequest: OnKeyringRequestHandler = async ({
-  origin,
-  request,
+    origin,
+    request,
 }) => {
-  // Your custom logic here...
-  return handleKeyringRequest(keyring, request);
+    // Your custom logic here.
+    return handleKeyringRequest(keyring, request);
 };
 ```
 

--- a/snaps/features/custom-evm-accounts/create-companion-dapp.md
+++ b/snaps/features/custom-evm-accounts/create-companion-dapp.md
@@ -45,7 +45,7 @@ Create a `KeyringSnapRpcClient`:
 
 ```ts
 import { KeyringSnapRpcClient } from "@metamask/keyring-api";
-import { defaultSnapOrigin as snapId } from '../config';
+import { defaultSnapOrigin as snapId } from "../config";
 
 let client = new KeyringSnapRpcClient(snapId, window.ethereum);
 ```

--- a/snaps/features/custom-evm-accounts/security.md
+++ b/snaps/features/custom-evm-accounts/security.md
@@ -28,20 +28,20 @@ For example:
 
     ```ts
     const account: KeyringAccount = {
-      id: uuid(),
-      options: {
-        privateKey: '0x01234...78', // !!! DO NOT DO THIS !!!
-      },
-      address,
-      methods: [
-        EthMethod.PersonalSign,
-        EthMethod.Sign,
-        EthMethod.SignTransaction,
-        EthMethod.SignTypedDataV1,
-        EthMethod.SignTypedDataV3,
-        EthMethod.SignTypedDataV4,
-      ],
-      type: EthAccountType.Eoa,
+        id: uuid(),
+        options: {
+            privateKey: "0x01234...78", // !!! DO NOT DO THIS !!!
+        },
+        address,
+        methods: [
+            EthMethod.PersonalSign,
+            EthMethod.Sign,
+            EthMethod.SignTransaction,
+            EthMethod.SignTypedDataV1,
+            EthMethod.SignTypedDataV3,
+            EthMethod.SignTypedDataV4,
+        ],
+        type: EthAccountType.Eoa,
     };
     ```
 
@@ -51,14 +51,14 @@ For example:
     
     ```ts
     await snap.request({
-      method: 'snap_manageState',
-      params: {
-        operation: 'update',
-        newState: {
-          // Your Snap's state here...
-          privateKey: '0x01234...78',
+        method: "snap_manageState",
+        params: {
+            operation: "update",
+            newState: {
+                // Your Snap's state here.
+                privateKey: "0x01234...78",
+            },
         },
-      },
     });
     ```
 
@@ -68,8 +68,8 @@ By default, MetaMask enforces the following restrictions on calling
 [Account Management API](../../reference/keyring-api/account-management/index.md) methods on your Snap based on
 the caller origin:
 
-| Method                                                                                                       |  MetaMask origin   |    Dapp origin     |
-|:-------------------------------------------------------------------------------------------------------------|:------------------:|:------------------:|
+| Method                                                                                                               |  MetaMask origin   |    Dapp origin     |
+|:---------------------------------------------------------------------------------------------------------------------|:------------------:|:------------------:|
 | [`keyring_listAccounts`](../../reference/keyring-api/account-management/index.md#keyring_listaccounts)               | :white_check_mark: | :white_check_mark: |
 | [`keyring_getAccount`](../../reference/keyring-api/account-management/index.md#keyring_getaccount)                   | :white_check_mark: | :white_check_mark: |
 | [`keyring_createAccount`](../../reference/keyring-api/account-management/index.md#keyring_createaccount)             |        :x:         | :white_check_mark: |
@@ -101,16 +101,16 @@ The following is an example of implementing such logic:
 
 ```ts
 const permissions: Record<string, string[]> = {
-  'https://<Dapp 1 domain>': [
-    // List of allowed methods for Dapp 1.
-  ],
-  'https://<Dapp 2 domain>': [
-    // List of allowed methods for Dapp 2.
-  ],
+    "https://<Dapp 1 domain>": [
+        // List of allowed methods for Dapp 1.
+    ],
+    "https://<Dapp 2 domain>": [
+        // List of allowed methods for Dapp 2.
+    ],
 };
 
-if (origin !== 'metamask' && !permissions[origin]?.includes(request.method)) {
-  // Reject the request.
+if (origin !== "metamask" && !permissions[origin]?.includes(request.method)) {
+    // Reject the request.
 }
 ```
 
@@ -124,14 +124,14 @@ redirected to a malicious website.
 
 ```ts
 async submitRequest(request: KeyringRequest): Promise<SubmitRequestResponse> {
-  // Your Snap's custom logic...
-  return {
-    pending: true,
-    redirect: {
-      message: 'Please continue in the dapp.',
-      url: 'https://<dapp domain>/sign?tx=1234', // !!! ENSURE THIS IS A SAFE URL !!!
-    },
-  };
+    // Your Snap's custom logic.
+    return {
+        pending: true,
+        redirect: {
+            message: "Please continue in the dapp.",
+            url: "https://<dapp domain>/sign?tx=1234", // !!! ENSURE THIS IS A SAFE URL !!!
+        },
+    };
 }
 ```
 
@@ -160,20 +160,20 @@ For example:
 - ❌ **Do NOT do this:**
 
   ```ts
-  // If `inputSecretValue` contains invalid hexadecimal characters, its value
-  // will be added to the error thrown by `toBuffer`.
+  // If inputSecretValue contains invalid hexadecimal characters, its value
+  // will be added to the error thrown by toBuffer.
   const privateKey = toBuffer(inputSecretValue);
-  // Use `privateKey` here...
+  // Use privateKey here.
   ```
 
 - ✅ **Do this instead:**
 
   ```ts
   try {
-    const privateKey = toBuffer(inputSecretValue);
-    // Use `privateKey` here...
+      const privateKey = toBuffer(inputSecretValue);
+      // Use privateKey here.
   } catch (error) {
-    throw new Error('Invalid private key');
+      throw new Error("Invalid private key");
   }
   ```
 
@@ -190,11 +190,11 @@ For example:
 
   ```ts
   export const onRpcRequest: OnRpcRequestHandler = async ({
-    //           ~~~           ~~~
-    origin,
-    request,
+      //         ~~~           ~~~
+      origin,
+      request,
   }) => {
-    return handleKeyringRequest(keyring, request);
+      return handleKeyringRequest(keyring, request);
   };
   ```
 
@@ -202,12 +202,12 @@ For example:
 
   ```ts
   export const onKeyringRequest: OnKeyringRequestHandler = async ({
-    //           ~~~~~~~           ~~~~~~~
-    origin,
-    request,
+      //         ~~~~~~~           ~~~~~~~
+      origin,
+      request,
   }) => {
-    // Any custom logic or extra security checks here...
-    return handleKeyringRequest(keyring, request);
+      // Any custom logic or extra security checks here.
+      return handleKeyringRequest(keyring, request);
   };
   ```
 

--- a/snaps/features/custom-name-resolution.md
+++ b/snaps/features/custom-name-resolution.md
@@ -35,7 +35,7 @@ Expose an [`onNameLookup`](../reference/entry-points.md#onnamelookup) entry poin
 The following example implements a very basic resolution from Unstoppable Domains domain names to
 Ethereum addresses in `onNameLookup`:
 
-```typescript title="snap/src/index.ts"
+```typescript title="index.ts"
 import type { OnNameLookupHandler } from "@metamask/snaps-types";
 
 const UNSTOPPABLE_API_KEY = "xxx";
@@ -47,7 +47,7 @@ export const onNameLookup: OnNameLookupHandler = async (request) => {
         const response = await fetch(`https://api.unstoppabledomains.com/resolve/domains/${domain}`, {
             headers: {
                 accept: "application/json",
-                authorization: `Bearer ${UNSTOPPABLE_API_KEY}`
+                authorization: `Bearer ${UNSTOPPABLE_API_KEY}`,
             },
         });
         const data = await response.json();

--- a/snaps/features/custom-ui.md
+++ b/snaps/features/custom-ui.md
@@ -24,7 +24,7 @@ Then, whenever you're required to return a custom UI component, import the compo
 SDK and build your UI with them.
 For example, to display a [`panel`](#panel) using [`snap_dialog`](../reference/snaps-api.md#snap_dialog):
 
-```javascript
+```javascript title="index.js"
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -51,7 +51,7 @@ Hovering the address shows the full value in a tooltip.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import { panel, heading, address } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -81,7 +81,7 @@ Outputs a read-only text field with a copy-to-clipboard shortcut.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import { text, copyable } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -106,7 +106,7 @@ Outputs a horizontal divider.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, divider, text } from "@metamask/snaps-sdk";
 
@@ -132,7 +132,7 @@ This is useful for [`panel`](#panel) titles.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -160,7 +160,7 @@ The SVG is rendered within an `<img>` tag, which prevents JavaScript or interact
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text, image } from "@metamask/snaps-sdk";
 
@@ -186,7 +186,7 @@ This component takes an array of custom UI components.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnTransactionHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -217,7 +217,7 @@ The label must be a string. The value can be a child component of type
 
 #### Example
 
-```javascript 
+```javascript title="index.js"
 import { panel, row, text, address } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -242,7 +242,7 @@ Outputs a loading indicator.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import { panel, heading, spinner } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -267,7 +267,7 @@ Outputs text.
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -291,7 +291,7 @@ module.exports.onHomePage = async () => {
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
 await snap.request({
@@ -316,7 +316,7 @@ await snap.request({
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, text } from "@metamask/snaps-sdk";
 
@@ -341,7 +341,7 @@ Text-based components (such as [`heading`](#heading) and [`text`](#text)) accept
 
 #### Example
 
-```javascript
+```javascript title="index.js"
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
 await snap.request({

--- a/snaps/features/localization.md
+++ b/snaps/features/localization.md
@@ -19,9 +19,9 @@ To call `snap_getLocale`, first request the required permission by adding it to 
 
 ```json title="snap.manifest.json"
 {
-  "initialPermissions": {
-    "snap_getLocale": {}
-  }
+    "initialPermissions": {
+        "snap_getLocale": {}
+    }
 }
 ```
 
@@ -36,13 +36,13 @@ following format:
 
 ```json title="en.json"
 {
-  "locale": "en",
-  "messages": {
-    "hello": {
-      "message": "Hello, world!",
-      "description": "The message that is returned when the `hello` method is called."
+    "locale": "en",
+    "messages": {
+        "hello": {
+            "message": "Hello, world!",
+            "description": "The message that is returned when the `hello` method is called."
+        }
     }
-  }
 }
 ```
 
@@ -50,27 +50,27 @@ You can then use these files in a localization module.
 The following is an example module:
 
 ```ts
-import da from '../locales/da.json';
-import en from '../locales/en.json';
-import nl from '../locales/nl.json';
+import da from "../locales/da.json";
+import en from "../locales/en.json";
+import nl from "../locales/nl.json";
 
 // Default language, to be used if there is not a valid translation in
 // the requested locale.
-const FALLBACK_LANGUAGE: Locale = 'en';
+const FALLBACK_LANGUAGE: Locale = "en";
 
 export const locales = {
-  da: da.messages,
-  en: en.messages,
-  nl: nl.messages,
+    da: da.messages,
+    en: en.messages,
+    nl: nl.messages,
 };
 
 export type Locale = keyof typeof locales;
 
 export async function getMessage(id: keyof (typeof locales)[Locale]) {
-  const locale = (await snap.request({ method: 'snap_getLocale' })) as Locale;
-  const { message } = locales[locale]?.[id] ?? locales[FALLBACK_LANGUAGE][id];
+    const locale = (await snap.request({ method: "snap_getLocale" })) as Locale;
+    const { message } = locales[locale]?.[id] ?? locales[FALLBACK_LANGUAGE][id];
 
-  return message;
+    return message;
 }
 ```
 
@@ -79,22 +79,22 @@ English as the default if the user's locale isn't available.
 
 The following is an example of using `getMessage` in a Snap's RPC request handler:
 
-```ts
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+```ts title="index.ts"
+import { rpcErrors } from "@metamask/rpc-errors";
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
 
-import { getMessage } from './locales';
+import { getMessage } from "./locales";
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
-  switch (request.method) {
-    case 'hello':
-      return await getMessage('hello');
-
-    default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
-  }
+    switch (request.method) {
+        case "hello":
+            return await getMessage("hello");
+    
+        default:
+            throw rpcErrors.methodNotFound({
+                data: { method: request.method },
+            });
+    }
 };
 ```
 
@@ -107,21 +107,21 @@ The following is an example of a localized manifest file:
 
 ```json title="snap.manifest.json"
 {
-  "version": "1.1.1",
-  "description": "{{ description }}",
-  "proposedName": "{{ name }}",
-  "source": {
-    "shasum": "XXX",
-    "locales": [
-      "locales/da.json",
-      "locales/en.json",
-      "locales/nl.json"
-    ]
-  },
-  "initialPermissions": {
-    "snap_getLocale": {}
-  },
-  "manifestVersion": "0.1"
+    "version": "1.1.1",
+    "description": "{{ description }}",
+    "proposedName": "{{ name }}",
+    "source": {
+        "shasum": "XXX",
+        "locales": [
+            "locales/da.json",
+            "locales/en.json",
+            "locales/nl.json"
+        ]
+    },
+    "initialPermissions": {
+      "snap_getLocale": {}
+    },
+    "manifestVersion": "0.1"
 }
 ```
 

--- a/snaps/features/non-evm-networks.md
+++ b/snaps/features/non-evm-networks.md
@@ -63,15 +63,15 @@ For example, to derive Dogecoin keys:
    [`snap_getBip44Entropy`](../reference/snaps-api.md#snap_getbip44entropy).
 2. Dogecoin has coin type `3`, so add the following to the manifest file:
 
-   ```json
+   ```json title="snap.manifest.json"
    {
-     "initialPermissions": {
-       "snap_getBip44Entropy": [
-         {
-           "coinType": 3
-         }
-       ]
-     }
+       "initialPermissions": {
+           "snap_getBip44Entropy": [
+               {
+                   "coinType": 3
+               }
+           ]
+       }
    }
    ```
 
@@ -83,15 +83,15 @@ For example, to derive Dogecoin keys:
 
    To get the second Dogecoin account, add the following code to your Snap:
 
-   ```javascript
-   import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+   ```javascript title="index.js"
+   import { getBIP44AddressKeyDeriver } from "@metamask/key-tree";
 
    // Get the Dogecoin node, corresponding to the path m/44'/3'.
    const dogecoinNode = await snap.request({
-     method: 'snap_getBip44Entropy',
-     params: {
-       coinType: 3,
-     },
+       method: "snap_getBip44Entropy",
+       params: {
+           coinType: 3,
+       },
    });
 
    /**

--- a/snaps/features/signature-insights.md
+++ b/snaps/features/signature-insights.md
@@ -147,9 +147,9 @@ export const onSignature: OnSignatureHandler = async ({
         content: panel([
             heading("My Signature Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
+            ...(insights.map((insight) => text(insight.value))),
         ]),
-        severity: SeverityLevel.Critical
+        severity: SeverityLevel.Critical,
     };
 };
 ```

--- a/snaps/features/static-files.md
+++ b/snaps/features/static-files.md
@@ -28,7 +28,7 @@ For example:
         "files": [
             "./files/myfile.bin"
         ]
-     }
+    }
 }
 ```
 
@@ -38,7 +38,7 @@ In your Snap code, load static files using [`snap_getFile`](../reference/snaps-a
 This method returns a string in the encoding specified, with a default of Base64 if no encoding is specified.
 For example:
 
-```javascript title="snap/src/index.js"
+```javascript title="index.js"
 const contents = await snap.request({
     method: "snap_getFile",
     params: {
@@ -47,6 +47,6 @@ const contents = await snap.request({
     },
 });
 
-// `0x...`
+// "0x..."
 console.log(contents);
 ```

--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -89,42 +89,41 @@ You can customize your Snap by editing `index.ts` in the `packages/snap/src` fol
 `index.ts` contains an example request that uses the
 [`snap_dialog`](../reference/snaps-api.md#snapdialog) method to display a custom confirmation screen:
 
-```ts
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { panel, text } from '@metamask/snaps-sdk';
+```ts title="index.ts"
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { panel, text } from "@metamask/snaps-sdk";
 
 /**
- * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
+ * Handle incoming JSON-RPC requests, sent through wallet_invokeSnap.
  *
- * @param args - The request handler args as object.
- * @param args.origin - The origin of the request, e.g., the website that
- * invoked the snap.
+ * @param args - The request handler arguments as an object.
+ * @param args.origin - The origin of the request, e.g., the website that invoked the Snap.
  * @param args.request - A validated JSON-RPC request object.
- * @returns The result of `snap_dialog`.
- * @throws If the request method is not valid for this snap.
+ * @returns The result of snap_dialog.
+ * @throws If the request method is not valid for this Snap.
  */
 export const onRpcRequest: OnRpcRequestHandler = async ({
-  origin,
-  request,
+    origin,
+    request,
 }) => {
-  switch (request.method) {
-    case 'hello':
-      return snap.request({
-        method: 'snap_dialog',
-        params: {
-          type: 'confirmation',
-          content: panel([
-            text(`Hello, **${origin}**!`),
-            text('This custom confirmation is just for display purposes.'),
-            text(
-              'But you can edit the Snap source code to make it do something, if you want to!',
-            ),
-          ]),
-        },
-      });
-    default:
-      throw new Error('Method not found.');
-  }
+    switch (request.method) {
+        case "hello":
+            return snap.request({
+                method: "snap_dialog",
+                params: {
+                    type: "confirmation",
+                    content: panel([
+                        text(`Hello, **${origin}**!`),
+                        text("This custom confirmation is just for display purposes."),
+                        text(
+                            "But you can edit the Snap source code to make it do something, if you want to!",
+                        ),
+                    ]),
+                },
+            });
+        default:
+            throw new Error("Method not found.");
+    }
 };
 ```
 

--- a/snaps/how-to/communicate-errors.md
+++ b/snaps/how-to/communicate-errors.md
@@ -16,18 +16,18 @@ To throw these known errors, first import them from the
 then throw them where needed.
 For example:
 
-```typescript
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { MethodNotFoundError } from '@metamask/snaps-sdk';
+```typescript title="index.ts"
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { MethodNotFoundError } from "@metamask/snaps-sdk";
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
-  switch (request.method) {
-    case 'hello':
-      return 'Hello World!';
+    switch (request.method) {
+        case "hello":
+            return "Hello World!";
     default:
-      // Throw a known error to avoid crashing the Snap
-      throw new MethodNotFoundError();
-  }
+        // Throw a known error to avoid crashing the Snap.
+        throw new MethodNotFoundError();
+    }
 };
 ```
 
@@ -37,7 +37,7 @@ The error class constructors exported by `@metamask/snaps-sdk` have the followin
 
 ```typescript
 class SnapJsonRpcError extends SnapError {
-  new (message?: string, data?: Record<string, Json>)
+    new (message?: string, data?: Record<string, Json>)
 }
 ```
 

--- a/snaps/how-to/connect-to-a-snap.md
+++ b/snaps/how-to/connect-to-a-snap.md
@@ -23,23 +23,22 @@ The following example uses the
 [`@metamask/detect-provider`](https://npmjs.com/package/@metamask/detect-provider) package to get
 the provider object from MetaMask first:
 
-```js
-import detectEthereumProvider from '@metamask/detect-provider';
+```js title="index.js"
+import detectEthereumProvider from "@metamask/detect-provider";
 
-// This resolves to the value of window.ethereum or null
+// This resolves to the value of window.ethereum or null.
 const provider = await detectEthereumProvider();
 
-// web3_clientVersion returns the installed MetaMask version as a string
+// web3_clientVersion returns the installed MetaMask version as a string.
 const isFlask = (
-  await provider?.request({ method: 'web3_clientVersion' })
-)?.includes('flask');
+    await provider?.request({ method: "web3_clientVersion" })
+)?.includes("flask");
 
 if (provider && isFlask) {
-  console.log('MetaMask Flask successfully detected!');
-
-  // Now you can use Snaps!
+    console.log("MetaMask Flask successfully detected!");
+    // Now you can use Snaps!
 } else {
-  console.error('Please install MetaMask Flask!', error);
+    console.error("Please install MetaMask Flask!", error);
 }
 ```
 
@@ -115,12 +114,12 @@ The user may have other Snaps installed that your dapp is not aware of.
 
 The following example verifies whether a Snap with ID `npm:super-snap` is installed:
 
-```ts
+```ts title="index.ts"
 const snaps = await ethereum.request({
-  method: 'wallet_getSnaps'
+    method: "wallet_getSnaps"
 });
 
-const isMySnapInstalled = Object.keys(snaps).includes('npm:super-snap');
+const isMySnapInstalled = Object.keys(snaps).includes("npm:super-snap");
 ```
 
 If you need to work with a specific version of a Snap, you can instead iterate over

--- a/snaps/how-to/debug-a-snap/common-issues.md
+++ b/snaps/how-to/debug-a-snap/common-issues.md
@@ -85,9 +85,9 @@ yarn add -D patch-package postinstall-postinstall
 
 Then add a postinstall script to your `package.json`:
 
-```diff
+```diff title="package.json"
  "scripts": {
-+  "postinstall": "patch-package"
++    "postinstall": "patch-package"
  }
 ```
 
@@ -116,7 +116,7 @@ You can easily patch this issue using `patch-package`.
 Open `node_modules/cross-fetch/browser-ponyfill.js` and find the following lines near the bottom of
 the file:
 
-```javascript
+```javascript title="browser-ponyfill.js"
 // Choose between native implementation (global) or custom implementation (__self__)
 // var ctx = global.fetch ? global : __self__;
 var ctx = __self__; // this line disable service worker support temporarily
@@ -124,11 +124,11 @@ var ctx = __self__; // this line disable service worker support temporarily
 
 You can replace that with the following snippet:
 
-```javascript
+```javascript title="browser-ponyfill.js"
 // Choose between native implementation (global) or custom implementation (__self__)
 var ctx = global.fetch
-  ? { ...global, fetch: global.fetch.bind(global) }
-  : __self__;
+    ? { ...global, fetch: global.fetch.bind(global) }
+    : __self__;
 // var ctx = __self__; // this line disable service worker support temporarily
 ```
 
@@ -177,38 +177,38 @@ In a production environment this may be a large task depending on the usage of `
 
 ```javascript
 const instance = axios.create({
-  baseURL: 'https://api.github.com/',
+    baseURL: "https://api.github.com/",
 });
 
 instance
-  .get('users/MetaMask')
-  .then((res) => {
-    if (res.status >= 400) {
-      throw new Error('Bad response from server');
-    }
-    return res.data;
-  })
-  .then((user) => {
-    console.log(user);
-  })
-  .catch((err) => {
-    console.error(err);
-  });
+    .get("users/MetaMask")
+    .then((res) => {
+        if (res.status >= 400) {
+            throw new Error("Bad response from server");
+        }
+        return res.data;
+    })
+    .then((user) => {
+        console.log(user);
+    })
+    .catch((err) => {
+        console.error(err);
+    });
 ```
 
 </TabItem>
 <TabItem value="fetch">
 
 ```javascript
-fetch('https://api.github.com/users/MetaMask')
-  .then((res) => {
-    if (!res.ok) {
-      throw new Error('Bad response from server');
-    }
-    return res.json();
-  })
-  .then((json) => console.log(json))
-  .catch((err) => console.error(err));
+fetch("https://api.github.com/users/MetaMask")
+    .then((res) => {
+        if (!res.ok) {
+            throw new Error("Bad response from server");
+        }
+        return res.json();
+    })
+    .then((json) => console.log(json))
+    .catch((err) => console.error(err));
 ```
 
 </TabItem>

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -23,7 +23,7 @@ following to the manifest file:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_dialog": {}
+    "snap_dialog": {}
 }
 ```
 
@@ -39,7 +39,7 @@ permission, add the following to the manifest file:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:network-access": {}
+    "endowment:network-access": {}
 }
 ```
 
@@ -62,20 +62,20 @@ The following example calls `wallet_requestSnaps` to request permission to conne
 ```js title="index.js"
 // If the Snap is not already installed, the user will be prompted to install it.
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
-  params: {
-    // Assuming the Snap is published to npm using the package name 'hello-snap'.
-    'npm:hello-snap': {},
-  },
+    method: "wallet_requestSnaps",
+    params: {
+        // Assuming the Snap is published to npm using the package name "hello-snap".
+        "npm:hello-snap": {},
+    },
 });
 
-// Invoke the 'hello' JSON-RPC method exposed by the Snap.
+// Invoke the "hello" JSON-RPC method exposed by the Snap.
 const response = await window.ethereum.request({
-  method: 'wallet_invokeSnap',
-  params: { snapId: 'npm:hello-snap', request: { method: 'hello' } },
+    method: "wallet_invokeSnap",
+    params: { snapId: "npm:hello-snap", request: { method: "hello" } },
 });
 
-console.log(response); // 'world!'
+console.log(response); // "world!"
 ```
 
 :::note

--- a/snaps/how-to/restrict-rpc-api.md
+++ b/snaps/how-to/restrict-rpc-api.md
@@ -25,7 +25,7 @@ You can restrict by method and origin using the `origin` parameter of the
 [`onRpcRequest`](../reference/entry-points.md#onrpcrequest) entry point.
 For example:
 
-```typescript
+```typescript title="index.ts"
 import type { OnRpcRequestHandler, UnauthorizedError } from "@metamask/snaps-sdk";
 
 type MethodPermission = "*" | string[];
@@ -34,7 +34,7 @@ const RPC_PERMISSIONS: Record<string, MethodPermission> = {
     hello: "*",
     secureMethod: [
         "https://metamask.io",
-        "https://www.mydomain.com"
+        "https://www.mydomain.com",
     ]
 };
 

--- a/snaps/how-to/test-a-snap.md
+++ b/snaps/how-to/test-a-snap.md
@@ -36,7 +36,7 @@ In the `jest.config.js` file, add the following:
 
 ```js title="jest.config.js"
 module.exports = {
-  preset: '@metamask/snaps-jest',
+    preset: "@metamask/snaps-jest",
 };
 ```
 
@@ -56,8 +56,8 @@ environment and matchers to your Jest configuration manually:
 
 ```js title="jest.config.js"
 module.exports = {
-  testEnvironment: '@metamask/snaps-jest',
-  setupFilesAfterEnv: ['@metamask/snaps-jest/dist/cjs/setup.js'],
+    testEnvironment: "@metamask/snaps-jest",
+    setupFilesAfterEnv: ["@metamask/snaps-jest/dist/cjs/setup.js"],
 };
 ```
 
@@ -67,10 +67,10 @@ For example:
 
 ```js title="jest.config.js"
 module.exports = {
-  preset: '@metamask/snaps-jest',
-  testEnvironmentOptions: {
-    // Options go here
-  },
+    preset: "@metamask/snaps-jest",
+    testEnvironmentOptions: {
+        // Options go here.
+    },
 };
 ```
 

--- a/snaps/how-to/use-environment-variables.md
+++ b/snaps/how-to/use-environment-variables.md
@@ -62,7 +62,7 @@ Snaps CLI:
             SNAP_ENV: process.env.SNAP_ENV,
             PUBLIC_KEY: process.env.PUBLIC_KEY,
         },
-        // Other options
+        // Other options.
     };
     ```
    
@@ -79,7 +79,7 @@ Snaps CLI:
             SNAP_ENV: process.env.SNAP_ENV,
             PUBLIC_KEY: process.env.PUBLIC_KEY,
         },
-        // Other options
+        // Other options.
     };
     
     export default config;
@@ -92,7 +92,7 @@ Snaps CLI:
     For example:
 
     ```typescript title="index.ts"
-    import { panel, text, heading } from '@metamask/snaps-sdk';
+    import { panel, text, heading } from "@metamask/snaps-sdk";
     
     await snap.request({
         method: "snap_dialog",
@@ -100,7 +100,7 @@ Snaps CLI:
             type: "alert",
             content: panel([
                 heading("This custom alert is just for display purposes."),
-                text("SNAP_ENV is ${process.env.SNAP_ENV}, PUBLIC_KEY is ${process.env.PUBLIC_KEY}"),
+                text(`SNAP_ENV is ${process.env.SNAP_ENV}, PUBLIC_KEY is ${process.env.PUBLIC_KEY}`),
             ]),
         },
     });

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -22,7 +22,7 @@ For example, to call [`snap_notify`](../../reference/snaps-api.md#snap_notify), 
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_notify": {}
+    "snap_notify": {}
 }
 ```
 
@@ -30,11 +30,11 @@ Your Snap can then call `snap_notify` in its source code:
 
 ```typescript title="index.ts"
 await snap.request({
-  method: 'snap_notify',
-  params: {
-    type: 'inApp',
-    message: 'Hello, world!',
-  },
+    method: "snap_notify",
+    params: {
+        type: "inApp",
+        message: "Hello, world!",
+    },
 });
 ```
 
@@ -59,19 +59,24 @@ For example, to call `wallet_snap`:
 ```js title="index.js"
 // Request permission to connect to the Snap.
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
-  params: {
-    'npm:hello-snap': {},
-  },
+    method: "wallet_requestSnaps",
+    params: {
+        "npm:hello-snap": {},
+    },
 });
 
-// Call the 'hello' method of the Snap using wallet_snap.
+// Call the "hello" method of the Snap using wallet_snap.
 const response = await window.ethereum.request({
-  method: 'wallet_snap',
-  params: { snapId: 'npm:hello-snap', request: { method: 'hello' } },
+    method: "wallet_snap",
+    params: {
+        snapId: "npm:hello-snap",
+        request: { 
+            method: "hello",
+        },
+    },
 });
 
-console.log(response); // 'world!'
+console.log(response); // "world!"
 ```
 
 ### Snap requests
@@ -86,16 +91,14 @@ the required permission:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:ethereum-provider": {}
+    "endowment:ethereum-provider": {}
 }
 ```
 
 Your Snap can then call `eth_requestAccounts` in its source code:
 
 ```typescript title="index.ts"
-await ethereum.request({
-  "method": "eth_requestAccounts"
-});
+await ethereum.request({ "method": "eth_requestAccounts" });
 ```
 
 The `ethereum` global available to Snaps has fewer capabilities than `window.ethereum` for dapps.
@@ -137,9 +140,9 @@ For example, to create a simple Snap with a custom API, first request the `endow
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:rpc": {
-    "dapps": true // Enable dapps to make JSON-RPC requests.
-  }
+    "endowment:rpc": {
+        "dapps": true // Enable dapps to make JSON-RPC requests.
+    }
 }
 ```
 
@@ -147,14 +150,14 @@ Your Snap can then implement and expose a custom API using the `onRpcRequest` fu
 
 ```typescript title="index.ts"
 module.exports.onRpcRequest = async ({ origin, request }) => {
-  switch (request.method) {
-    // Expose a 'hello' JSON-RPC method to dapps.
-    case 'hello':
-      return 'world!';
-
-    default:
-      throw new Error('Method not found.');
-  }
+    switch (request.method) {
+        // Expose a "hello" JSON-RPC method to dapps.
+        case "hello":
+            return "world!";
+    
+        default:
+            throw new Error("Method not found.");
+    }
 };
 ```
 
@@ -164,18 +167,23 @@ A dapp can then install the Snap and call the exposed method:
 // Request permission to connect to the Snap.
 // If the Snap is not already installed, the user will be prompted to install it.
 await window.ethereum.request({
-  method: 'wallet_requestSnaps',
-  params: {
-    // Assuming the Snap is published to npm using the package name 'hello-snap'.
-    'npm:hello-snap': {},
-  },
+    method: "wallet_requestSnaps",
+    params: {
+        // Assuming the Snap is published to npm using the package name "hello-snap".
+        "npm:hello-snap": {},
+    },
 });
 
-// Invoke the 'hello' JSON-RPC method exposed by the Snap.
+// Invoke the "hello" JSON-RPC method exposed by the Snap.
 const response = await window.ethereum.request({
-  method: 'wallet_invokeSnap',
-  params: { snapId: 'npm:hello-snap', request: { method: 'hello' } },
+    method: "wallet_invokeSnap",
+    params: {
+        snapId: "npm:hello-snap",
+        request: {
+            method: "hello",
+        },
+    },
 });
 
-console.log(response); // 'world!'
+console.log(response); // "world!"
 ```

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -136,12 +136,13 @@ However, if you want to do something such as manage the user's keys for a partic
 create a dapp that sends transactions for that protocol via your Snap, you must implement a custom API.
 :::
 
-For example, to create a simple Snap with a custom API, first request the `endowment:rpc` permission:
+For example, to create a simple Snap with a custom API, first request the `endowment:rpc` permission.
+Set `dapps` to `true` to enable dapps to make JSON-RPC requests.
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
     "endowment:rpc": {
-        "dapps": true // Enable dapps to make JSON-RPC requests.
+        "dapps": true
     }
 }
 ```

--- a/snaps/learn/about-snaps/files.md
+++ b/snaps/learn/about-snaps/files.md
@@ -45,28 +45,28 @@ To get MetaMask to execute your Snap, you must have a valid manifest file named 
 located in your package root directory.
 The manifest file of `Hello World` would look something like this:
 
-```json
+```json title="snap.manifest.json"
 {
-  "version": "1.0.0",
-  "proposedName": "Hello World",
-  "description": "A Snap that says hello!",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Hello/hello-snap.git"
-  },
-  "source": {
-    "shasum": "w3FltkDjKQZiPwM+AThnmypt0OFF7hj4ycg/kxxv+nU=",
-    "location": {
-      "npm": {
-        "filePath": "dist/bundle.js",
-        "iconPath": "images/icon.svg",
-        "packageName": "hello-snap",
-        "registry": "https://registry.npmjs.org/"
-      }
-    }
-  },
-  "initialPermissions": {},
-  "manifestVersion": "0.1"
+    "version": "1.0.0",
+    "proposedName": "Hello World",
+    "description": "A Snap that says hello!",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Hello/hello-snap.git"
+    },
+    "source": {
+        "shasum": "w3FltkDjKQZiPwM+AThnmypt0OFF7hj4ycg/kxxv+nU=",
+        "location": {
+            "npm": {
+                "filePath": "dist/bundle.js",
+                "iconPath": "images/icon.svg",
+                "packageName": "hello-snap",
+                "registry": "https://registry.npmjs.org/"
+            }
+        }
+    },
+    "initialPermissions": {},
+    "manifestVersion": "0.1"
 }
 ```
 

--- a/snaps/learn/best-practices/security-guidelines.md
+++ b/snaps/learn/best-practices/security-guidelines.md
@@ -76,12 +76,11 @@ The following are guidelines for user notifications and authorizations:
     const referrer = new URL(origin);
 
     if(referrer.protocol === "https:" && 
-       (referrer.host.endsWith(".metamask.io") || 
-        referrer.host === "metamask.io")) { 
-      console.log("URL is valid"); 
+        (referrer.host.endsWith(".metamask.io") || referrer.host === "metamask.io")) { 
+            console.log("URL is valid"); 
     }
     else { 
-      console.log("URL is NOT valid"); 
+        console.log("URL is NOT valid"); 
     }
     ```
     
@@ -148,13 +147,13 @@ The following are guidelines for validating RPC parameters and handling values:
   mislead the user.
   For example: 
 
-  ![Example not using copyable with Markdown rendering](../../assets/copyable-example-1.png)
+  <img src={require("../../assets/copyable-example-1.png").default} alt="Example not using copyable with Markdown rendering" style={{border: "1px solid #DCDCDC"}} />
 
   The special characters `*` and `_` render Markdown formatting, so what the user sees does not
   match the content.
   To avoid this, use `copyable` instead:
 
-  ![Example using copyable with clean rendering](../../assets/copyable-example-2.png)
+  <img src={require("../../assets/copyable-example-2.png").default} alt="Example using copyable with clean rendering" style={{border: "1px solid #DCDCDC"}} />
 
   `copyable` does not render Markdown and has the added benefit that the user can select to copy the content.
   Also, the formatting provides a visual delineator to separate arbitrary input or fields from user

--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -106,12 +106,12 @@ and add `iconPath` with the value `"images/gas.svg"` to point to your new icon:
 
 ```json title="snap.manifest.json"
 "location": {
-   "npm": {
-      "filePath": "dist/bundle.js",
-      "iconPath": "images/gas.svg",
-      "packageName": "snap",
-      "registry": "https://registry.npmjs.org/"
-   }
+    "npm": {
+        "filePath": "dist/bundle.js",
+        "iconPath": "images/gas.svg",
+        "packageName": "snap",
+        "registry": "https://registry.npmjs.org/"
+    }
 }
 ```
 
@@ -120,9 +120,9 @@ Edit the `files` array and add the `images/` folder:
 
 ```json title="package.json"
 "files": [
-  "dist/",
-  "images/",
-  "snap.manifest.json"
+    "dist/",
+    "images/",
+    "snap.manifest.json"
 ],
 ```
 
@@ -134,12 +134,12 @@ permission by adding `"endowment:network-access": {}` to the `initialPermissions
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_dialog": {},
-  "endowment:rpc": {
-    "dapps": true,
-    "snaps": false
-  }, 
-  "endowment:network-access": {}
+    "snap_dialog": {},
+    "endowment:rpc": {
+        "dapps": true,
+        "snaps": false
+    }, 
+    "endowment:network-access": {}
 },
 "manifestVersion": "0.1"
 ```
@@ -153,20 +153,20 @@ To get a gas fee estimate, use the public API endpoint provided by
 Add the following `getFees()` function to the beginning of the `/packages/snap/src/index.ts` file:
 
 ```typescript title="index.ts"
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { panel, text } from '@metamask/snaps-sdk';
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { panel, text } from "@metamask/snaps-sdk";
 
 async function getFees() {
-  const response = await fetch('https://beaconcha.in/api/v1/execution/gasnow'); 
-  return response.text();
+    const response = await fetch("https://beaconcha.in/api/v1/execution/gasnow"); 
+    return response.text();
 }
 ```
 
 Next, add the `copyable` component to the second import of the file: 
 
 ```typescript title="index.ts"
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { panel, text, copyable } from '@metamask/snaps-sdk';
+import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
+import { panel, text, copyable } from "@metamask/snaps-sdk";
 ```
 
 Modify the Snap RPC message handler that displays the dialog.
@@ -176,23 +176,23 @@ For the `hello` method, the handler returns a call to MetaMask with the paramete
 dialog, and passes some static strings.
 
 Since `getFees()` returns a promise, you must use `then()` to resolve it in your `hello` method.
-Rewrite the `hello` method using the following code:
+Update the `hello` method with the following code:
 
 ```typescript title="index.ts"
-case 'hello':
-  return getFees().then(fees => {
-    return snap.request({
-      method: 'snap_dialog',
-      params: {
-        type: 'alert',
-        content: panel([
-          text(`Hello, **${origin}**!`),
-          text(`Current gas fee estimates:`),
-          copyable(fees),
-        ]),
-      }
+case "hello":
+    return getFees().then(fees => {
+        return snap.request({
+            method: 'snap_dialog',
+            params: {
+                type: "alert",
+                content: panel([
+                    text(`Hello, **${origin}**!`),
+                    text("Current gas fee estimates:"),
+                    copyable(fees),
+                ]),
+            }
+        });
     });
-  });
 ```
 
 ### 5. Build and test the Snap

--- a/snaps/learn/tutorials/transaction-insights.md
+++ b/snaps/learn/tutorials/transaction-insights.md
@@ -86,8 +86,8 @@ permissions by modifying `initialPermissions`:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:transaction-insight": {},
-  "endowment:ethereum-provider": {}
+    "endowment:transaction-insight": {},
+    "endowment:ethereum-provider": {}
 }
 ```
 
@@ -102,47 +102,46 @@ To calculate and display the gas fees a user would pay as a percentage of their 
 replace the code in `packages/snap/src/index.ts` with the following:
 
 ```typescript title="index.ts"
-import type { OnTransactionHandler } from '@metamask/snaps-sdk';
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import type { OnTransactionHandler } from "@metamask/snaps-sdk";
+import { heading, panel, text } from "@metamask/snaps-sdk";
 
 // Handle outgoing transactions.
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
 
-  // Use the ethereum provider to fetch the gas price.
-  const currentGasPrice = await ethereum.request({
-    method: 'eth_gasPrice',
-  }) as string;
+    // Use the Ethereum provider to fetch the gas price.
+    const currentGasPrice = await ethereum.request({
+        method: "eth_gasPrice",
+    }) as string;
 
-  // Get fields from the transaction object.
-  const transactionGas = parseInt(transaction.gas as string, 16);
-  const currentGasPriceInWei = parseInt(currentGasPrice ?? '', 16);
-  const maxFeePerGasInWei = parseInt(transaction.maxFeePerGas as string, 16);
-  const maxPriorityFeePerGasInWei = parseInt(
-    transaction.maxPriorityFeePerGas as string,
-    16,
-  );
+    // Get fields from the transaction object.
+    const transactionGas = parseInt(transaction.gas as string, 16);
+    const currentGasPriceInWei = parseInt(currentGasPrice ?? "", 16);
+    const maxFeePerGasInWei = parseInt(transaction.maxFeePerGas as string, 16);
+    const maxPriorityFeePerGasInWei = parseInt(
+        transaction.maxPriorityFeePerGas as string,
+        16,
+    );
 
-  // Calculate gas fees the user would pay.
-  const gasFees = Math.min(
-    maxFeePerGasInWei * transactionGas,
-    (currentGasPriceInWei + maxPriorityFeePerGasInWei) * transactionGas,
-  );
+    // Calculate gas fees the user would pay.
+    const gasFees = Math.min(
+        maxFeePerGasInWei * transactionGas,
+        (currentGasPriceInWei + maxPriorityFeePerGasInWei) * transactionGas,
+    );
 
-  // Calculate gas fees as percentage of transaction.
-  const transactionValueInWei = parseInt(transaction.value as string, 16);
-  const gasFeesPercentage = (gasFees / (gasFees + transactionValueInWei)) * 100;
+    // Calculate gas fees as percentage of transaction.
+    const transactionValueInWei = parseInt(transaction.value as string, 16);
+    const gasFeesPercentage = (gasFees / (gasFees + transactionValueInWei)) * 100;
 
-  // Display percentage of gas fees in the transaction insights UI.
-  return {
-    content: panel([
-      heading('Transaction insights Snap'),
-      text(
-        `As set up, you are paying **${gasFeesPercentage.toFixed(
-          2,
-        )}%** in gas fees for this transaction.`,
-      ),
-    ]),
-  };
+    // Display percentage of gas fees in the transaction insights UI.
+    return {
+        content: panel([
+            heading("Transaction insights Snap"),
+            text(
+                `As set up, you are paying **${gasFeesPercentage.toFixed(2)}%**
+                in gas fees for this transaction.`,
+            ),
+        ]),
+    };
 };
 ```
 
@@ -192,16 +191,16 @@ To build and test your Snap:
 The Snap should display a gas fee percentage for ETH transfers initiated by the user.
 For contract interactions, add the following code to the beginning of the `onTransaction` entry point:
 
-```typescript
-if (typeof transaction.data === 'string' && transaction.data !== '0x') {
-  return {
-    content: panel([
-      heading('Percent Snap'),
-      text(
-        'This Snap only provides transaction insights for simple ETH transfers.',
-      ),
-    ]),
-  };
+```typescript title="index.ts"
+if (typeof transaction.data === "string" && transaction.data !== "0x") {
+    return {
+        content: panel([
+            heading("Percent Snap"),
+            text(
+                "This Snap only provides transaction insights for simple ETH transfers.",
+            ),
+        ]),
+    };
 }
 ```
 

--- a/snaps/reference/cli/options.md
+++ b/snaps/reference/cli/options.md
@@ -167,7 +167,7 @@ When set to `true`, WebAssembly files can be imported in the Snap.
 For example:
 
 ```typescript
-import program from './program.wasm';
+import program from "./program.wasm";
 
 // Program is initialized synchronously.
 // ...
@@ -523,7 +523,7 @@ stats: {
     builtIns: {
         ignore: [
             // Built-in modules to ignore.
-        ]
+        ],
     },
 },
 ```

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -45,7 +45,7 @@ An object containing an RPC request specified in the `endowment:cronjob` permiss
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnCronjobHandler } from "@metamask/sdk";
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
@@ -68,7 +68,7 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 module.exports.onCronjob = async ({ request }) => {
     switch (request.method) {
         case "exampleMethodOne":
@@ -113,7 +113,7 @@ A content object displayed using [custom UI](../features/custom-ui.md).
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnHomePageHandler } from "@metamask/snaps-sdk";
 import { panel, text, heading } from "@metamask/snaps-sdk";
 
@@ -130,7 +130,7 @@ export const onHomePage: OnHomePageHandler = async () => {
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { panel, text, heading } from "@metamask/snaps-sdk";
 
 module.exports.onHomePage = async () => {
@@ -165,7 +165,7 @@ None.
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnInstallHandler } from "@metamask/snaps-sdk";
 import { heading, panel, text } from "@metamask/snaps-sdk";
 
@@ -188,7 +188,7 @@ export const onInstall: OnInstallHandler = async () => {
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { heading, panel, text } from "@metamask/snaps-sdk";
 
 module.exports.onInstall = async () => {
@@ -237,7 +237,7 @@ An object containing:
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnNameLookupHandler } from "@metamask/snaps-types";
 
 export const onNameLookup: OnNameLookupHandler = async (request) => {
@@ -264,7 +264,7 @@ export const onNameLookup: OnNameLookupHandler = async (request) => {
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 module.exports.onNameLookup = async ({ request }) => {
     const { chainId, address, domain } = request;
   
@@ -316,7 +316,7 @@ A promise containing the return of the implemented method.
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 export const onRpcRequest: OnRpcRequestHandler = async ({
@@ -336,7 +336,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     case 'hello':
@@ -388,7 +388,7 @@ An object containing:
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnSignatureHandler, SeverityLevel } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -401,9 +401,9 @@ export const onSignature: OnSignatureHandler = async ({
         content: panel([
             heading("My Signature Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
+            ...(insights.map((insight) => text(insight.value))),
         ]),
-        severity: SeverityLevel.Critical
+        severity: SeverityLevel.Critical,
     };
 };
 ```
@@ -411,7 +411,7 @@ export const onSignature: OnSignatureHandler = async ({
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { SeverityLevel } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -424,9 +424,9 @@ module.exports.onSignature = async ({
         content: panel([
             heading("My Signature Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
+            ...(insights.map((insight) => text(insight.value))),
         ]),
-        severity: SeverityLevel.Critical
+        severity: SeverityLevel.Critical,
     };
 };
 ```
@@ -467,7 +467,7 @@ for the transaction that `onTransaction` was called with.
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnTransactionHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -481,8 +481,8 @@ export const onTransaction: OnTransactionHandler = async ({
         content: panel([
             heading("My Transaction Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
-        ])
+            ...(insights.map((insight) => text(insight.value))),
+        ]),
     };
 };
 ```
@@ -490,7 +490,7 @@ export const onTransaction: OnTransactionHandler = async ({
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
 module.exports.onTransaction = async ({
@@ -503,8 +503,8 @@ module.exports.onTransaction = async ({
         content: panel([
             heading("My Transaction Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
-        ])
+            ...(insights.map((insight) => text(insight.value))),
+        ]),
     };
 };
 ```
@@ -525,7 +525,7 @@ insight with the severity level `critical`:
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnTransactionHandler } from "@metamask/snaps-sdk";
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
@@ -539,10 +539,10 @@ export const onTransaction: OnTransactionHandler = async ({
         content: panel([
             heading("My Transaction Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
+            ...(insights.map((insight) => text(insight.value))),
         ]),
         // highlight-next-line
-        severity: "critical"
+        severity: "critical",
     };
 };
 ```
@@ -550,7 +550,7 @@ export const onTransaction: OnTransactionHandler = async ({
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { panel, heading, text } from "@metamask/snaps-sdk";
 
 module.exports.onTransaction = async ({
@@ -563,10 +563,10 @@ module.exports.onTransaction = async ({
         content: panel([
             heading("My Transaction Insights"),
             text("Here are the insights:"),
-            ...(insights.map((insight) => text(insight.value)))
+            ...(insights.map((insight) => text(insight.value))),
         ]),
         // highlight-next-line
-        severity: "critical"
+        severity: "critical",
     };
 };
 ```
@@ -593,7 +593,7 @@ None.
 <Tabs>
 <TabItem value="TypeScript">
 
-```typescript
+```typescript title="index.ts"
 import type { OnUpdateHandler } from "@metamask/snaps-sdk";
 import { heading, panel, text } from "@metamask/snaps-sdk";
 
@@ -619,7 +619,7 @@ export const onUpdate: OnUpdateHandler = async () => {
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
+```js title="index.js"
 import { heading, panel, text } from "@metamask/snaps-sdk";
 
 module.exports.onUpdate = async () => {

--- a/snaps/reference/jest.md
+++ b/snaps/reference/jest.md
@@ -28,13 +28,13 @@ An object with functions that can be used to interact with the Snap.
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should do something', async () => {
-    await installSnap(/* optional Snap ID */);
-    // ...
-  });
+describe("MySnap", () => {
+    it("should do something", async () => {
+        await installSnap(/* optional Snap ID */);
+        // ...
+    });
 });
 ```
 
@@ -54,24 +54,23 @@ which can be checked using [Jest matchers](#jest-matchers).
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should respond to foo with bar', async () => {
-    const { request } = await installSnap(/* optional snap ID */);
-    const response = await request({
-      origin: 'http://localhost:8080',
-      method: 'foo',
-      params: [],
+describe("MySnap", () => {
+    it("should respond to foo with bar", async () => {
+        const { request } = await installSnap(/* optional snap ID */);
+        const response = await request({
+            origin: "http://localhost:8080",
+            method: "foo",
+            params: [],
+        });
+    
+        /* Check the response using Jest matchers. Since the response is a standard JSON-RPC response,
+         * you can use any standard Jest matchers to check it, including snapshot matchers. */
+        expect(response).toRespondWith("bar");
+        expect(response).not.toRespondWithError("baz");
+        expect(response).toMatchSnapshot();
     });
-
-    /* Check the response using Jest matchers. Since the response
-     * is a standard JSON-RPC response, you can use any standard
-     * Jest matchers to check it, including snapshot matchers. */
-    expect(response).toRespondWith('bar');
-    expect(response).not.toRespondWithError('baz');
-    expect(response).toMatchSnapshot();
-  });
 });
 ```
 
@@ -106,23 +105,23 @@ An object with the user interface that was shown by the Snap, in the
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
-import { panel, text } from '@metamask/snaps-sdk';
+import { installSnap } from "@metamask/snaps-jest";
+import { panel, text } from "@metamask/snaps-sdk";
 
-describe('MySnap', () => {
-  it('should return insights', async () => {
-    const { onTransaction } = await installSnap(/* optional Snap ID */);
-    const response = await onTransaction({
-      value: '0x0',
-      data: '0x',
-      gasLimit: '0x5208',
-      maxFeePerGas: '0x5208',
-      maxPriorityFeePerGas: '0x5208',
-      nonce: '0x0',
+describe("MySnap", () => {
+    it("should return insights", async () => {
+        const { onTransaction } = await installSnap(/* optional Snap ID */);
+        const response = await onTransaction({
+            value: "0x0",
+            data: "0x",
+            gasLimit: "0x5208",
+            maxFeePerGas: "0x5208",
+            maxPriorityFeePerGas: "0x5208",
+            nonce: "0x0",
+        });
+    
+        expect(response).toRender(panel([text("Hello, world!")]));
     });
-
-    expect(response).toRender(panel([text('Hello, world!')]));
-  });
 });
 ```
 
@@ -145,20 +144,20 @@ which can be checked using [Jest matchers](#jest-matchers).
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap } from "@metamask/snaps-jest";
 
-describe('MySnap', () => {
-  it('should end foo cronjobs with response bar', async () => {
-    const { onCronjob } = await installSnap(/* optional snap ID */);
-    const response = await onCronjob({
-      method: 'foo',
-      params: [],
+describe("MySnap", () => {
+    it("should end foo cronjobs with response bar", async () => {
+        const { onCronjob } = await installSnap(/* optional snap ID */);
+        const response = await onCronjob({
+            method: "foo",
+            params: [],
+        });
+    
+        // Check the response using Jest matchers.
+        expect(response).toRespondWith("bar");
+        expect(response).not.toRespondWithError("baz");
     });
-
-    // Check the response using Jest matchers
-    expect(response).toRespondWith('bar');
-    expect(response).not.toRespondWithError('baz');
-  });
 });
 ```
 
@@ -170,16 +169,16 @@ takes no arguments, and returns a promise that resolves to the response from the
 entry point.
 
 ```js
-import { installSnap } from '@metamask/snaps-jest';
-import { panel, text } from '@metamask/snaps-sdk';
+import { installSnap } from "@metamask/snaps-jest";
+import { panel, text } from "@metamask/snaps-sdk";
 
-describe('MySnap', () => {
-  it('should render the home page', async () => {
-    const { onHomePage } = await installSnap(/* optional snap ID */);
-    const response = await onHomePage();
-
-    expect(response).toRender(panel([text('Hello, world!')]));
-  });
+describe("MySnap", () => {
+    it("should render the home page", async () => {
+        const { onHomePage } = await installSnap(/* optional snap ID */);
+        const response = await onHomePage();
+    
+        expect(response).toRender(panel([text("Hello, world!")]));
+    });
 });
 ```
 
@@ -197,33 +196,32 @@ be used to interact with the user interface.
 #### Example
 
 ```javascript
-import { installSnap } from '@metamask/snaps-jest';
-import { text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
+import { installSnap } from "@metamask/snaps-jest";
+import { text } from "@metamask/snaps-sdk";
+import { assert } from "@metamask/utils";
 
-describe('MySnap', () => {
-  it('should render an alert with hello world', async () => {
-    const { request } = await installSnap(/* optional Snap ID */);
-
-    // Note: You cannot resolve the promise yet!
-    const response = request({
-      method: 'foo',
+describe("MySnap", () => {
+    it("should render an alert with hello world", async () => {
+        const { request } = await installSnap(/* optional Snap ID */);
+    
+        // Note: You cannot resolve the promise yet!
+        const response = request({
+            method: "foo",
+        });
+    
+        const ui = await response.getInterface();
+    
+        // This is useful if you're using TypeScript, since it infers the type of the user interface.
+        assert(ui.type === "alert");
+        expect(ui).toRender(text("Hello, world!"));
+    
+        // Select the OK button.
+        await ui.ok();
+    
+        // Now you can resolve the promise.
+        const result = await response;
+        expect(result).toRespondWith("bar");
     });
-
-    const ui = await response.getInterface();
-
-    // This is useful if you're using TypeScript, since it infers the type
-    // of the user interface.
-    assert(ui.type === 'alert');
-    expect(ui).toRender(text('Hello, world!'));
-
-    // "Click" the OK button.
-    await ui.ok();
-
-    // Now you can resolve the promise.
-    const result = await response;
-    expect(result).toRespondWith('bar');
-  });
 });
 ```
 
@@ -256,7 +254,7 @@ This server serves the execution environment, simulator, and the Snap bundle dur
 The server options are:
 
 - `enabled` - Enables or disables the built-in HTTP server.
-  Set to `false` to use your own HTTP server, which you can specify when calling [`installSnap`](#installsnap), e.g. `installSnap('local:http://my-server')`.
+  Set to `false` to use your own HTTP server, which you can specify when calling [`installSnap`](#installsnap), e.g. `installSnap("local:http://my-server")`.
   The default is `true`.
 - `port` - The port to use for the built-in HTTP server.
   The default is a random available (unprivileged) port.
@@ -267,14 +265,14 @@ The server options are:
 
 #### Example
 
-```javascript
+```javascript title="jest.config.js"
 module.exports = {
-  preset: '@metamask/snaps-jest',
-  testEnvironmentOptions: {
-    server: {
-      port: 8080,
-      root: '/path/to/snap/files',
+    preset: "@metamask/snaps-jest",
+    testEnvironmentOptions: {
+        server: {
+            port: 8080,
+            root: "/path/to/snap/files",
+        },
     },
-  },
 };
 ```

--- a/snaps/reference/keyring-api/account-management/events.md
+++ b/snaps/reference/keyring-api/account-management/events.md
@@ -20,9 +20,9 @@ MetaMask returns an error if the account already exists or the account object is
 ```typescript
 try {
     emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, { account });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```
 
@@ -40,9 +40,9 @@ MetaMask returns an error if one of the following is true:
 ```typescript
 try {
     emitSnapKeyringEvent(snap, KeyringEvent.AccountUpdated, { account });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```
 
@@ -58,9 +58,9 @@ try {
     emitSnapKeyringEvent(snap, KeyringEvent.AccountDeleted, {
         id: account.id,
     });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```
 
@@ -79,9 +79,9 @@ try {
         id: request.id,
         result,
     });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```
 
@@ -99,8 +99,8 @@ try {
     emitSnapKeyringEvent(snap, KeyringEvent.RequestRejected, {
         id: request.id,
     });
-    // Update your Snap's state...
+    // Update your Snap's state.
 } catch (error) {
-    // Handle the error...
+    // Handle the error.
 }
 ```

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -18,7 +18,7 @@ manifest file:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_dialog": {}
+    "snap_dialog": {}
 }
 ```
 
@@ -38,28 +38,28 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:cronjob": {
-    "jobs": [
-      {
-        "expression": "* * * * *",
-        "request": {
-          "method": "exampleMethodOne",
-          "params": {
-            "param1": "foo"
-          }
-        }
-      },
-      {
-        "expression": "*/2 * * * *",
-        "request": {
-          "method": "exampleMethodTwo",
-          "params": {
-            "param1": "bar"
-          }
-        }
-      }
-    ]
-  }
+    "endowment:cronjob": {
+        "jobs": [
+            {
+                "expression": "* * * * *",
+                "request": {
+                    "method": "exampleMethodOne",
+                    "params": {
+                        "param1": "foo"
+                    }
+                }
+            },
+            {
+                "expression": "*/2 * * * *",
+                "request": {
+                    "method": "exampleMethodTwo",
+                    "params": {
+                        "param1": "bar"
+                    }
+                }
+            }
+        ]
+    }
 }
 ```
 
@@ -74,7 +74,7 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:ethereum-provider": {}
+    "endowment:ethereum-provider": {}
 }
 ```
 
@@ -94,7 +94,7 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:page-home": {}
+    "endowment:page-home": {}
 }
 ```
 
@@ -113,9 +113,9 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:keyring": {
-    "allowedOrigins": ["https://<dapp domain>"]
-  }
+    "endowment:keyring": {
+        "allowedOrigins": ["https://<dapp domain>"]
+    }
 }
 ```
 
@@ -135,7 +135,7 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:lifecycle-hooks": {}
+    "endowment:lifecycle-hooks": {}
 }
 ```
 
@@ -168,13 +168,13 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:name-lookup": {
-    "chains": ["eip155:1"],
-    "matchers": {
-      "tlds": ["crypto"],
-      "schemes": ["farcaster"]
+    "endowment:name-lookup": {
+        "chains": ["eip155:1"],
+        "matchers": {
+            "tlds": ["crypto"],
+            "schemes": ["farcaster"]
+        }
     }
-  }
 },
 ```
 
@@ -197,7 +197,7 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:network-access": {}
+    "endowment:network-access": {}
 }
 ```
 
@@ -229,10 +229,10 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:rpc": {
-    "dapps": true,
-    "snaps": false
-  }
+    "endowment:rpc": {
+        "dapps": true,
+        "snaps": false
+    }
 }
 ```
 
@@ -245,13 +245,13 @@ Specify this caveat in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:rpc": { 
-    "allowedOrigins": [
-      "metamask.io", 
-      "consensys.io",
-      "npm:@metamask/example-snap"
-    ] 
-  }
+    "endowment:rpc": { 
+        "allowedOrigins": [
+            "metamask.io", 
+            "consensys.io",
+            "npm:@metamask/example-snap"
+        ] 
+    }
 }
 ```
 
@@ -280,9 +280,9 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:transaction-insight": {
-    "allowTransactionOrigin": true
-  }
+    "endowment:transaction-insight": {
+        "allowTransactionOrigin": true
+    }
 }
 ```
 
@@ -305,9 +305,9 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:signature-insight": {
-    "allowSignatureOrigin": true
-  }
+    "endowment:signature-insight": {
+        "allowSignatureOrigin": true
+    }
 },
 ```
 
@@ -320,7 +320,7 @@ Specify this permission in the manifest file as follows:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:webassembly": {}
+    "endowment:webassembly": {}
 }
 ```
 
@@ -335,9 +335,9 @@ For example:
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:transaction-insight": {
-    "maxRequestTime": 10000
-  }
+    "endowment:transaction-insight": {
+        "maxRequestTime": 10000
+    }
 }
 ```
 
@@ -365,17 +365,15 @@ Calling `eth_requestAccounts` requires the
 
 ```json title="snap.manifest.json"
 "initialPermissions": {
-  "endowment:ethereum-provider": {}
+    "endowment:ethereum-provider": {}
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```js
-await ethereum.request({
-  "method": "eth_requestAccounts"
-});
+```js title="index.js"
+await ethereum.request({ "method": "eth_requestAccounts" });
 ```
 
 </TabItem>
@@ -390,18 +388,18 @@ The following is an example `eth_accounts` permission:
 
 ```json
 {
-  "id": "47vm2UUi1pccNAeYKGmwF", // example
-  "parentCapability": "eth_accounts",
-  "invoker": "npm:SNAP_ID",
-  "caveats": [
-    {
-      "type": "restrictReturnedAccounts",
-      "value": [
-        "0xc403b37bf1e700cb214ea1be9de066824b420de6" // example connected account #1
-      ]
-    }
-  ],
-  "date": 1692616452846
+    "id": "47vm2UUi1pccNAeYKGmwF", // example
+    "parentCapability": "eth_accounts",
+    "invoker": "npm:SNAP_ID",
+    "caveats": [
+        {
+            "type": "restrictReturnedAccounts",
+            "value": [
+                "0xc403b37bf1e700cb214ea1be9de066824b420de6" // example connected account #1
+            ]
+        }
+    ],
+    "date": 1692616452846
 }
 ```
 

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -388,14 +388,14 @@ The following is an example `eth_accounts` permission:
 
 ```json
 {
-    "id": "47vm2UUi1pccNAeYKGmwF", // example
+    "id": "47vm2UUi1pccNAeYKGmwF",
     "parentCapability": "eth_accounts",
     "invoker": "npm:SNAP_ID",
     "caveats": [
         {
             "type": "restrictReturnedAccounts",
             "value": [
-                "0xc403b37bf1e700cb214ea1be9de066824b420de6" // example connected account #1
+                "0xc403b37bf1e700cb214ea1be9de066824b420de6"
             ]
         }
     ],

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -1,11 +1,10 @@
 ---
 description: See the Snaps API reference.
-toc_max_heading_level: 2
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Snaps API
 
@@ -31,26 +30,26 @@ Displays an alert that can only be acknowledged.
 
 An object containing the contents of the alert dialog:
 
-- `type` - The type of dialog (`'alert'`).
+- `type` - The type of dialog (`"alert"`).
 - `content` - The content of the alert, as a [custom UI](../features/custom-ui.md) component.
 
 #### Example
 
-```javascript
-import { panel, text, heading } from '@metamask/snaps-sdk';
+```javascript title="index.js"
+import { panel, text, heading } from "@metamask/snaps-sdk";
 
 await snap.request({
-  method: 'snap_dialog',
-  params: {
-    type: 'alert',
-    content: panel([
-      heading('Something happened in the system'),
-      text('The thing that happened is...'),
-    ]),
-  },
+    method: "snap_dialog",
+    params: {
+        type: "alert",
+        content: panel([
+            heading("Something happened in the system"),
+            text("The thing that happened is..."),
+        ]),
+    },
 });
 
-// Code that should execute after the alert has been acknowledged
+// Code that should execute after the alert has been acknowledged.
 ```
 
 ### Confirmation dialog
@@ -61,7 +60,7 @@ Displays a confirmation that can be accepted or rejected.
 
 An object containing the contents of the confirmation dialog:
 
-- `type` - The type of dialog (`'confirmation'`).
+- `type` - The type of dialog (`"confirmation"`).
 - `content` - The content of the confirmation, as a [custom UI](../features/custom-ui.md) component.
 
 #### Returns
@@ -70,22 +69,22 @@ An object containing the contents of the confirmation dialog:
 
 #### Example
 
-```javascript
-import { panel, text, heading } from '@metamask/snaps-sdk';
+```javascript title="index.js"
+import { panel, text, heading } from "@metamask/snaps-sdk";
 
 const result = await snap.request({
-  method: 'snap_dialog',
-  params: {
-    type: 'confirmation',
-    content: panel([
-      heading('Would you like to take the action?'),
-      text('The action is...'),
-    ]),
-  },
+    method: "snap_dialog",
+    params: {
+        type: "confirmation",
+        content: panel([
+            heading("Would you like to take the action?"),
+            text("The action is..."),
+        ]),
+    },
 });
 
 if (result === true) {
-  // Do the action
+    // Do the action.
 }
 ```
 
@@ -97,7 +96,7 @@ Displays a prompt where the user can enter a text response.
 
 An object containing the contents of the prompt dialog:
 
-- `type` - The type of dialog (`'prompt'`).
+- `type` - The type of dialog (`"prompt"`).
 - `content` - The content of the prompt, as a [custom UI](../features/custom-ui.md) component.
 - `placeholder` - Text that will be in the input field when nothing is typed.
 
@@ -107,22 +106,22 @@ The text entered by the user if the prompt was submitted or `null` if the prompt
 
 #### Example
 
-```javascript
-import { panel, text, heading } from '@metamask/snaps-sdk';
+```javascript title="index.js"
+import { panel, text, heading } from "@metamask/snaps-sdk";
 
 const walletAddress = await snap.request({
-  method: 'snap_dialog',
-  params: {
-    type: 'prompt',
-    content: panel([
-      heading('What is the wallet address?'),
-      text('Please enter the wallet address to be monitored'),
-    ]),
-    placeholder: '0x123...',
-  },
+    method: "snap_dialog",
+    params: {
+        type: "prompt",
+        content: panel([
+            heading("What is the wallet address?"),
+            text("Please enter the wallet address to be monitored"),
+        ]),
+        placeholder: "0x123...",
+    },
 });
 
-// `walletAddress` will be a string containing the address entered by the user
+//`walletAddress will be a string containing the address entered by the user.
 ```
 
 ## `snap_getBip32Entropy`
@@ -143,7 +142,7 @@ This method is designed to be used with the
 for user addresses, but it's your responsibility to know how to use those keys to, for example,
 derive an address for the relevant protocol or sign a transaction for the user.
 
-### Parameters
+#### Parameters
 
 An object containing:
 
@@ -151,9 +150,9 @@ An object containing:
   retrieve.
   For example, `["m", "44'", "60'"]`.
 - `curve` - The curve to use for the key derivation.
-  Must be `'ed25519'` or `'secp256k1'`.
+  Must be `"ed25519"` or `"secp256k1"`.
 
-### Returns
+#### Returns
 
 An object representing the
 [SLIP-10](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) HD tree node and containing
@@ -165,47 +164,47 @@ its corresponding key material:
 - `privateKey` - The private key of the node.
 - `publicKey` - The public key of the node.
 - `chainCode` - The chain code of the node.
-- `curve` - The name of the curve used by the node: `'ed25519'` or `'secp256k1'`.
+- `curve` - The name of the curve used by the node: `"ed25519"` or `"secp256k1"`.
 
-### Example
+#### Example
 
 <Tabs>
 <TabItem value="Manifest file">
 
-```json
+```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_getBip32Entropy": [
-    {
-      "path": ["m", "44'", "3'"],
-      "curve": "secp256k1" // Or "ed25519"
-    }
-  ]
+    "snap_getBip32Entropy": [
+        {
+            "path": ["m", "44'", "3'"],
+            "curve": "secp256k1" // Or "ed25519"
+        }
+    ]
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```javascript
-import { SLIP10Node } from '@metamask/key-tree';
+```javascript title="index.js"
+import { SLIP10Node } from "@metamask/key-tree";
 
-// This example uses Dogecoin, which has a derivation path starting with `m/44'/3'`.
+// This example uses Dogecoin, which has a derivation path starting with m/44'/3'.
 const dogecoinNode = await snap.request({
-  method: 'snap_getBip32Entropy',
-  params: {
-    // Must be specified exactly in the manifest
-    path: ['m', "44'", "3'"],
-    curve: 'secp256k1',
-  },
+    method: "snap_getBip32Entropy",
+    params: {
+        // The path and curve must be specified in the initial permissions.
+        path: ["m", "44'", "3'"],
+        curve: "secp256k1",
+    },
 });
 
 // Next, create an instance of a SLIP-10 node for the Dogecoin node.
 const dogecoinSlip10Node = await SLIP10Node.fromJSON(dogecoinNode);
 
-// m / 44' / 3' / 0'
+// m/44'/3'/0'
 const accountKey0 = await dogecoinSlip10Node.derive(["bip32:0'"]);
 
-// m / 44' / 3' / 1'
+// m/44'/3'/1'
 const accountKey1 = await dogecoinSlip10Node.derive(["bip32:1'"]);
 
 // Now, you can ask the user to sign transactions, etc.
@@ -220,7 +219,7 @@ Gets the [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 derivation path specified by the `path` parameter.
 Note that this returns the public key, not the extended public key (`xpub`), or Ethereum address.
 
-### Parameters
+#### Parameters
 
 An object containing:
 
@@ -228,46 +227,46 @@ An object containing:
   retrieve.
   For example, `["m", "44'", "60'"]`.
 - `curve` - The curve to use for the key derivation.
-  Must be `'ed25519'` or `'secp256k1'`.
+  Must be `"ed25519"` or `"secp256k1"`.
 - `compressed` - Indicates whether the public key should be compressed.
   The default is `false`.
 
-### Returns
+#### Returns
 
 The public key as hexadecimal string.
 
-### Example
+#### Example
 
 <Tabs>
 <TabItem value="Manifest file">
 
-```json
+```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_getBip32PublicKey": [
-    {
-      "path": ["m", "44'", "3'", "0'", "0", "0"],
-      "curve": "secp256k1" // Or "ed25519"
-    }
-  ]
+    "snap_getBip32PublicKey": [
+        {
+            "path": ["m", "44'", "3'", "0'", "0", "0"],
+            "curve": "secp256k1" // Or "ed25519"
+        }
+    ]
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```javascript
-// This example uses Dogecoin, which has a derivation path starting with `m/44'/3'`.
+```javascript title="index.js"
+// This example uses Dogecoin, which has a derivation path starting with m/44'/3'.
 const dogecoinPublicKey = await snap.request({
-  method: 'snap_getBip32PublicKey',
-  params: {
-    // The path and curve must be specified in the initial permissions.
-    path: ['m', "44'", "3'", "0'", '0', '0'],
-    curve: 'secp256k1',
-    compressed: false,
-  },
+    method: "snap_getBip32PublicKey",
+    params: {
+        // The path and curve must be specified in the initial permissions.
+        path: ['m", "44'", "3'", "0'", '0", '0'],
+        curve: "secp256k1",
+        compressed: false,
+    },
 });
 
-// `0x...`
+// "0x..."
 console.log(dogecoinPublicKey);
 ```
 
@@ -294,7 +293,7 @@ This method is designed to be used with the
 for user addresses, but it's your responsibility to know how to use those keys to, for example,
 derive an address for the relevant protocol or sign a transaction for the user.
 
-### Parameters
+#### Parameters
 
 An object containing `coinType`, the BIP-44 coin type to get the entropy for.
 
@@ -305,7 +304,7 @@ If you wish to connect to MetaMask accounts in a Snap, use
 [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts).
 :::
 
-### Returns
+#### Returns
 
 An object representing the
 [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) `coin_type` HD tree node
@@ -319,48 +318,47 @@ and containing its corresponding key material:
 - `publicKey` - The hexadecimal-encoded string representation of the public key for the node.
 - `chainCode` - The hexadecimal-encoded string representation of the chain code for the node.
 - `path` - A human-readable representation of the BIP-44 HD tree path of the node.
-  Since this is a `coin_type` node, the path is of the form `m / 44' / coin_type'`.
+  Since this is a `coin_type` node, the path is of the form `m/44'/coin_type'`.
 
-### Example
+#### Example
 
 <Tabs>
 <TabItem value="Manifest file">
 
-```json
+```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_getBip44Entropy": [
-    {
-      "coinType": 3
-    }
-  ]
+    "snap_getBip44Entropy": [
+        {
+            "coinType": 3
+        }
+    ]
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```javascript
-import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+```javascript title="index.js"
+import { getBIP44AddressKeyDeriver } from "@metamask/key-tree";
 
-// This example uses Dogecoin, which has `coin_type` 3.
+// This example uses Dogecoin, which has coin_type 3.
 const dogecoinNode = await snap.request({
-  method: 'snap_getBip44Entropy',
-  params: {
-    coinType: 3,
-  },
+    method: "snap_getBip44Entropy",
+    params: {
+        coinType: 3,
+    },
 });
 
 // Next, create an address key deriver function for the Dogecoin coin_type node.
-// In this case, its path is: m / 44' / 3' / 0' / 0 / address_index
+// In this case, its path is: m/44'/3'/0'/0/address_index
 const deriveDogecoinAddress = await getBIP44AddressKeyDeriver(dogecoinNode);
 
-// These are BIP-44 nodes containing the extended private keys for
-// the respective derivation paths.
+// These are BIP-44 nodes containing the extended private keys for the respective derivation paths.
 
-// m / 44' / 3' / 0' / 0 / 0
+// m/44'/3'/0'/0/0
 const addressKey0 = await deriveDogecoinAddress(0);
 
-// m / 44' / 3' / 0' / 0 / 1
+// m/44'/3'/0'/0/1
 const addressKey1 = await deriveDogecoinAddress(1);
 
 // Now, you can ask the user to sign transactions, etc.
@@ -378,31 +376,31 @@ It is useful to check if MetaMask is locked in the following situations:
 - When running background operations that require MetaMask to be unlocked, for example, [accessing encrypted state](#snap_managestate). If MetaMask is locked, the user gets a popup asking them to enter their password, which might be unexpected or confusing.
 - When [displaying a dialog](#snap_dialog). Dialogs do not work when MetaMask is locked.
 
-### Returns
+#### Returns
 
 `true` if MetaMask is locked, `false` if MetaMask is unlocked.
 
-### Example
+#### Example
 
-```typescript
-import type { OnCronjobHandler } from '@metamask/snaps-sdk';
-import { MethodNotFoundError } from '@metamask/snaps-sdk';
+```typescript title="index.js"
+import type { OnCronjobHandler } from "@metamask/snaps-sdk";
+import { MethodNotFoundError } from "@metamask/snaps-sdk";
 
 export const onCronjob: OnCronjobHandler = async ({ request }) => {
-  switch (request.method) {
-    case 'execute':
-      // Find out if MetaMask is locked
-      const { locked } = await snap.request({
-        method: 'snap_getClientStatus'
-      });
-
-      if (!locked) {
-        // Do something that requires MetaMask to be unlocked, like access encrypted state
-      }
-
-    default:
-      throw new MethodNotFoundError();
-  }
+    switch (request.method) {
+        case "execute":
+            // Find out if MetaMask is locked.
+            const { locked } = await snap.request({
+                method: "snap_getClientStatus"
+            });
+      
+            if (!locked) {
+                // Do something that requires MetaMask to be unlocked, such as access encrypted state.
+            }
+    
+        default:
+            throw new MethodNotFoundError();
+    }
 };
 ```
 
@@ -418,7 +416,7 @@ Using a salt results in entropy unrelated to the entropy generated without a sal
 
 This value is deterministic: it's always the same for the same Snap, user account, and salt.
 
-### Parameters
+#### Parameters
 
 An object containing:
 
@@ -427,34 +425,34 @@ An object containing:
 - `salt` (optional) - An arbitrary string to be used as a salt for the entropy.
   This can be used to generate different entropy for different purposes.
 
-### Returns
+#### Returns
 
 The entropy as a hexadecimal string.
 
-### Example
+#### Example
 
 <Tabs>
 <TabItem value="Manifest file">
 
-```json
+```json title="snap.manifest.json"
 "initialPermissions": {
-  "snap_getEntropy": {}
+    "snap_getEntropy": {}
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```javascript
+```javascript title="index.js"
 const entropy = await snap.request({
-  method: 'snap_getEntropy',
-  params: {
-    version: 1,
-    salt: 'foo', // Optional
-  },
+    method: "snap_getEntropy",
+    params: {
+        version: 1,
+        salt: "foo", // Optional
+    },
 });
 
-// `0x...`
+// "0x..."
 console.log(entropy);
 ```
 
@@ -466,47 +464,47 @@ console.log(entropy);
 Gets a static file's content in UTF-8, Base64, or hexadecimal.
 The file must be [specified in the Snap's manifest file](../features/static-files.md).
 
-### Parameters
+#### Parameters
 
 An object containing:
 
 - `path` - The path to the file, relative to the Snap's package directory (that is, one level above `src`).
 - `encoding` (optional) - One of `utf8`, `base64`, or `hex`. The default is `base64`.
 
-### Returns
+#### Returns
 
 The file content as a string in the requested encoding.
 
-### Example
+#### Example
 
 <Tabs>
 <TabItem value="Manifest file">
 
-```json
+```json title="snap.manifest.json"
 "source": {
-  "shasum": "xxx",
-  "location": {
-    // ...
-  },
-  "files": [
-    "./files/myfile.bin"
-  ]
+    "shasum": "xxx",
+    "location": {
+        // ...
+    },
+    "files": [
+        "./files/myfile.bin"
+    ]
 }
 ```
 
 </TabItem>
 <TabItem value="JavaScript">
 
-```javascript
+```javascript title="index.js"
 const contents = await snap.request({
-  method: 'snap_getFile',
-  params: {
-    path: './files/myfile.bin',
-    encoding: 'hex',
-  },
+    method: "snap_getFile",
+    params: {
+        path: "./files/myfile.bin",
+        encoding: "hex",
+    },
 });
 
-// `0x...`
+// "0x..."
 console.log(contents);
 ```
 
@@ -517,30 +515,30 @@ console.log(contents);
 
 Gets the user's locale setting. You can use this method to localize text in your snap.
 
-### Returns
+#### Returns
 
 The user's locale setting as a [language code](https://github.com/MetaMask/metamask-extension/blob/develop/app/_locales/index.json).
 
-### Example
+#### Example
 
-```javascript
-import { panel, text } from '@metamask/snaps-sdk';
+```javascript title="index.js"
+import { panel, text } from "@metamask/snaps-sdk";
 
-const locale = await snap.request({ method: 'snap_getLocale' });
+const locale = await snap.request({ method: "snap_getLocale" });
 
-let greeting = 'Hello';
-if(locale === 'es') {
-  greeting = 'Hola';
+let greeting = "Hello";
+if(locale === "es") {
+    greeting = "Hola";
 }
 
 await snap.request({
-  method: 'snap_dialog',
-  params: {
-    type: 'alert',
-    content: panel([
-      text(greeting),
-    ]),
-  },
+    method: "snap_dialog",
+    params: {
+        type: "alert",
+        content: panel([
+            text(greeting),
+        ]),
+    },
 });
 ```
 
@@ -574,48 +572,48 @@ This can be done using [`snap_manageState`](#snap_managestate).
 
 #### Example
 
-```typescript
-import { Keyring, KeyringAccount } from '@metamask/keyring-api';
+```typescript title="index.ts"
+import { Keyring, KeyringAccount } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
-  // ... other methods
-
-  async createAccount(
-    name: string,
-    options: Record<string, Json> | null = null,
-  ): Promise<KeyringAccount> {
-
-    const account: KeyringAccount = {
-      id: uuid(),
-      name,
-      options,
-      address,
-      supportedMethods: [
-        'eth_sendTransaction',
-        'eth_sign',
-        'eth_signTransaction',
-        'eth_signTypedData_v1',
-        'eth_signTypedData_v2',
-        'eth_signTypedData_v3',
-        'eth_signTypedData_v4',
-        'eth_signTypedData',
-        'personal_sign',
-      ],
-      type: 'eip155:eoa',
-    };
-
-    // Store the account in state
-
-    await snap.request({
-      method: 'snap_manageAccounts',
-      params: {
-        method: 'createAccount',
-        params: { account },
-      },
-    });
-
-    return account;
-  }
+    // Other methods.
+  
+    async createAccount(
+        name: string,
+        options: Record<string, Json> | null = null,
+    ): Promise<KeyringAccount> {
+  
+        const account: KeyringAccount = {
+            id: uuid(),
+            name,
+            options,
+            address,
+            supportedMethods: [
+                "eth_sendTransaction",
+                "eth_sign",
+                "eth_signTransaction",
+                "eth_signTypedData_v1",
+                "eth_signTypedData_v2",
+                "eth_signTypedData_v3",
+                "eth_signTypedData_v4",
+                "eth_signTypedData",
+                "personal_sign",
+            ],
+            type: "eip155:eoa",
+        };
+    
+        // Store the account in state.
+    
+        await snap.request({
+            method: "snap_manageAccounts",
+            params: {
+                method: "createAccount",
+                params: { account },
+            },
+        });
+    
+        return account;
+    }
 }
 ```
 
@@ -638,23 +636,23 @@ This can be done using [`snap_manageState`](#snap_managestate).
 
 #### Example
 
-```typescript
-import { Keyring, KeyringAccount } from '@metamask/keyring-api';
+```typescript title="index.ts"
+import { Keyring, KeyringAccount } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
-  // ... other methods
-
-  async updateAccount(account: KeyringAccount): Promise<void> {
-    // Store the new account details in state
-
-    await snap.request({
-      method: 'snap_manageAccounts',
-      params: {
-        method: 'updateAccount',
-        params: { account },
-      },
-    });
-  }
+    // Other methods.
+  
+    async updateAccount(account: KeyringAccount): Promise<void> {
+        // Store the new account details in state.
+    
+        await snap.request({
+            method: "snap_manageAccounts",
+            params: {
+                method: "updateAccount",
+                params: { account },
+            },
+        });
+    }
 }
 ```
 
@@ -677,23 +675,23 @@ This can be done using [`snap_manageState`](#snap_managestate).
 
 #### Example
 
-```typescript
-import { Keyring } from '@metamask/keyring-api';
+```typescript title="index.ts"
+import { Keyring } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
-  // ... other methods
-
-  async deleteAccount(id: string): Promise<void> {
-    // Delete the account from state
-
-    await snap.request({
-      method: 'snap_manageAccounts',
-      params: {
-        method: 'deleteAccount',
-        params: { id },
-      },
-    });
-  }
+    // Other methods.
+  
+    async deleteAccount(id: string): Promise<void> {
+        // Delete the account from state.
+    
+        await snap.request({
+            method: "snap_manageAccounts",
+            params: {
+                method: "deleteAccount",
+                params: { id },
+            },
+        });
+    }
 }
 ```
 
@@ -710,25 +708,25 @@ An array of [account objects](keyring-api/account-management/objects.md#keyringa
 
 #### Example
 
-```typescript
-import { Keyring, KeyringAccount } from '@metamask/keyring-api';
+```typescript title="index.ts"
+import { Keyring, KeyringAccount } from "@metamask/keyring-api";
 
 class MyKeyring implements Keyring {
-  // ... other methods
-
-  async checkIfAccountsInSync(): Promise<boolean> {
-
-    const knownAccounts: KeyringAccount[] = /* grab accounts from Snap state */;
-
-    const listedAccounts: KeyringAccount[] = await snap.request({
-      method: 'snap_manageAccounts',
-      params: {
-        method: 'listAccounts'
-      },
-    });
-
-    // compare the arrays and return the response
-  }
+    // Other methods.
+  
+    async checkIfAccountsInSync(): Promise<boolean> {
+  
+        const knownAccounts: KeyringAccount[] = /* Grab accounts from Snap state. */;
+    
+        const listedAccounts: KeyringAccount[] = await snap.request({
+            method: "snap_manageAccounts",
+            params: {
+                method: "listAccounts",
+            },
+        });
+    
+        // Compare the arrays and return the response.
+    }
 }
 ```
 
@@ -749,24 +747,24 @@ This is usually called as part of the
 
 #### Example
 
-```typescript
-import { Keyring } from '@metamask/keyring-api';
-import { Json } from '@metamask/utils';
+```typescript title="index.ts"
+import { Keyring } from "@metamask/keyring-api";
+import { Json } from "@metamask/utils";
 
 class MyKeyring implements Keyring {
-  // ... other methods
-
-  async approveRequest(id: string, result?: Json): Promise<void> {
-    // Do any Snap-side logic to finish approving the request
-
-    await snap.request({
-      method: 'snap_manageAccounts',
-      params: {
-        method: 'submitResponse',
-        params: { id, result}
-      },
-    });
-  }
+    // Other methods.
+  
+    async approveRequest(id: string, result?: Json): Promise<void> {
+        // Do any Snap-side logic to finish approving the request.
+    
+        await snap.request({
+            method: "snap_manageAccounts",
+            params: {
+                method: "submitResponse",
+                params: { id, result },
+            },
+        });
+    }
 }
 ```
 
@@ -784,44 +782,49 @@ If you need to access encrypted state in a background task such as a cron job, y
 unexpected password request popup.
 :::
 
-### Parameters
+#### Parameters
 
 An object containing:
 
-- `operation` - The state operation to perform (`'clear'`, `'get'`, or `'update'`).
-- `newState` - The value to update state with if the operation is `update`, and nothing otherwise.
+- `operation` - The state operation to perform (`"clear"`, `"get"`, or `"update"`).
+- `newState` - The value to update state with if the operation is `"update"`, and nothing otherwise.
 - `encrypted` (optional) - Indicates whether the Snap will encrypt the data.
   The default is `true`.
   If set to `false`, the Snap will use a separate storage section, and will not encrypt the data.
   This is useful to access the data from background operations without requiring the user to enter
   their password in the case that MetaMask is locked.
 
-### Returns
+#### Returns
 
 The value stored in state if the operation is `get`, and `null` otherwise.
 
-### Example
+#### Example
 
-```javascript
+```javascript title="index.js"
 // Persist some data.
 await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'update', newState: { hello: 'world' } },
+    method: "snap_manageState",
+    params: { 
+        operation: "update",
+        newState: { hello: "world" },
+    },
 });
 
 // At a later time, get the data stored.
 const persistedData = await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'get' },
+    method: "snap_manageState",
+    params: { operation: "get" },
 });
 
 console.log(persistedData);
-// { hello: 'world' }
+// { hello: "world" }
 
 // If there's no need to store data anymore, clear it out.
 await snap.request({
-  method: 'snap_manageState',
-  params: { operation: 'clear' },
+    method: "snap_manageState",
+    params: { 
+        operation: "clear",
+    },
 });
 ```
 
@@ -837,7 +840,7 @@ The ability for Snaps to trigger notifications is rate-limited to:
 - 5 in-app notifications per minute per Snap.
 :::
 
-### Parameters
+#### Parameters
 
 An object containing the contents of the notification:
 
@@ -848,14 +851,14 @@ An object containing the contents of the notification:
   the user.
 - `message` - A message to show in the notification.
 
-### Example
+#### Example
 
-```javascript
+```javascript title="index.js"
 await snap.request({
-  method: 'snap_notify',
-  params: {
-    type: 'inApp',
-    message: 'Hello, world!',
-  },
+    method: "snap_notify",
+    params: {
+        type: "inApp",
+        message: "Hello, world!",
+    },
 });
 ```

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -121,7 +121,7 @@ const walletAddress = await snap.request({
     },
 });
 
-//`walletAddress will be a string containing the address entered by the user.
+// walletAddress will be a string containing the address entered by the user.
 ```
 
 ## `snap_getBip32Entropy`
@@ -245,7 +245,7 @@ The public key as hexadecimal string.
     "snap_getBip32PublicKey": [
         {
             "path": ["m", "44'", "3'", "0'", "0", "0"],
-            "curve": "secp256k1" // Or "ed25519"
+            "curve": "secp256k1"
         }
     ]
 }
@@ -260,7 +260,7 @@ const dogecoinPublicKey = await snap.request({
     method: "snap_getBip32PublicKey",
     params: {
         // The path and curve must be specified in the initial permissions.
-        path: ['m", "44'", "3'", "0'", '0", '0'],
+        path: ["m", "44'", "3'", "0'", "0", "0"],
         curve: "secp256k1",
         compressed: false,
     },


### PR DESCRIPTION
Update code samples:

- Prefer double quotes over single quotes
- Prefer four-space indentation over two-space indentation
- Prefer trailing commas for ts and js files
- Add titles with file names where applicable
- Make code comments consistent

Fixes #1144