### PR TITLE
Add Celo WebSocket support.

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,6 +11,7 @@ of the [MetaMask developer page](https://metamask.io/developer/).
 
 ## July 2024
 
+- Documented [Celo WebSocket support](/services/reference/celo/). ([#1446](https://github.com/MetaMask/metamask-docs/pull/1446))
 - Documented [ZKsync Era WebSocket support](/services/reference/zksync). ([#1438](https://github.com/MetaMask/metamask-docs/pull/1438))
 - Documented support for the [ZKsync Era network API service](/services/reference/zksync). ([#1372](https://github.com/MetaMask/metamask-docs/pull/1372))
 - Added [Services](/services) and [Developer tools](/developer-tools) to MetaMask documentation. ([#1325](https://github.com/MetaMask/metamask-docs/pull/1325))

--- a/services/concepts/websockets.md
+++ b/services/concepts/websockets.md
@@ -47,6 +47,7 @@ Infura support subscriptions over WebSockets for the following networks:
 - [Ethereum](../reference/ethereum/index.md)
 - [Arbitrum](../reference/arbitrum/index.md)
 - [Avalanche (C-Chain)](../reference/avalanche-c-chain/index.md)
+- [Celo](../reference/celo/index.md)
 - [Linea](../reference/linea/index.md)
 - [Optimism](../reference/optimism/index.md)
 - [Polygon](../reference/polygon-pos/index.md)

--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -64,13 +64,13 @@ The Holesky testnet is supported through the
 service and does not currently support WebSockets.
 :::
 
-| Network | Description             | URL                                       |
-| ------- | ----------------------- | ----------------------------------------- |
-| Mainnet | JSON-RPC over HTTPS     | `https://mainnet.infura.io/v3/<API-KEY>`  |
-| Mainnet | JSON-RPC over WebSocket | `wss://mainnet.infura.io/ws/v3/<API-KEY>` |
-| Holesky | JSON-RPC over HTTPS     | `https://holesky.infura.io/v3/<API-KEY>`  |
-| Sepolia | JSON-RPC over HTTPS     | `https://sepolia.infura.io/v3/<API-KEY>`  |
-| Sepolia | JSON-RPC over WebSocket | `wss://sepolia.infura.io/ws/v3/<API-KEY>` |
+| Network           | Description             | URL                                       |
+| ----------------- | ----------------------- | ----------------------------------------- |
+| Mainnet           | JSON-RPC over HTTPS     | `https://mainnet.infura.io/v3/<API-KEY>`  |
+| Mainnet           | JSON-RPC over WebSocket | `wss://mainnet.infura.io/ws/v3/<API-KEY>` |
+| Testnet (Holesky) | JSON-RPC over HTTPS     | `https://holesky.infura.io/v3/<API-KEY>`  |
+| Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://sepolia.infura.io/v3/<API-KEY>`  |
+| Testnet (Sepolia) | JSON-RPC over WebSocket | `wss://sepolia.infura.io/ws/v3/<API-KEY>` |
 
 ## IPFS
 
@@ -98,13 +98,13 @@ Linea Goerli is being deprecated. We discourage new development with this testne
 Sepolia instead.
 
 :::
-| Network | Description | URL |
+| Network           | Description             | URL                                             |
 |-------------------|-------------------------|-------------------------------------------------|
-| Mainnet | JSON-RPC over HTTPS | `https://linea-mainnet.infura.io/v3/<API-KEY>` |
-| Mainnet | JSON-RPC over WebSocket | `wss://linea-mainnet.infura.io/ws/v3/<API-KEY>` |
-| Testnet (Goerli) | JSON-RPC over HTTPS | `https://linea-goerli.infura.io/v3/<API-KEY>` |
-| Testnet (Goerli) | JSON-RPC over WebSocket | `wss://linea-goerli.infura.io/ws/v3//<API-KEY>` |
-| Testnet (Sepolia) | JSON-RPC over HTTPS | `https://linea-sepolia.infura.io/v3/<API-KEY>` |
+| Mainnet           | JSON-RPC over HTTPS     | `https://linea-mainnet.infura.io/v3/<API-KEY>`  |
+| Mainnet           | JSON-RPC over WebSocket | `wss://linea-mainnet.infura.io/ws/v3/<API-KEY>` |
+| Testnet (Goerli)  | JSON-RPC over HTTPS     | `https://linea-goerli.infura.io/v3/<API-KEY>`   |
+| Testnet (Goerli)  | JSON-RPC over WebSocket | `wss://linea-goerli.infura.io/ws/v3//<API-KEY>` |
+| Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://linea-sepolia.infura.io/v3/<API-KEY>`  |
 | Testnet (Sepolia) | JSON-RPC over WebSocket | `wss://linea-sepolia.infura.io/ws/v3/<API-KEY>` |
 
 ## Mantle

--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -49,10 +49,12 @@ request to `support@infura.io` and we will assess if your request can be accommo
 
 ## Celo
 
-| Network             | Description         | URL                                             |
-| ------------------- | ------------------- | ----------------------------------------------- |
-| Mainnet             | JSON-RPC over HTTPS | `https://celo-mainnet.infura.io/v3/<API-KEY>`   |
-| Testnet (Alfajores) | JSON-RPC over HTTPS | `https://celo-alfajores.infura.io/v3/<API-KEY>` |
+| Network             | Description             | URL                                              |
+|---------------------|-------------------------|--------------------------------------------------|
+| Mainnet             | JSON-RPC over HTTPS     | `https://celo-mainnet.infura.io/v3/<API-KEY>`    |
+| Mainnet             | JSON-RPC over WebSocket | `wss://celo-mainnet.infura.io/ws/v3/<API-KEY>`   |
+| Testnet (Alfajores) | JSON-RPC over HTTPS     | `https://celo-alfajores.infura.io/v3/<API-KEY>`  |
+| Testnet (Alfajores) | JSON-RPC over WebSocket | `wss://celo-alfajores.infura.io/ws/v3/<API-KEY>` |
 
 ## Ethereum
 

--- a/services/reference/celo/json-rpc-methods/_eth_accounts-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_accounts-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_accounts", "params": [], "id": 1}'
+```
+
+  </TabItem>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_accounts", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_blocknumber-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_blocknumber-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}'
+```
+
+  </TabItem>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_call-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_call-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155", "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "gas": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x9184e72a", "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}, "latest"], "id": 1}'
+```
+
+  </TabItem>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_call", "params": [{"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155", "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "gas": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x9184e72a", "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}, "latest"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_chainid-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_chainid-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}'
+```
+
+  </TabItem>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_estimategas-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_estimategas-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"from": "0x9cE564c7d09f88E7d8233Cdd3A4d7AC42aBFf3aC", "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "value": "0x9184e72a"}], "id": 1}'
+```
+
+  </TabItem>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"from": "0x9cE564c7d09f88E7d8233Cdd3A4d7AC42aBFf3aC", "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "value": "0x9184e72a"}], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gasprice-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gasprice-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getbalance-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getbalance-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "latest"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "latest"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getblockbyhash-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getblockbyhash-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBlockByHash", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35", false], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBlockByHash", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35", false], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getblockbynumber-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getblockbynumber-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["0x5BAD55", false], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["0x5BAD55", false], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getblockreceipts-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getblockreceipts-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem";
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBlockReceipts", "params": ["latest"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBlockReceipts", "params": ["latest"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getblocktransactioncountbyhash-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getblocktransactioncountbyhash-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBlockTransactionCountByHash", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBlockTransactionCountByHash", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getblocktransactioncountbynumber-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getblocktransactioncountbynumber-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getBlockTransactionCountByNumber", "params": ["latest"], "id":1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getBlockTransactionCountByNumber", "params": ["latest"], "id":1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getcode-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getcode-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getCode", "params": ["0x06012c8cf97bead5deae237070f9587f8e7a266d", "0x65a8db"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getCode", "params": ["0x06012c8cf97bead5deae237070f9587f8e7a266d", "0x65a8db"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getlogs-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getlogs-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getLogs", "params": [{"blockHash": "0x7c5a35e9cb3e8ae0e221ab470abae9d446c3a5626ce6689fc777dcffcab52c70", "topics": ["0x241ea03ca20251805084d27d4440371c34a0b85ff108f6bb5611248f73818b80"]}], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getLogs", "params": [{"blockHash": "0x7c5a35e9cb3e8ae0e221ab470abae9d446c3a5626ce6689fc777dcffcab52c70", "topics": ["0x241ea03ca20251805084d27d4440371c34a0b85ff108f6bb5611248f73818b80"]}], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getproof-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getproof-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getProof", "id": 1, "params": ["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842", ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"], "latest"]}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getProof", "id": 1, "params": ["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842", ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"], "latest"]}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_getstorageat-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_getstorageat-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9", "0x65a8db"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9", "0x65a8db"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gettransactionbyblockhashandindex-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gettransactionbyblockhashandindex-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getTransactionByBlockHashAndIndex", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35", "0x0"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getTransactionByBlockHashAndIndex", "params": ["0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35", "0x0"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gettransactionbyblocknumberandindex-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gettransactionbyblocknumberandindex-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getTransactionByBlockNumberAndIndex", "params": ["0x5BAD55", "0x0"], "id":1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getTransactionByBlockNumberAndIndex", "params": ["0x5BAD55", "0x0"], "id":1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gettransactionbyhash-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gettransactionbyhash-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getTransactionByHash", "params": ["0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getTransactionByHash", "params": ["0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gettransactioncount-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gettransactioncount-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getTransactionCount", "params": ["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "0x5bad55"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getTransactionCount", "params": ["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "0x5bad55"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_gettransactionreceipt-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_gettransactionreceipt-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_sendrawtransaction-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_sendrawtransaction-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_sendRawTransaction", "params": ["0xf869018203e882520894f17f52151ebef6c7334fad080c5704d77216b732881bc16d674ec80000801ba02da1c48b670996dcb1f447ef9ef00b33033c48a4fe938f420bec3e56bfd24071a062e0aa78a81bf0290afbc3a9d8e9a068e6d74caa66c5e0fa8a46deaae96b0833"], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_sendRawTransaction", "params": ["0xf869018203e882520894f17f52151ebef6c7334fad080c5704d77216b732881bc16d674ec80000801ba02da1c48b670996dcb1f447ef9ef00b33033c48a4fe938f420bec3e56bfd24071a062e0aa78a81bf0290afbc3a9d8e9a068e6d74caa66c5e0fa8a46deaae96b0833"], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_eth_syncing-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_eth_syncing-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_net_listening-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_net_listening-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "net_listening", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "net_listening", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_net_peercount-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_net_peercount-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "net_peerCount", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "net_peerCount", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_net_version-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_net_version-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "net_version", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "net_version", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/_web3_clientversion-request.mdx
+++ b/services/reference/celo/json-rpc-methods/_web3_clientversion-request.mdx
@@ -5,10 +5,17 @@ import TabItem from "@theme/TabItem"
   <TabItem value="cURL">
 
 ```bash
-curl https://celo-alfajores.infura.io/v3/YOUR-API-KEY \
+curl https://celo-mainnet.infura.io/v3/YOUR-API-KEY \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "web3_clientVersion", "params": [], "id": 1}'
+```
+
+  </TabItem>
+    <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "method": "web3_clientVersion", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/celo/json-rpc-methods/subscription-methods/_eth_subscribe-request.mdx
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/_eth_subscribe-request.mdx
@@ -1,0 +1,28 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+  <TabItem value="newHeads">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "id": 1, "method": "eth_subscribe", "params": ["newHeads"]}'
+```
+
+  </TabItem>
+  <TabItem value="logs">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "id": 1, "method": "eth_subscribe", "params": ["logs", {"address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd", "topics": ["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"]}]}'
+```
+
+  </TabItem>
+
+  <TabItem value="newPendingTransactions">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"]}'
+```
+
+  </TabItem>
+</Tabs>
+

--- a/services/reference/celo/json-rpc-methods/subscription-methods/_eth_unsubscribe-request.mdx
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/_eth_unsubscribe-request.mdx
@@ -1,0 +1,13 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+  <TabItem value="WSS">
+
+```bash
+wscat -c wss://celo-mainnet.infura.io/ws/v3/YOUR-API-KEY -x '{"jsonrpc": "2.0", "id": 1, "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}'
+```
+
+  </TabItem>
+</Tabs>
+

--- a/services/reference/celo/json-rpc-methods/subscription-methods/eth_subscribe.mdx
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/eth_subscribe.mdx
@@ -1,0 +1,40 @@
+---
+title: "eth_subscribe"
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+import Description from "/services/reference/_partials/subscription-methods/_eth_subscribe-description.mdx";
+
+<Description />
+
+## Parameters
+
+import Params from "/services/reference/_partials/subscription-methods/_eth_subscribe-parameters.mdx";
+
+<Params />
+
+## Returns
+
+import Returns from "/services/reference/_partials/subscription-methods/_eth_subscribe-returns.mdx";
+
+<Returns />
+
+## Example
+
+import Example from "/services/reference/_partials/subscription-methods/_eth_subscribe-example.mdx";
+
+<Example />
+
+### Request
+
+import Request from "./_eth_subscribe-request.mdx";
+
+<Request />
+
+### Response
+
+import Response from "/services/reference/_partials/subscription-methods/_eth_subscribe-response.mdx";
+
+<Response />

--- a/services/reference/celo/json-rpc-methods/subscription-methods/eth_unsubscribe.mdx
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/eth_unsubscribe.mdx
@@ -1,0 +1,40 @@
+---
+title: "eth_unsubscribe"
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+import Description from "/services/reference/_partials/subscription-methods/_eth_unsubscribe-description.mdx";
+
+<Description />
+
+## Parameters
+
+import Params from "/services/reference/_partials/subscription-methods/_eth_unsubscribe-parameters.mdx";
+
+<Params />
+
+## Returns
+
+import Returns from "/services/reference/_partials/subscription-methods/_eth_unsubscribe-returns.mdx";
+
+<Returns />
+
+## Example
+
+import Example from "/services/reference/_partials/subscription-methods/_eth_unsubscribe-example.mdx";
+
+<Example />
+
+### Request
+
+import Request from "./_eth_unsubscribe-request.mdx";
+
+<Request />
+
+### Response
+
+import Response from "/services/reference/_partials/subscription-methods/_eth_unsubscribe-response.mdx";
+
+<Response />

--- a/services/reference/celo/json-rpc-methods/subscription-methods/index.md
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/index.md
@@ -1,0 +1,19 @@
+---
+title: "Subscription methods"
+---
+
+# Subscription methods
+
+Subscription methods are available for [WebSocket](../../../../learn/websockets.md) connections only, and allow you to wait for events instead of polling for them. For example, dapps can subscribe to logs and receive notifications when a specific event occurs.
+
+The following subscription methods are available:
+
+- [`eth_subscribe`](./eth_subscribe.mdx) - Create a subscription to a particular event
+- [`eth_unsubscribe`](./eth_unsubscribe.mdx) - Cancel an active subscription
+
+:::info
+
+We recommend you use the WSS protocol to set up bidirectional stateful subscriptions. Stateless HTTP WebSockets are also
+supported.
+
+:::

--- a/services/reference/celo/json-rpc-methods/subscription-methods/index.md
+++ b/services/reference/celo/json-rpc-methods/subscription-methods/index.md
@@ -4,7 +4,7 @@ title: "Subscription methods"
 
 # Subscription methods
 
-Subscription methods are available for [WebSocket](../../../../learn/websockets.md) connections only, and allow you to wait for events instead of polling for them. For example, dapps can subscribe to logs and receive notifications when a specific event occurs.
+Subscription methods are available for [WebSocket](../../../../concepts/websockets.md) connections only, and allow you to wait for events instead of polling for them. For example, dapps can subscribe to logs and receive notifications when a specific event occurs.
 
 The following subscription methods are available:
 


### PR DESCRIPTION
# Description

- Add Celo WebSocket support.
- Updated Celo examples to use mainnet instead of testnet for maintenance purposes.


## Preview

[https://metamask-docs-git-celo-websockets-metamask-web.vercel.app/services/reference/celo/](https://metamask-docs-git-celo-websockets-metamask-web.vercel.app/services/reference/celo/)

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.
