### PR TITLE
Document using node.js modules in Snaps

### DIFF
--- a/snaps/learn/about-snaps/execution-environment.md
+++ b/snaps/learn/about-snaps/execution-environment.md
@@ -50,9 +50,8 @@ The following globals are also available:
 - `URL`
 
 :::info note
-To use the `Buffer` global, or a Node.js built-in module such as `crypto` or `path`, you
-must [provide a fallback](https://webpack.js.org/configuration/resolve/#resolvefallback) using the
-[`customizeWebpackConfig`](../../reference/cli/options.md#customizewebpackconfig) configuration option.
+To use Node.js built-in modules such as `crypto` and `path`, set the
+[`polyfills`](../../reference/cli/options.md#polyfills) option to `true`.
 :::
 
 ## Secure ECMAScript (SES)

--- a/snaps/learn/about-snaps/execution-environment.md
+++ b/snaps/learn/about-snaps/execution-environment.md
@@ -13,12 +13,23 @@ other parts of the application.
 This environment does not have a DOM, Node.js built-ins, or platform-specific APIs other than the
 default `snap` global and MetaMask's `ethereum` global.
 
-:::note
+The execution environment is designed to:
+
+- Prevent Snaps from influencing any other running code, including MetaMask itself.
+  That is, it prevents all Snaps from polluting the global environment and malicious Snaps from
+  stealing from users.
+- Prevent Snaps from accessing sensitive JavaScript global APIs (such as `fetch`) without permission.
+- Be "fully virtualizable," or platform-independent.
+
+This allows you to safely execute Snaps anywhere, without the Snap needing to worry about where and
+how it's executed.
+
+## Supported globals
+
 A Snap can access the [Snaps API](apis.md#snaps-api) using the `snap` global, and the
 [MetaMask JSON-RPC API](apis.md#metamask-json-rpc-api) using the `ethereum` global.
 To access the `ethereum` global, a Snap must request the
 [`endowment:ethereum-provider`](../../reference/permissions.md#endowmentethereum-provider) permission.
-:::
 
 Almost all
 [standard JavaScript globals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects)
@@ -28,7 +39,6 @@ This includes globals such as `Promise`, `Error`, `Math`, `Set`, and `Reflect`.
 The following globals are also available:
 
 - `console`
-- `crypto`
 - `fetch` (with the
   [`endowment:network-access`](../../reference/permissions.md#endowmentnetwork-access) permission)
 - `setTimeout` / `clearTimeout`
@@ -40,16 +50,11 @@ The following globals are also available:
 - `atob` / `btoa`
 - `URL`
 
-The execution environment is designed to:
-
-- Prevent Snaps from influencing any other running code, including MetaMask itself.
-  That is, it prevents all Snaps from polluting the global environment and malicious Snaps from
-  stealing from users.
-- Prevent Snaps from accessing sensitive JavaScript global APIs (such as `fetch`) without permission.
-- Be "fully virtualizable," or platform-independent.
-
-This allows you to safely execute Snaps anywhere, without the Snap needing to worry about where and
-how it's executed.
+:::info note
+To use the `Buffer` global, or a Node.js built-in module such as `crypto` or `path`, you
+must [provide a fallback](https://webpack.js.org/configuration/resolve/#resolvefallback) using the
+[`customizeWebpackConfig`](../../reference/cli/options.md#customizewebpackconfig) configuration option.
+:::
 
 ## Secure ECMAScript (SES)
 

--- a/snaps/learn/about-snaps/execution-environment.md
+++ b/snaps/learn/about-snaps/execution-environment.md
@@ -15,9 +15,8 @@ default `snap` global and MetaMask's `ethereum` global.
 
 The execution environment is designed to:
 
-- Prevent Snaps from influencing any other running code, including MetaMask itself.
-  That is, it prevents all Snaps from polluting the global environment and malicious Snaps from
-  stealing from users.
+- Prevent Snaps from polluting the global environment.
+- Prevent malicious Snaps from stealing from users.
 - Prevent Snaps from accessing sensitive JavaScript global APIs (such as `fetch`) without permission.
 - Be "fully virtualizable," or platform-independent.
 

--- a/snaps/learn/about-snaps/execution-environment.md
+++ b/snaps/learn/about-snaps/execution-environment.md
@@ -51,7 +51,7 @@ The following globals are also available:
 
 :::info note
 To use Node.js built-in modules such as `crypto` and `path`, set the
-[`polyfills`](../../reference/cli/options.md#polyfills) option to `true`.
+[`polyfills`](../../reference/cli/options.md#polyfills) configuration option to `true`.
 :::
 
 ## Secure ECMAScript (SES)

--- a/snaps/reference/cli/options.md
+++ b/snaps/reference/cli/options.md
@@ -390,6 +390,36 @@ output: {
 Path to the output directory.
 The default is `"dist"`.
 
+### `polyfills`
+
+<Tabs>
+<TabItem value="Syntax">
+
+```javascript
+polyfills: <BOOLEAN|OBJECT>
+```
+
+</TabItem>
+<TabItem value="Example">
+
+```javascript
+polyfills: {
+    buffer: true,
+    crypto: true,
+    path: true,
+}
+```
+
+</TabItem>
+</Tabs>
+
+Enables or disables providing polyfills for Node.js built-in modules.
+If set to `true`, all available polyfills are provided.
+The default is `false`.
+
+You can also set this option to an object with specific polyfills set to `true`.
+See [the list of available polyfills](https://github.com/MetaMask/snaps/blob/51a1d04ea50c5c286262df1959ef0b1ced84b6e2/packages/snaps-cli/src/config.ts#L383-L416).
+
 ### `server`
 
 The development server configuration.
@@ -527,8 +557,8 @@ stats: {
 </Tabs>
 
 Enables or disables showing a warning if the `Buffer` global is used but not provided.
-The `Buffer` global is not available in the Snaps runtime by default, and must be provided using the
-[`customizeWebpackConfig`](#customizewebpackconfig) option.
+The `Buffer` global is not available in the Snaps runtime by default.
+To use `Buffer`, set [`polyfills`](#polyfills) to `true`.
 
 The default is `true`.
 
@@ -563,8 +593,8 @@ Enables or disables checking for missing built-in modules.
 
 Not specifying this option, or specifying an ignore list, enables checking for missing built-in modules.
 When enabled, the CLI shows a warning if a built-in is used but not provided.
-The Snaps CLI does not support Node.js built-ins out of the box, and any used built-ins must be
-provided using the [`customizeWebpackConfig`](#customizewebpackconfig) option.
+The Snaps CLI does not support Node.js built-ins out of the box.
+To use built-ins, set [`polyfills`](#polyfills) to `true`.
 
 You can specify a list of built-ins to ignore when checking for missing built-ins.
 This is useful if the built-in is not actually used in the Snap, but is added by a dependency.


### PR DESCRIPTION
This PR slightly rearranges the "Snaps execution environment" concept page and adds a note on how to use the Node.js built-in modules, which are not supported by default. It also documents the missing `polyfills` config option. Fixes #855.

Preview: https://docs.metamask.io/855-nodejs-modules/snaps/learn/about-snaps/execution-environment/