### PR TITLE
fix the MetaMask - RPC Error: Invalid JSON-RPC request in the tutorials "Create a Snap to estimate gas fees"

### DIFF
--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -150,7 +150,7 @@ Open `packages/snap/src/index.ts`.
 This is the main code file for your Snap.
 To get a gas fee estimate, use the public API endpoint provided by
 [Open Source Ethereum Explorer](https://beaconcha.in/).
-Add the following `getFees()` function to the beginning of the `/packages/snap/src/index.ts` file:
+If it not already present, add the following `getFees()` function to the beginning of the `/packages/snap/src/index.ts` file:
 
 ```typescript title="index.ts"
 import type { OnRpcRequestHandler } from "@metamask/snaps-sdk";
@@ -235,22 +235,29 @@ To build and test your Snap:
 
 You have integrated a public API into MetaMask and displayed real-time gas fee estimates.
 
-7. If you click the **Send message** button, but got a error like this.
+## Troubleshoot
+
+If you click the **Send message** button and receive an error message similar to the following, update `packages/site/src/pages/index.tsx`:
+
 <p align="center">
 <img src="https://github.com/MetaMask/metamask-docs/assets/5465932/a22481a0-30d5-4efd-8cc5-c42db70f7eb1" alt="An error happened" width="400px" style={{border: '1px solid #DCDCDC'}} />
 </p>
 
-You need to replace line 114 in `packages/site/src/pages/index.tsx` with this:
+Replace `await invokeSnap({ method: 'hello' })` on line 114 of `packages/site/src/pages/index.tsx` with the following code:
 ```typescript title="index.tsx"
   await invokeSnap({ method: 'hello', params: {} });
 ```
+This ensures the `invokeSnap` function calls an additional `params` property.
 
-### 6. Next steps
+The **Send message** button on the page should now be enabled.
 
-Next, you can try:
+## Next steps
+
+This tutorial walked you through creating a Snap to estimate gas fees using the `fetch` API and display results in an alert.
+Next, you can try the following:
 
 - Parsing the JSON response from the remote API.
-- Displaying the fees in a nicely formatted way.
+- Displaying the fees in a clear and well-structured format.
 
 You can also update the fields in `snap.manifest.json` to match your custom Snap:
 

--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -235,6 +235,16 @@ To build and test your Snap:
 
 You have integrated a public API into MetaMask and displayed real-time gas fee estimates.
 
+7. If you click the **Send message** button, but got a error like this.
+<p align="center">
+<img src="https://github.com/MetaMask/metamask-docs/assets/5465932/a22481a0-30d5-4efd-8cc5-c42db70f7eb1" alt="An error happened" width="400px" style={{border: '1px solid #DCDCDC'}} />
+</p>
+
+You need to replace line 114 in `packages/site/src/pages/index.tsx` with this:
+```typescript title="index.tsx"
+  await invokeSnap({ method: 'hello', params: {} });
+```
+
 ### 6. Next steps
 
 Next, you can try:


### PR DESCRIPTION
To fix the error when click the "Send message" button.
![image](https://github.com/MetaMask/metamask-docs/assets/5465932/a7703d5a-58a6-4e15-87cf-f92fad34b2d5)
