### PR TITLE
fix(docs): ACT-1539 - Fix for Handling Object Type for Input

### DIFF
--- a/src/components/ParserOpenRPC/InteractiveBox/index.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/index.tsx
@@ -131,7 +131,7 @@ export default function InteractiveBox({
           if (isObject(value)) {
             return [
               checkName(name),
-              Object.fromEntries(Object.entries(value).map(([key, val]) => [key, isObject(val) ? val.value : val]))
+              Object.fromEntries(Object.entries(value).map(([key, val]) => [key, isObject(val) && val?.description ? val.value : val]))
             ];
           }
           return [checkName(name), value];


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Handle object type for input when it’s an object with description and value fields.
It’s related to Harrie's latest changes to the JSON-RPC schema.

Before:
<img width="989" alt="Screenshot 2024-09-23 at 18 15 27" src="https://github.com/user-attachments/assets/381f7933-ff6d-4683-9283-67d776f8ec70">

After:
<img width="983" alt="Screenshot 2024-09-23 at 18 16 01" src="https://github.com/user-attachments/assets/6eec2c13-8745-4095-8de0-f2ec09ff12f9">