### PR TITLE
feat(reference): act-1398 - added request submit

### DIFF
--- a/src/components/ParserOpenRPC/DetailsBox/index.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/index.tsx
@@ -31,7 +31,10 @@ export default function DetailsBox({ method, description, params, components, re
       )}
       <Heading as="h1">{method}</Heading>
       <MDContent content={description} />
-      <Heading as="h2" className={clsx(styles.secondaryHeading, "padding-vert--md")}>
+      <Heading
+        as="h2"
+        className={clsx(styles.secondaryHeading, "padding-top--lg padding-bottom--md")}
+      >
         Parameters
       </Heading>
       {params.length === 0 ? (
@@ -41,7 +44,10 @@ export default function DetailsBox({ method, description, params, components, re
           {params && renderParamSchemas(params, components)}
         </>
       )}
-      <Heading as="h2" className={clsx(styles.secondaryHeading, styles.borderBottomLine, "padding-vert--md")}>
+      <Heading
+        as="h2"
+        className={clsx(styles.secondaryHeading, styles.borderBottomLine, "padding-top--lg padding-vert--md")}
+      >
         Returns
       </Heading>
       {result?.description && (

--- a/src/components/ParserOpenRPC/RequestBox/index.tsx
+++ b/src/components/ParserOpenRPC/RequestBox/index.tsx
@@ -12,20 +12,17 @@ interface RequestBoxProps {
   params: MethodParam[];
   response?: any;
   openModal: () => void;
+  submitRequest: () => void;
 }
 
-export default function RequestBox({ isMetamaskInstalled, method, params, response, openModal }: RequestBoxProps) {
+export default function RequestBox({ isMetamaskInstalled, method, params, response, openModal, submitRequest }: RequestBoxProps) {
   const exampleRequest = useMemo(() => {
     return `await window.ethereum.request({\n "method": "${method}",\n "params": [${params}],\n});`;
   }, [method, params]);
 
   const exampleResponse = useMemo(() => {
-    const ex = {
-      "jsonrpc": "2.0",
-      "id": 1,
-      "result": `${response}`,
-    };
-    return JSON.stringify(ex, null, 2);
+    if (!response || response === null) return false
+    return JSON.stringify(response, null, 2);
   }, [response]);
 
   return (
@@ -40,28 +37,36 @@ export default function RequestBox({ isMetamaskInstalled, method, params, respon
           </CodeBlock>
         </div>
         <div className={styles.cardFooter}>
+          {params.length > 0 && (
+            <button
+              className={clsx(global.linkBtn, "margin-right--md")}
+              disabled={!isMetamaskInstalled}
+              onClick={openModal}
+            >
+              Customize request
+            </button>
+          )}
           <button
-            className={clsx(global.linkBtn, "margin-right--md")}
+            className={global.primaryBtn}
             disabled={!isMetamaskInstalled}
-            onClick={openModal}
+            onClick={submitRequest}
           >
-            Customize request
-          </button>
-          <button className={global.primaryBtn} disabled={!isMetamaskInstalled}>
             Run request
           </button>
         </div>
       </div>
-      <div className={styles.cardWrapper}>
-        <div className={styles.cardHeader}>
-          <strong className={styles.cardHeading}>Response</strong>
+      {response !== null && (
+        <div className={styles.cardWrapper}>
+          <div className={styles.cardHeader}>
+            <strong className={styles.cardHeading}>Response</strong>
+          </div>
+          <div>
+            <CodeBlock language="javascript" className="margin-bottom--none">
+              {exampleResponse}
+            </CodeBlock>
+          </div>
         </div>
-        <div>
-          <CodeBlock language="javascript" className="margin-bottom--none">
-            {exampleResponse}
-          </CodeBlock>
-        </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/components/ParserOpenRPC/index.tsx
+++ b/src/components/ParserOpenRPC/index.tsx
@@ -18,6 +18,7 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
   if (!method || !network) return null;
   const [metamaskInstalled, setMetamaskInstalled] = useState(false);
   const [isModalOpen, setModalOpen] = useState(false);
+  const [reqResult, setReqResult] = useState(null)
   const openModal = () => setModalOpen(true);
   const closeModal = () => setModalOpen(false);
 
@@ -61,6 +62,18 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
     setMetamaskInstalled(installed);
   }, []);
 
+  const onSubmitRequestHandle = async () => {
+    try {
+      const response = await (window as any).ethereum.request({
+        method: method,
+        params: []
+      })
+      setReqResult(response);
+    } catch (e) {
+      setReqResult(e);
+    };
+  };
+
   return (
     <div className={global.rowWrap}>
       <div className={global.colLeft}>
@@ -92,8 +105,9 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
             isMetamaskInstalled={metamaskInstalled}
             method={method}
             params={[]}
-            response={"0x"}
+            response={reqResult}
             openModal={openModal}
+            submitRequest={onSubmitRequestHandle}
           />
         </div>
       </div>

--- a/wallet/reference/new-reference.mdx
+++ b/wallet/reference/new-reference.mdx
@@ -8,4 +8,4 @@ sidebar_class_name: "hidden"
 import ParserOpenRPC from "@site/src/components/ParserOpenRPC";
 import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc";
 
-<ParserOpenRPC network={NETWORK_NAMES.metamask} method="eth_call" />
+<ParserOpenRPC network={NETWORK_NAMES.metamask} method="eth_blockNumber" />


### PR DESCRIPTION
## Description

- Added the ability to send method requests (**without params**) and display responses in a code block.

## How to test:

1) Go to the test page for the `eth_blockNumber` method - /wallet/reference/new-reference/
2) Сlick on the "run request" button and check the appearance of the "response" section

**NOTE:** _if you **do not have** the metamask extension installed in your browser, the button will be disabled and at the top there will be a message about the need for installation => install it and test steps 1 and 2_

![Screenshot 2024-06-18 at 14 47 00](https://github.com/MetaMask/metamask-docs/assets/98453427/685e285e-7eb3-4830-a303-5c33a8e5d838)
<img width="1546" alt="Screenshot 2024-06-18 at 14 58 01" src="https://github.com/MetaMask/metamask-docs/assets/98453427/516068fd-5d8b-41bd-875e-cd9a12bd9afe">

## Links:

[JIRA Issue](https://infura.atlassian.net/browse/ACT-1398)
