### PR TITLE
Update 'MetaMask SDK' Footer Link Destination for Correct Navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -455,7 +455,7 @@ const config = {
               },
               {
                 label: "MetaMask SDK",
-                to: "/sdk",
+                to: "/wallet/how-to/use-sdk",
               },
               {
                 label: "Snaps",


### PR DESCRIPTION
# Description
Resolved the issue by updating the "MetaMask SDK" footer link to direct to `/wallet/how-to/use-sdk`, ensuring correct navigation and resolving the 404 error. This enhancement improves user experience by providing access to relevant documentation.


## Issue(s) fixed: https://github.com/MetaMask/metamask-docs/issues/1253

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
