### PR TITLE
Fix Snaps parameters in dapp API section

### DIFF
--- a/snaps/reference/wallet-api-for-snaps.md
+++ b/snaps/reference/wallet-api-for-snaps.md
@@ -105,14 +105,12 @@ An object mapping the IDs of permitted Snaps to their metadata:
 ```js
 await window.ethereum.request({
   "method": "wallet_requestSnaps",
-  "params": [
-    {
-      "npm:@metamask/example-snap": {},
-      "npm:fooSnap": {
-        "version": "^1.0.2"
-      }
+  "params": {
+    "npm:@metamask/example-snap": {},
+    "npm:foo-snap": {
+      "version": "^1.0.2"
     }
-  ]
+  }
 });
 ```
 
@@ -129,7 +127,7 @@ await window.ethereum.request({
   },
   "npm:fooSnap": {
     "version": "1.0.5",
-    "id": "npm:fooSnap",
+    "id": "npm:foo-snap",
     "enabled": true,
     "blocked": false
   }
@@ -168,14 +166,12 @@ The result of the Snap method call.
 ```js
 await window.ethereum.request({
   "method": "wallet_snap",
-  "params": [
-    {
-      "snapId": "npm:@metamask/example-snap",
-      "request": {
-        "method": "hello"
-      }
+  "params": {
+    "snapId": "npm:@metamask/example-snap",
+    "request": {
+      "method": "hello"
     }
-  ]
+  }
 });
 ```
 
@@ -218,14 +214,12 @@ The result of the Snap method call.
 ```js
 await window.ethereum.request({
   "method": "wallet_invokeSnap",
-  "params": [
-    {
-      "snapId": "npm:@metamask/example-snap",
-      "request": {
-        "method": "hello"
-      }
+  "params": {
+    "snapId": "npm:@metamask/example-snap",
+    "request": {
+      "method": "hello"
     }
-  ]
+  }
 });
 ```
 


### PR DESCRIPTION
# Description

Fixes the parameters in the examples section of "Wallet API for Snaps". The documentation explaining the format was correct, but the code example was not.

`wallet_requestSnaps`, `wallet_snap` & `wallet_invokeSnap` all take object parameters only.
