### PR TITLE
Fixed openrpcDocument to be a fixed version

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,7 @@ const config = {
             }],
           ],
           openrpc: {
-            openrpcDocument: "https://metamask.github.io/api-specs/latest/openrpc.json",
+            openrpcDocument: "https://metamask.github.io/api-specs/0.8.2/openrpc.json",
             path: "reference",
             sidebarLabel: "JSON-RPC API",
           },


### PR DESCRIPTION
Use the versioned link to the api specs so its a bit less confusing on how to deploy