### PR TITLE
feat(reference): act-1327 - added support eip-6963

### DIFF
--- a/src/components/ParserOpenRPC/AuthBox/index.tsx
+++ b/src/components/ParserOpenRPC/AuthBox/index.tsx
@@ -23,7 +23,7 @@ export const AuthBox = ({ metamaskProviders = [], selectedProvider, handleConnec
     return <MetamaskInstallMessage />
   }
 
-  if (metamaskProviders.length === 1) {
+  if (metamaskProviders.length > 0) {
     return null
   }
 

--- a/src/components/ParserOpenRPC/AuthBox/index.tsx
+++ b/src/components/ParserOpenRPC/AuthBox/index.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";
 import global from "../global.module.css";
+import { EIP6963ProviderDetail } from "@site/src/hooks/store.ts"
 
 interface AuthBoxProps {
-  isMetamaskInstalled: boolean;
+  metamaskProviders: any;
+  handleConnect: (i) => void;
+  selectedProvider?: number;
 }
 
 const MetamaskInstallMessage = () => (
@@ -15,10 +18,33 @@ const MetamaskInstallMessage = () => (
   </div>
 );
 
-export const AuthBox = ({ isMetamaskInstalled }: AuthBoxProps) => {
+export const AuthBox = ({ metamaskProviders = [], selectedProvider, handleConnect }: AuthBoxProps) => {
+  if (metamaskProviders.length === 0) {
+    return <MetamaskInstallMessage />
+  }
+
+  if (metamaskProviders.length === 1) {
+    return null
+  }
+
   return (
-    <>
-      {!isMetamaskInstalled ? <MetamaskInstallMessage /> : null}
-    </>
+    <div className={styles.msgWrapper}>
+      <p>Select a MetaMask provider to use interactive features:</p>
+      <div className={styles.mmBtnRow}>
+        {metamaskProviders.map((provider: EIP6963ProviderDetail, i) => (
+          <div key={provider.info.uuid} className={styles.mmBtnCol}>
+            <button className={styles.mmBtn} onClick={() => handleConnect(i)}>
+              <img
+                src={provider.info.icon}
+                alt={provider.info.name}
+                width="30"
+              />
+              <div className="padding-left--md">{provider.info.name}</div>
+              {selectedProvider === i && <span className={styles.mmBtnCheck}>&#10003;</span>}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/src/components/ParserOpenRPC/AuthBox/styles.module.css
+++ b/src/components/ParserOpenRPC/AuthBox/styles.module.css
@@ -17,3 +17,37 @@
   font-size: 14px;
   line-height: 22px;
 }
+
+.mmBtnRow {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.mmBtnCol {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.mmBtn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 16px 30px 16px 20px;
+  width: 100%;
+  background: none;
+  border-radius: 10px;
+  outline: none;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+  border: 1px solid rgba(3, 118, 201, 1);
+  color: rgba(3, 118, 201, 1);
+}
+
+.mmBtnCheck {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 15px;
+  font-size: 16px;
+}

--- a/src/components/ParserOpenRPC/index.tsx
+++ b/src/components/ParserOpenRPC/index.tsx
@@ -90,7 +90,6 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
 
   const location = useLocation();
 
-  // const [metamaskProviders, setMetamaskProviders] = useState([]);
   const [selectedWallet, setSelectedWallet] = useState(0);
   const providers = useSyncProviders();
 
@@ -107,7 +106,12 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
   }, []);
 
   const metamaskProviders = useMemo(() => {
-    return providers.filter(pr => pr?.info?.name?.includes("MetaMask"));
+    const isMetamasks = providers.filter(pr => pr?.info?.name?.includes("MetaMask"));
+    if (isMetamasks.length > 1) {
+      const indexWallet = isMetamasks.findIndex(item => item.info.name === "MetaMask");
+      setSelectedWallet(indexWallet);
+    }
+    return isMetamasks;
   }, [providers]);
 
   const onParamsChangeHandle = (data) => {

--- a/src/hooks/store.ts
+++ b/src/hooks/store.ts
@@ -1,0 +1,49 @@
+declare global{
+  interface WindowEventMap {
+    "eip6963:announceProvider": CustomEvent
+  }
+}
+
+export interface EIP6963ProviderInfo {
+  walletId: string;
+  uuid: string;
+  name: string;
+  icon: string;
+}
+
+export interface EIP1193Provider {
+  isStatus?: boolean;
+  host?: string;
+  path?: string;
+  sendAsync?: (request: { method: string, params?: Array<unknown> }, callback: (error: Error | null, response: unknown) => void) => void;
+  send?: (request: { method: string, params?: Array<unknown> }, callback: (error: Error | null, response: unknown) => void) => void;
+  request: (request: { method: string, params?: Array<unknown> }) => Promise<unknown>;
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+
+type EIP6963AnnounceProviderEvent = {
+  detail: {
+    info: EIP6963ProviderInfo;
+    provider: EIP1193Provider;
+  }
+}
+
+let providers: EIP6963ProviderDetail[] = []
+export const store = {
+  value: ()=> providers,
+  subscribe: (callback: ()=> void) => {
+    function onAnnouncement(event: EIP6963AnnounceProviderEvent){
+      if(providers.map(p => p.info.uuid).includes(event.detail.info.uuid)) return
+      providers = [...providers, event.detail]
+      callback()
+    }
+    window.addEventListener("eip6963:announceProvider", onAnnouncement);
+    window.dispatchEvent(new Event("eip6963:requestProvider"));
+
+    return () => window.removeEventListener("eip6963:announceProvider", onAnnouncement)
+  }
+}

--- a/src/hooks/useSyncProviders.ts
+++ b/src/hooks/useSyncProviders.ts
@@ -1,0 +1,4 @@
+import { useSyncExternalStore } from "react";
+import { store } from "./store";
+
+export const useSyncProviders = ()=> useSyncExternalStore(store.subscribe, store.value, store.value)

--- a/wallet/reference/new-reference.mdx
+++ b/wallet/reference/new-reference.mdx
@@ -8,4 +8,4 @@ sidebar_class_name: "hidden"
 import ParserOpenRPC from "@site/src/components/ParserOpenRPC";
 import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc";
 
-<ParserOpenRPC network={NETWORK_NAMES.metamask} method="eth_call" />
+<ParserOpenRPC network={NETWORK_NAMES.metamask} method="eth_requestAccounts" />


### PR DESCRIPTION
## Description:

- Added support **EIP-6963** ( detect if the user has both `MetaMask` and `MetaMask Flask` installed on their browser and if this is the case propose them to pick the wallet to choose to interact with the MetaMask Docs )

##  How to test:

- Go to the test page - **/wallet/reference/new-reference**
- Test what you can choose from two providers (install them first)
![Screenshot 2024-07-05 at 17 28 10](https://github.com/MetaMask/metamask-docs/assets/98453427/264d7615-81b9-4f89-86da-c90cb1a55673)

## Links:

[JIRA Issue](https://infura.atlassian.net/browse/ACT-1327)