### PR TITLE
redirect URLs with trailing slash

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "cleanUrls": true,
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/guide",


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Redirect URLs with trailing slash to path without trailing slash: https://vercel.com/docs/projects/project-configuration#trailingslash

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

In the current docs, only the first URL redirects to the correct page:

- https://docs.metamask.io/wallet/reference/rpc-api
- https://docs.metamask.io/wallet/reference/rpc-api/

With this PR, both URLs should redirect properly (same with all other redirects):

- https://metamask-docs-mwme8la04-metamask-web.vercel.app/wallet/reference/rpc-api
- https://metamask-docs-mwme8la04-metamask-web.vercel.app/wallet/reference/rpc-api/

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
