### PR TITLE
Update allowedOrigins example

### DIFF
--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -247,8 +247,8 @@ Specify this caveat in the manifest file as follows:
 "initialPermissions": {
     "endowment:rpc": { 
         "allowedOrigins": [
-            "metamask.io", 
-            "consensys.io",
+            "https://metamask.io", 
+            "https://consensys.io",
             "npm:@metamask/example-snap"
         ] 
     }


### PR DESCRIPTION
This example was incorrect, the URLs need the `https://` to work.

This closes #1272 