### PR TITLE
Remove Flask-only admonition for interactive UI

### DIFF
--- a/snaps/features/custom-ui/index.md
+++ b/snaps/features/custom-ui/index.md
@@ -77,9 +77,6 @@ await snap.request({
 
 ### `button`
 
-:::flaskOnly
-:::
-
 Outputs a button that the user can select.
 For use in [interactive UI](interactive-ui.md).
 
@@ -178,9 +175,6 @@ module.exports.onHomePage = async () => {
 </p>
 
 ### `form`
-
-:::flaskOnly
-:::
 
 Outputs a form for use in [interactive UI](interactive-ui.md).
 
@@ -295,9 +289,6 @@ module.exports.onHomePage = async () => {
 </p>
 
 ### `input`
-
-:::flaskOnly
-:::
 
 Outputs an input component for use in [interactive UI](interactive-ui.md).
 

--- a/snaps/features/custom-ui/interactive-ui.md
+++ b/snaps/features/custom-ui/interactive-ui.md
@@ -1,14 +1,9 @@
 ---
 description: Display and update interactive user interfaces.
 sidebar_position: 1
-sidebar_custom_props:
-  flask_only: true
 ---
 
 # Interactive UI
-
-:::flaskOnly
-:::
 
 You can display interactive user interface (UI) components.
 Interactive UI is an extension of [custom UI](index.md).

--- a/snaps/index.mdx
+++ b/snaps/index.mdx
@@ -67,6 +67,12 @@ The following Snaps features are available in the stable version of MetaMask:
       description: "Display custom UI in MetaMask using a set of pre-defined components."
     },
     {
+      icon: require("./assets/features/custom-ui.png").default,
+      href: "features/custom-ui/interactive-ui",
+      title: "Interactive UI",
+      description: "Display interactive UI in MetaMask that can be updated dynamically."
+    },
+    {
       icon: require("./assets/features/network.png").default,
       href: "reference/permissions#endowmentnetwork-access",
       title: "Network access",
@@ -115,13 +121,6 @@ the canary distribution of MetaMask:
       href: "reference/entry-points/#transaction-severity-level",
       title: "Transaction severity",
       description: "Add extra friction to the transaction flow if a transaction looks risky.",
-      flaskOnly: true
-    },
-    {
-      icon: require("./assets/features/custom-ui.png").default,
-      href: "features/custom-ui/interactive-ui",
-      title: "Interactive UI",
-      description: "Display interactive UI in MetaMask using a set of pre-defined components.",
       flaskOnly: true
     },
     {

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -873,9 +873,6 @@ These methods do not require requesting permission in the Snap manifest file.
 
 ### `snap_createInterface`
 
-:::flaskOnly
-:::
-
 Creates an interactive interface for use in [interactive UI](../features/custom-ui/interactive-ui.md).
 
 #### Parameters
@@ -915,9 +912,6 @@ await snap.request({
 ```
 
 ### `snap_getInterfaceState`
-
-:::flaskOnly
-:::
 
 Gets the state of an interactive interface by its ID.
 For use in [interactive UI](../features/custom-ui/interactive-ui.md).
@@ -982,9 +976,6 @@ console.log(state);
 ```
 
 ### `snap_updateInterface`
-
-:::flaskOnly
-:::
 
 Updates an interactive interface.
 For use in [interactive UI](../features/custom-ui/interactive-ui.md).


### PR DESCRIPTION
# Description

This feature is already in stable and the admonition can be removed.

## Issue(s) fixed

n/a

## Preview

n/a

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
