### PR TITLE
fix: replace yarn cmd with npx

### DIFF
--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -25,13 +25,13 @@ Create a new Snap project using the
 starter kit by running:
 
 ```bash
-yarn create @metamask/snap gas-estimation-snap
+npx @metamask/create-snap gas-estimation-snap
 ```
 
 or
 
 ```bash
-npx @metamask/create-snap gas-estimation-snap
+yarn create @metamask/snap gas-estimation-snap
 ```
 
 or

--- a/snaps/learn/tutorials/gas-estimation.md
+++ b/snaps/learn/tutorials/gas-estimation.md
@@ -31,13 +31,13 @@ npx @metamask/create-snap gas-estimation-snap
 or
 
 ```bash
-yarn create @metamask/snap gas-estimation-snap
+npm create @metamask/snap gas-estimation-snap
 ```
 
 or
 
 ```bash
-npm create @metamask/snap gas-estimation-snap
+yarn create @metamask/snap gas-estimation-snap
 ```
 
 Next, `cd` into the `gas-estimation-snap` project directory and run:


### PR DESCRIPTION
# Description

I have replaced the `yarn` command with `npx` as described in the issue.

## Issue(s) fixed

Issue # 1367

Fixes # 1367

## Preview

 https://docs.metamask.io/snaps/learn/tutorials/gas-estimation/ is the page where these changes will reflect.

## Checklist

Complete this checklist before merging your PR:

- [No ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [Required to be reviewed by member ] The proposed changes have been reviewed and approved by a member of the documentation team.
