### PR TITLE
Move wallet_*snap methods to Snaps docs

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,6 +11,10 @@ of the [MetaMask developer page](https://metamask.io/developer/).
 
 ## April 2024
 
+- Moved Snaps-specific Wallet API methods from the
+  [Wallet JSON-RPC API reference](/wallet/reference/json-rpc-api) to the
+  [Snaps reference](/snaps/reference/wallet-json-rpc-api).
+  ([#1286](https://github.com/MetaMask/metamask-docs/pull/1286))
 - Documented [Snaps data storage](/snaps/features/data-storage).
   ([#1278](https://github.com/MetaMask/metamask-docs/pull/1278))
 - Documented [how to get your Snap allowlisted](/snaps/how-to/get-allowlisted).

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,7 +13,7 @@ of the [MetaMask developer page](https://metamask.io/developer/).
 
 - Moved Snaps-specific Wallet API methods from the
   [Wallet JSON-RPC API reference](/wallet/reference/json-rpc-api) to the
-  [Snaps reference](/snaps/reference/wallet-json-rpc-api).
+  [Snaps reference](/snaps/reference/wallet-api-for-snaps).
   ([#1286](https://github.com/MetaMask/metamask-docs/pull/1286))
 - Documented [Snaps data storage](/snaps/features/data-storage).
   ([#1278](https://github.com/MetaMask/metamask-docs/pull/1278))

--- a/snaps/how-to/connect-to-a-snap.md
+++ b/snaps/how-to/connect-to-a-snap.md
@@ -52,7 +52,7 @@ See the following resources for detecting multiple wallets (via
 
 ## Connect to a Snap
 
-Connect to a Snap by calling the [`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps)
+Connect to a Snap by calling the [`wallet_requestSnaps`](../reference/wallet-api-for-snaps.md#wallet_requestsnaps)
 method from your dapp.
 If a user doesn't have the Snap installed in their MetaMask wallet, MetaMask prompts the user to
 install the Snap.
@@ -101,7 +101,7 @@ Do not assume that data stored by a Snap is unique to your dapp.
 ## Determine whether a Snap is installed
 
 Determine whether a Snap is installed by calling the
-[`wallet_getSnaps`](/wallet/reference/wallet_getsnaps) method from your dapp.
+[`wallet_getSnaps`](../reference/wallet-api-for-snaps.md#wallet_getsnaps) method from your dapp.
 This method returns a list of only those Snaps that are connected to your current dapp.
 
 The response is in the form of an object keyed by the ID of the Snap.
@@ -138,7 +138,7 @@ to work with that version.
 At any time, a user can open their MetaMask Snaps settings menu and see all the dapps connected to a Snap.
 From that menu they can revoke a dapp connection.
 If your dapp loses the connection to a Snap, you can reconnect by calling
-[`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps).
+[`wallet_requestSnaps`](../reference/wallet-api-for-snaps.md#wallet_requestsnaps).
 Since the Snap is already installed, this returns a success response without MetaMask showing a pop-up.
 However, if the user has disabled the Snap, the response has `enabled` set to `false` for your `SNAP_ID`:
 

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -63,10 +63,10 @@ See the [`eth_accounts` dynamic permission](../reference/permissions.md#eth_acco
 
 ## Request permissions from a dapp
 
-Dapps that communicate with Snaps using [`wallet_snap`](../reference/wallet-json-rpc-api.md#wallet_snap)
-or [`wallet_invokeSnap`](../reference/wallet-json-rpc-api.md#wallet_invokesnap) must request
+Dapps that communicate with Snaps using [`wallet_snap`](../reference/wallet-api-for-snaps.md#wallet_snap)
+or [`wallet_invokeSnap`](../reference/wallet-api-for-snaps.md#wallet_invokesnap) must request
 permission to do so by calling
-[`wallet_requestSnaps`](../reference/wallet-json-rpc-api.md#wallet_requestsnaps) first.
+[`wallet_requestSnaps`](../reference/wallet-api-for-snaps.md#wallet_requestsnaps) first.
 
 The following example calls `wallet_requestSnaps` to request permission to connect to the
 `hello-snap` Snap, then calls `wallet_invokeSnap` to invoke the `hello` JSON-RPC method exposed by the Snap:

--- a/snaps/how-to/request-permissions.md
+++ b/snaps/how-to/request-permissions.md
@@ -63,10 +63,13 @@ See the [`eth_accounts` dynamic permission](../reference/permissions.md#eth_acco
 
 ## Request permissions from a dapp
 
-Dapps that communicate with Snaps using [`wallet_snap`](/wallet/reference/wallet_snap) and [`wallet_invokeSnap`](/wallet/reference/wallet_invokesnap) must request permission to do so by calling the
-[`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps) MetaMask JSON-RPC API method.
+Dapps that communicate with Snaps using [`wallet_snap`](../reference/wallet-json-rpc-api.md#wallet_snap)
+or [`wallet_invokeSnap`](../reference/wallet-json-rpc-api.md#wallet_invokesnap) must request
+permission to do so by calling
+[`wallet_requestSnaps`](../reference/wallet-json-rpc-api.md#wallet_requestsnaps) first.
 
-The following example calls `wallet_requestSnaps` to request permission to connect to the `hello-snap` Snap, then calls `wallet_invokeSnap` to invoke the `hello` JSON-RPC method exposed by the Snap:
+The following example calls `wallet_requestSnaps` to request permission to connect to the
+`hello-snap` Snap, then calls `wallet_invokeSnap` to invoke the `hello` JSON-RPC method exposed by the Snap:
 
 ```js title="index.js"
 // If the Snap is not already installed, the user will be prompted to install it.

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -108,7 +108,7 @@ The `ethereum` global available to Snaps has fewer capabilities than `window.eth
 Snaps can only use it to make read requests, not to write to the blockchain or initiate transactions.
 Snaps can call all Wallet JSON-RPC API methods **except** the following:
 
-- [`wallet_requestSnaps`](/wallet/reference/wallet_requestSnaps)
+- [`wallet_requestSnaps`](../../reference/wallet-api-for-snaps.md#wallet_requestsnaps)
 - [`wallet_requestPermissions`](/wallet/reference/wallet_requestPermissions)
 - [`wallet_revokePermissions`](/wallet/reference/wallet_revokePermissions)
 - [`wallet_addEthereumChain`](/wallet/reference/wallet_addEthereumChain)

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -38,20 +38,20 @@ await snap.request({
 });
 ```
 
-## Wallet JSON-RPC API
+## Wallet API
 
 ### Dapp requests
 
 Dapps can install and communicate with Snaps using the following
-[Wallet JSON-RPC API](../../reference/wallet-json-rpc-api.md) methods:
+[Wallet API methods for Snaps](../../reference/wallet-api-for-snaps.md):
 
-- [`wallet_getSnaps`](../../reference/wallet-json-rpc-api.md#wallet_getsnaps) - Gets the dapp's
+- [`wallet_getSnaps`](../../reference/wallet-api-for-snaps.md#wallet_getsnaps) - Gets the dapp's
   permitted Snaps.
-- [`wallet_requestSnaps`](../../reference/wallet-json-rpc-api.md#wallet_requestsnaps) - Requests
+- [`wallet_requestSnaps`](../../reference/wallet-api-for-snaps.md#wallet_requestsnaps) - Requests
   permission to communicate with the specified Snaps.
-- [`wallet_snap`](../../reference/wallet-json-rpc-api.md#wallet_snap) - (Restricted) Calls the
+- [`wallet_snap`](../../reference/wallet-api-for-snaps.md#wallet_snap) - (Restricted) Calls the
   specified custom JSON-RPC API method of the specified Snap.
-- [`wallet_invokeSnap`](../../reference/wallet-json-rpc-api.md#wallet_invokesnap) - (Restricted)
+- [`wallet_invokeSnap`](../../reference/wallet-api-for-snaps.md#wallet_invokesnap) - (Restricted)
   Synonymous with `wallet_snap`.
 
 A dapp must first [request permission](../../how-to/request-permissions.md#request-permissions-from-a-dapp)

--- a/snaps/learn/about-snaps/apis.md
+++ b/snaps/learn/about-snaps/apis.md
@@ -38,21 +38,24 @@ await snap.request({
 });
 ```
 
-## MetaMask JSON-RPC API
+## Wallet JSON-RPC API
 
 ### Dapp requests
 
 Dapps can install and communicate with Snaps using the following
-[MetaMask JSON-RPC API](/wallet/reference/json-rpc-api) methods:
+[Wallet JSON-RPC API](../../reference/wallet-json-rpc-api.md) methods:
 
-- [`wallet_getSnaps`](/wallet/reference/wallet_getsnaps) - Gets the dapp's permitted Snaps.
-- [`wallet_requestSnaps`](/wallet/reference/wallet_requestsnaps) - Requests permission to
-  communicate with the specified Snaps.
-- [`wallet_snap`](/wallet/reference/wallet_snap) - (Restricted) Calls the specified custom JSON-RPC
-  API method of the specified Snap.
-- [`wallet_invokeSnap`](/wallet/reference/wallet_invokesnap) - (Restricted) Synonymous with `wallet_snap`.
+- [`wallet_getSnaps`](../../reference/wallet-json-rpc-api.md#wallet_getsnaps) - Gets the dapp's
+  permitted Snaps.
+- [`wallet_requestSnaps`](../../reference/wallet-json-rpc-api.md#wallet_requestsnaps) - Requests
+  permission to communicate with the specified Snaps.
+- [`wallet_snap`](../../reference/wallet-json-rpc-api.md#wallet_snap) - (Restricted) Calls the
+  specified custom JSON-RPC API method of the specified Snap.
+- [`wallet_invokeSnap`](../../reference/wallet-json-rpc-api.md#wallet_invokesnap) - (Restricted)
+  Synonymous with `wallet_snap`.
 
-A dapp must first request permission to communicate with a Snap using `wallet_requestSnaps`.
+A dapp must first [request permission](../../how-to/request-permissions.md#request-permissions-from-a-dapp)
+to communicate with a Snap using `wallet_requestSnaps`.
 The dapp can then call `wallet_snap` or `wallet_invokeSnap` on the permitted Snap.
 For example, to call `wallet_snap`:
 
@@ -81,7 +84,7 @@ console.log(response); // "world!"
 
 ### Snap requests
 
-Snaps can also call some MetaMask JSON-RPC API methods using the `ethereum` global, which is an
+Snaps can also call some Wallet JSON-RPC API methods using the `ethereum` global, which is an
 [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) provider.
 
 To expose `ethereum` to the Snap execution environment, a Snap must first request the
@@ -103,7 +106,7 @@ await ethereum.request({ "method": "eth_requestAccounts" });
 
 The `ethereum` global available to Snaps has fewer capabilities than `window.ethereum` for dapps.
 Snaps can only use it to make read requests, not to write to the blockchain or initiate transactions.
-Snaps can call all MetaMask API methods **except** the following:
+Snaps can call all Wallet JSON-RPC API methods **except** the following:
 
 - [`wallet_requestSnaps`](/wallet/reference/wallet_requestSnaps)
 - [`wallet_requestPermissions`](/wallet/reference/wallet_requestPermissions)

--- a/snaps/reference/cli/_category_.json
+++ b/snaps/reference/cli/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Snaps command line",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "slug": "reference/cli"

--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -1,6 +1,6 @@
 ---
 description: See the Snaps entry points reference.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import Tabs from '@theme/Tabs';

--- a/snaps/reference/jest.md
+++ b/snaps/reference/jest.md
@@ -1,6 +1,6 @@
 ---
 description: See the Jest API and options reference.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Jest API and options

--- a/snaps/reference/keyring-api/index.md
+++ b/snaps/reference/keyring-api/index.md
@@ -1,6 +1,6 @@
 ---
 description: See the Keyring API reference.
-sidebar_position: 6
+sidebar_position: 7
 tags:
   - Keyring API
 ---

--- a/snaps/reference/known-errors.md
+++ b/snaps/reference/known-errors.md
@@ -1,6 +1,6 @@
 ---
 description: See the Snaps known errors reference
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Snaps known errors

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -1,6 +1,6 @@
 ---
 description: See the Snaps permissions reference.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 import Tabs from '@theme/Tabs';

--- a/snaps/reference/resources.md
+++ b/snaps/reference/resources.md
@@ -1,6 +1,6 @@
 ---
 description: See more Snaps resources.
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Resources

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -9,8 +9,13 @@ import TabItem from "@theme/TabItem";
 # Snaps API
 
 Snaps can communicate with and modify the functionality of MetaMask using the [Snaps API](../learn/about-snaps/apis.md#snaps-api).
-To call each method, you must first [request permission](../how-to/request-permissions.md) in the Snap
-manifest file.
+To call each method (except the [interactive UI methods](#interactive-ui-methods)), you must first
+[request permission](../how-to/request-permissions.md) in the Snap manifest file.
+
+:::note
+See the [Wallet JSON-RPC API](wallet-json-rpc-api.md) for methods that dapps can call to communicate
+with Snaps.
+:::
 
 ## `snap_dialog`
 

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -13,8 +13,8 @@ To call each method (except the [interactive UI methods](#interactive-ui-methods
 [request permission](../how-to/request-permissions.md) in the Snap manifest file.
 
 :::note
-See the [Wallet JSON-RPC API](wallet-json-rpc-api.md) for methods that dapps can call to communicate
-with Snaps.
+See the [Wallet API for Snaps](wallet-api-for-snaps.md) for methods that dapps can call to
+communicate with Snaps.
 :::
 
 ## `snap_dialog`

--- a/snaps/reference/wallet-api-for-snaps.md
+++ b/snaps/reference/wallet-api-for-snaps.md
@@ -1,5 +1,5 @@
 ---
-description: See the Wallet JSON-RPC API reference.
+description: See the Wallet API for Snaps reference.
 sidebar_position: 2
 toc_max_heading_level: 2
 ---
@@ -7,7 +7,7 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Wallet JSON-RPC API
+# Wallet API for Snaps
 
 Dapps can install and communicate with Snaps using a subset of the
 [Wallet JSON-RPC API](/wallet/concepts/wallet-api/#json-rpc-api).

--- a/snaps/reference/wallet-json-rpc-api.md
+++ b/snaps/reference/wallet-json-rpc-api.md
@@ -1,0 +1,240 @@
+---
+description: See the Wallet JSON-RPC API reference.
+sidebar_position: 2
+toc_max_heading_level: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Wallet JSON-RPC API
+
+Dapps can install and communicate with Snaps using a subset of the
+[Wallet JSON-RPC API](/wallet/concepts/wallet-api/#json-rpc-api).
+This page is a reference for those Snaps-specific methods.
+
+:::note
+See the [Wallet JSON-RPC API interactive reference](/wallet/reference/json-rpc-api) for the other
+methods dapps can call.
+:::
+
+## `wallet_getSnaps`
+
+Returns the IDs of the dapp's permitted Snaps and some relevant metadata.
+
+### Returns
+
+An object mapping the IDs of permitted Snaps to their metadata:
+
+- `id`: `string` - The ID of the Snap.
+- `initialPermissions`: `string` - The initial permissions of the Snap, which will be requested when
+  the Snap is installed.
+- `version`: `string` - The version of the Snap.
+- `enabled`: `boolean` - Indicates whether the Snap is enabled.
+- `blocked`: `boolean` - Indicates whether the Snap is blocked.
+
+### Example
+
+<Tabs>
+<TabItem value="Request">
+
+```js
+await window.ethereum.request({
+  "method": "wallet_getSnaps",
+  "params": []
+});
+```
+
+</TabItem>
+<TabItem value="Result">
+
+```json
+{
+  "npm:@metamask/example-snap": {
+    "version": "1.0.0",
+    "id": "npm:@metamask/example-snap",
+    "enabled": true,
+    "blocked": false
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## `wallet_requestSnaps`
+
+[Requests permission](../how-to/request-permissions.md#request-permissions-from-a-dapp) for a dapp
+to communicate with the specified Snaps and attempts to install them if they're not already installed.
+
+If the Snap version range is specified, MetaMask attempts to install a version of the Snap that
+satisfies the range.
+If a compatible version of the Snap is already installed, the request succeeds.
+If an incompatible version is installed, MetaMask attempts to update the Snap to the latest version
+that satisfies the range.
+The request succeeds if the Snap is successfully installed.
+
+If the installation of any Snap fails, this method returns the error that caused the failure.
+
+:::note
+A dapp must call this method on Snap before calling [`wallet_snap`](#wallet_snap) or
+[`wallet_invokeSnap`](#wallet_invokesnap) on the Snap.
+:::
+
+### Parameters
+
+An object mapping the IDs of the requested Snaps to optional SemVer version ranges.
+The SemVer version ranges use the same semantics as npm `package.json` ranges.
+
+### Returns
+
+An object mapping the IDs of permitted Snaps to their metadata:
+
+- `id`: `string` - The ID of the Snap.
+- `initialPermissions`: `string` - The initial permissions of the Snap, which will be request when
+  the Snap is installed.
+- `version`: `string` - The version of the Snap.
+- `enabled`: `boolean` - Indicates whether the Snap is enabled.
+- `blocked`: `boolean` - Indicates whether the Snap is blocked.
+
+### Example
+
+<Tabs>
+<TabItem value="Request">
+
+```js
+await window.ethereum.request({
+  "method": "wallet_requestSnaps",
+  "params": [
+    {
+      "npm:@metamask/example-snap": {},
+      "npm:fooSnap": {
+        "version": "^1.0.2"
+      }
+    }
+  ]
+});
+```
+
+</TabItem>
+<TabItem value="Result">
+
+```json
+{
+  "npm:@metamask/example-snap": {
+    "version": "1.0.0",
+    "id": "npm:@metamask/example-snap",
+    "enabled": true,
+    "blocked": false
+  },
+  "npm:fooSnap": {
+    "version": "1.0.5",
+    "id": "npm:fooSnap",
+    "enabled": true,
+    "blocked": false
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## `wallet_snap`
+
+Calls the specified JSON-RPC API method of the specified Snap.
+The Snap must be installed and the dapp must have permission to communicate with the Snap, or the
+request is rejected.
+The dapp can install the Snap and request permission to communicate with it using
+[`wallet_requestSnaps`](#wallet_requestsnaps).
+
+This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap).
+
+### Parameters
+
+An object containing:
+
+- `snapId`: `string` - The ID of the Snap to invoke.
+- `request`: `object` - The JSON-RPC request object to send to the invoked Snap.
+
+### Returns
+
+The result of the Snap method call.
+
+### Example
+
+<Tabs>
+<TabItem value="Request">
+
+```js
+await window.ethereum.request({
+  "method": "wallet_snap",
+  "params": [
+    {
+      "snapId": "npm:@metamask/example-snap",
+      "request": {
+        "method": "hello"
+      }
+    }
+  ]
+});
+```
+
+</TabItem>
+<TabItem value="Result">
+
+```json
+{}
+```
+
+</TabItem>
+</Tabs>
+
+## `wallet_invokeSnap`
+
+Calls the specified JSON-RPC API method of the specified Snap.
+The Snap must be installed and the dapp must have permission to communicate with the Snap, or the
+request is rejected.
+The dapp can install the Snap and request permission to communicate with it using
+[`wallet_requestSnaps`](#wallet_requestsnaps).
+
+This method is synonymous to [`wallet_snap`](#wallet_snap).
+
+### Parameters
+
+An object containing:
+
+- `snapId`: `string` - The ID of the Snap to invoke.
+- `request`: `object` - The JSON-RPC request object to send to the invoked Snap.
+
+### Returns
+
+The result of the Snap method call.
+
+### Example
+
+<Tabs>
+<TabItem value="Request">
+
+```js
+await window.ethereum.request({
+  "method": "wallet_invokeSnap",
+  "params": [
+    {
+      "snapId": "npm:@metamask/example-snap",
+      "request": {
+        "method": "hello"
+      }
+    }
+  ]
+});
+```
+
+</TabItem>
+<TabItem value="Result">
+
+```json
+{}
+```
+
+</TabItem>
+</Tabs>

--- a/wallet/concepts/wallet-api.md
+++ b/wallet/concepts/wallet-api.md
@@ -78,22 +78,25 @@ Restricted methods are methods that cannot be called unless you have permission 
 The following methods are restricted:
 
 - [`eth_accounts`](/wallet/reference/eth_accounts) - Gaining permission requires calling `wallet_requestPermissions`. 
-Granting permission for `eth_accounts` also grants permissions for the following methods:
+  Granting permission for `eth_accounts` also grants permissions for the following methods:
+
   - [`eth_sendTransaction`](/wallet/reference/eth_sendTransaction)
+
   - [`personal_sign`](/wallet/reference/personal_sign)
+
   - [`eth_signTypedData_v4`](/wallet/reference/eth_signTypedData_v4)
 
-:::caution important
-To access accounts, we recommend using [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts), which automatically asks for permission to use `eth_accounts` by calling `wallet_requestPermissions` internally.
-See [how to access a user's accounts](../how-to/connect/access-accounts.md) for more information.
-:::
+  :::caution important
+  To access accounts, we recommend using [`eth_requestAccounts`](/wallet/reference/eth_requestAccounts),
+  which automatically asks for permission to use `eth_accounts` by calling `wallet_requestPermissions` internally.
+  See [how to access a user's accounts](../how-to/connect/access-accounts.md) for more information.
+  :::
 
-- [`wallet_snap`](/wallet/reference/wallet_snap) - Gaining permission requires calling `wallet_requestSnap`.
-- [`wallet_invokeSnap`](/wallet/reference/wallet_invokeSnap) - Gaining permission requires calling `wallet_requestSnap`.
-  
-:::info note
-For more information on using `wallet_snap` and `wallet_invokeSnap`, see the [how to request Snap permissions from a dapp](/snaps/how-to/request-permissions/#request-permissions-from-a-dapp).
-:::
+- [`wallet_snap`](/snaps/reference/wallet-json-rpc-api/#wallet_snap) - Gaining permission requires
+  calling `wallet_requestSnap`.
+
+- [`wallet_invokeSnap`](/snaps/reference/wallet-json-rpc-api/#wallet_invokesnap) - Gaining
+  permission requires calling `wallet_requestSnap`.
 
 ### Unrestricted methods
 

--- a/wallet/concepts/wallet-api.md
+++ b/wallet/concepts/wallet-api.md
@@ -73,7 +73,9 @@ This requires that dapps obtain user consent before accessing certain features.
 Under the hood, permissions are plain, JSON-compatible objects, with fields that are mostly used
 internally by MetaMask.
 
-Restricted methods are methods that cannot be called unless you have permission to do so using [`wallet_requestPermissions`](/wallet/reference/wallet_requestpermissions) or [`wallet_requestSnaps`](/wallet/reference/wallet_requestSnaps).
+Restricted methods are methods that cannot be called unless you have permission to do so using
+[`wallet_requestPermissions`](/wallet/reference/wallet_requestpermissions) or
+[`wallet_requestSnaps`](/snaps/reference/wallet-api-for-snaps/#wallet_requestsnaps).
 
 The following methods are restricted:
 
@@ -92,10 +94,10 @@ The following methods are restricted:
   See [how to access a user's accounts](../how-to/connect/access-accounts.md) for more information.
   :::
 
-- [`wallet_snap`](/snaps/reference/wallet-json-rpc-api/#wallet_snap) - Gaining permission requires
+- [`wallet_snap`](/snaps/reference/wallet-api-for-snaps/#wallet_snap) - Gaining permission requires
   calling `wallet_requestSnap`.
 
-- [`wallet_invokeSnap`](/snaps/reference/wallet-json-rpc-api/#wallet_invokesnap) - Gaining
+- [`wallet_invokeSnap`](/snaps/reference/wallet-api-for-snaps/#wallet_invokesnap) - Gaining
   permission requires calling `wallet_requestSnap`.
 
 ### Unrestricted methods


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Move `wallet_snap`, `wallet_invokeSnap`, `wallet_getSnaps`, and `wallet_requestSnap` docs to a new reference page in the Snaps docs, "Wallet API for Snaps." Update context and links accordingly.

Also see https://github.com/MetaMask/api-specs/pull/218, which removes these methods from the interactive reference.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #1283

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://docs.metamask.io/1283-move-snaps-methods/snaps/reference/wallet-api-for-snaps/

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
