### PR TITLE
add: connectkit to list of supported third-party libraries

### DIFF
--- a/wallet/how-to/connect/index.md
+++ b/wallet/how-to/connect/index.md
@@ -32,6 +32,7 @@ You can connect to MetaMask using the following third-party libraries that suppo
 - [MIPD Store](https://github.com/wevm/mipd)
 - [RainbowKit](https://www.rainbowkit.com)
 - [Web3-Onboard](https://onboard.blocknative.com)
+- [ConnectKit](https://docs.family.co/connectkit)
 
 ## Connect to MetaMask directly using Vite
 


### PR DESCRIPTION
# Description

Adds Family's [ConnectKit](https://docs.family.co/connectkit) to list of third-party libraries that support MetaMask/EIP-6963.

## Issue(s) fixed

N/A

## Preview

https://docs.metamask.io/wallet/how-to/connect/#connect-to-metamask-using-third-party-libraries

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
