### PR TITLE
Clarify where to update Snap repository.url

### DIFF
--- a/snaps/learn/about-snaps/files.md
+++ b/snaps/learn/about-snaps/files.md
@@ -75,23 +75,30 @@ The manifest tells MetaMask important information about your Snap, such as where
 reproduce the `source.shasum` value), and what
 [permissions the Snap requests](../../how-to/request-permissions.md) (using `initialPermissions`).
 
-:::note
-Currently, Snaps can only be
-[published to the official npm registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry),
-and the manifest must also match the corresponding fields of the `package.json` file.
-In the future, developers will be able to distribute Snaps in different ways, and the manifest will
-expand to support different publishing solutions.
-
-The [Snaps publishing specification](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-9.md)
-details the requirements of both `snap.manifest.json` and its relationship to `package.json`.
-:::
-
 You might need to modify some manifest fields manually.
 For example, if you change the location of the icon SVG file, you must update
 `source.location.npm.iconPath` to match.
 You can also use the [Snaps CLI](../../reference/cli/subcommands.md) to update some fields for you.
 For example, running [`yarn mm-snap build`](../../reference/cli/subcommands.md#b-build) or
 [`yarn mm-snap manifest --fix`](../../reference/cli/subcommands.md#m-manifest) updates `source.shasum`.
+
+:::caution important
+Some manifest fields must match the corresponding fields of the `/snap/package.json` file.
+
+When updating the `version` and `repository` fields, the Snap inherits the values from `package.json`
+and overwrites them in `snap.manifest.json`.
+We recommend updating `version` and `repository` in `package.json` first, then building the Snap project.
+
+The [Snaps publishing specification](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-9.md)
+details the requirements of both `snap.manifest.json` and its relationship to `package.json`.
+:::
+
+:::note
+Currently, Snaps can only be
+[published to the official npm registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry).
+In the future, developers will be able to distribute Snaps in different ways, and the manifest will
+expand to support different publishing solutions.
+:::
 
 ## Configuration file
 

--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -246,15 +246,16 @@ You can also update the fields in `snap.manifest.json` to match your custom Snap
 
 - `proposedName` - The name of your Snap.
 - `description` - The description of your Snap.
-- `repository` - The URL of your cloned GitHub repository.
 - `source` - The `shasum` is set automatically when you build from the command line.
   If you decided to publish your Snap to `npm`, update the `location` to its published location.
 
-Similarly, you should update the `name`, `version`, `description`, and `repository` sections of
-`/packages/snap/package.json` even if you do not plan to publish your Snap to [`npm`](https://www.npmjs.com/).
+Similarly, you should update the `name`, `version`, `description`, and `repository` fields of
+`/packages/snap/package.json` even if you do not plan to publish your Snap to npm.
 
-:::tip
-The `version` field in `snap.manifest.json` inherits the `version` field from `package.json`.
+:::caution important
+The `version` and `repository` fields in `snap.manifest.json` inherit the values from
+`package.json` and overwrite them in `snap.manifest.json`.
+We recommend updating `version` and `repository` in `package.json` first, then building the Snap project.
 :::
 
 You can update the content of `/packages/site/src/pages/index.tsx` by changing the

--- a/snaps/learn/tutorials/transaction-insights.md
+++ b/snaps/learn/tutorials/transaction-insights.md
@@ -212,15 +212,16 @@ You can update the fields in `snap.manifest.json` to match your custom Snap:
 - `proposedName` - The name of your Snap.
   This replaces **TYPESCRIPT EXAMPLE SNAP** in the transaction insights UI.
 - `description` - The description of your Snap.
-- `repository` - The URL of your cloned GitHub repository.
 - `source` - The `shasum` is set automatically when you build from the command line.
   If you decided to publish your Snap to npm, update the `location` to its published location.
 
-Similarly, you should update the `name`, `version`, `description`, and `repository` sections of
-`packages/snap/package.json` even if you don't plan to publish your Snap to `npm`.
+Similarly, you should update the `name`, `version`, `description`, and `repository` fields of
+`packages/snap/package.json` even if you don't plan to publish your Snap to npm.
 
-:::note
-The `version` field in `snap.manifest.json` inherits the `version` field from `package.json`.
+:::caution important
+The `version` and `repository` fields in `snap.manifest.json` inherit the values from
+`package.json` and overwrite them in `snap.manifest.json`.
+We recommend updating `version` and `repository` in `package.json` first, then building the Snap project.
 :::
 
 You should also add an icon by following the steps outlined in the 
@@ -230,4 +231,4 @@ Lastly, you can update the content of `packages/site/src/pages/index.tsx`, such 
 template **Send Hello** button.
 
 After you've made all necessary changes, you can
-[publish your Snap to `npm`](../../how-to/publish-a-snap.md#publish-your-snap).
+[publish your Snap to npm](../../how-to/publish-a-snap.md).


### PR DESCRIPTION
This PR adds a recommendation to update `repository.url` and `version` in `package.json` instead of `snap.manifest.json`. Fixes #1168.