### PR TITLE
feat(reference): imp for reference pages

### DIFF
--- a/src/components/ParserOpenRPC/InteractiveBox/index.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/index.tsx
@@ -32,6 +32,7 @@ interface InteractiveBoxProps {
   onParamChange: (data) => void;
   drawerLabel?: string | null;
   closeComplexTypeView?: () => void;
+  isOpen?: boolean;
 }
 
 export default function InteractiveBox({
@@ -41,6 +42,7 @@ export default function InteractiveBox({
   onParamChange,
   drawerLabel,
   closeComplexTypeView,
+  isOpen = false
 }: InteractiveBoxProps) {
   const [parsedSchema, setParsedSchema] = useState<RJSFSchema>(null);
   const [defaultFormData, setDefaultFormData] = useState<any>({});
@@ -116,8 +118,10 @@ export default function InteractiveBox({
   }, []);
 
   const onChangeHandler = (data) => {
-    setCurrentFormData({...data});
-    onParamChange({...data});
+    if (isOpen) {
+      setCurrentFormData({...data});
+      onParamChange({...data});
+    }
   };
 
   const cloneAndSetNullIfExists = (obj, key) => {

--- a/src/components/ParserOpenRPC/RequestBox/index.tsx
+++ b/src/components/ParserOpenRPC/RequestBox/index.tsx
@@ -65,13 +65,13 @@ export default function RequestBox({
           </button>
         </div>
       </div>
-      {response !== null && (
+      {response !== undefined && (
         <div className={styles.cardWrapper}>
           <div className={styles.cardHeader}>
             <strong className={styles.cardHeading}>Response</strong>
           </div>
           <div>
-            <CodeBlock language="javascript" className="margin-bottom--none">
+            <CodeBlock language="javascript" className={clsx(styles.responseBlock, "margin-bottom--none")}>
               {exampleResponse}
             </CodeBlock>
           </div>

--- a/src/components/ParserOpenRPC/RequestBox/styles.module.css
+++ b/src/components/ParserOpenRPC/RequestBox/styles.module.css
@@ -21,3 +21,8 @@
   border-top: 1px solid #848c96;
   padding: 16px;
 }
+
+.responseBlock {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/src/components/ParserOpenRPC/index.tsx
+++ b/src/components/ParserOpenRPC/index.tsx
@@ -32,7 +32,7 @@ export const ParserOpenRPCContext =
 export default function ParserOpenRPC({ network, method }: ParserProps) {
   if (!method || !network) return null;
   const [isModalOpen, setModalOpen] = useState(false);
-  const [reqResult, setReqResult] = useState(null);
+  const [reqResult, setReqResult] = useState(undefined);
   const [paramsData, setParamsData] = useState([]);
   const [isDrawerContentFixed, setIsDrawerContentFixed] = useState(false);
   const [drawerLabel, setDrawerLabel] = useState(null);
@@ -88,7 +88,7 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
     );
 
     return {
-      description: currentMethod.summary || currentMethod.description || null,
+      description: currentMethod.description || currentMethod.summary || null,
       params: currentMethod.params || [],
       result: currentMethod.result || null,
       components: currentNetwork.data.components || null,

--- a/src/components/ParserOpenRPC/index.tsx
+++ b/src/components/ParserOpenRPC/index.tsx
@@ -93,6 +93,7 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
       result: currentMethod.result || null,
       components: currentNetwork.data.components || null,
       examples: currentMethod?.examples,
+      paramStructure: currentMethod?.paramStructure || null,
       errors,
       tags,
     };
@@ -103,18 +104,27 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
   const { metaMaskProvider, metaMaskConnectHandler } = useContext(MetamaskProviderContext);
 
   const onParamsChangeHandle = (data) => {
+    trackInputChangeForSegment({
+      eventName: "Request Configuration Started",
+      userExperience: "B",
+    });
+
     if (
       typeof data !== "object" ||
       data === null ||
       Object.keys(data).length === 0
     ) {
       setParamsData([]);
+      return
     }
+
+    if (typeof data === "object" && currentMethodData.paramStructure === "by-name") {
+      setParamsData({...data});
+      return
+    }
+
     setParamsData(Object.values(data));
-    trackInputChangeForSegment({
-      eventName: "Request Configuration Started",
-      userExperience: "B",
-    });
+    
   };
 
   const onSubmitRequestHandle = async () => {

--- a/src/components/ParserOpenRPC/index.tsx
+++ b/src/components/ParserOpenRPC/index.tsx
@@ -206,6 +206,7 @@ export default function ParserOpenRPC({ network, method }: ParserProps) {
               onParamChange={onParamsChangeHandle}
               drawerLabel={drawerLabel}
               closeComplexTypeView={closeComplexTypeView}
+              isOpen={isModalOpen}
             />
           </ModalDrawer>
         </div>


### PR DESCRIPTION
## Description

- display `null` if it comes in the response block
- display default data for the object (ex: `addEthereumChain`)
- handling object "by-name" `wallet_watchAsset`
- style fix => If the response is large, then a scroll appears in the response block

https://infura.atlassian.net/browse/ACT-1507


