### PR TITLE
Fix broken links in MM docs

### DIFF
--- a/services/reference/base/json-rpc-methods/index.md
+++ b/services/reference/base/json-rpc-methods/index.md
@@ -5,6 +5,6 @@ description: Supported standard Ethereum methods on Base network.
 
 # JSON-RPC methods
 
-The standard Ethereum methods documented in this section are supported by Infura on the Base network. For custom Base methods, please see the official [Optimism Ethereum JSON-RPC API documentation](https://community.optimism.io/docs/developers/build/json-rpc/) (Bedrock release).
+The standard Ethereum methods documented in this section are supported by Infura on the Base network. For custom Base methods, see the official [Optimism Ethereum JSON-RPC API documentation](https://docs.optimism.io/builders/node-operators/json-rpc) (Bedrock release).
 
-The Base optimistic layer 2 rollup chain is built by Coinbase, in collaboration with Optimism on the MIT-licensed OP Stack ([Bedrock](https://community.optimism.io/docs/developers/bedrock/)).
+The Base optimistic layer 2 rollup chain is built by Coinbase, in collaboration with Optimism on the MIT-licensed OP Stack ([Bedrock](https://docs.optimism.io/stack/getting-started#the-op-stack-today)).

--- a/services/reference/optimism/json-rpc-methods/index.md
+++ b/services/reference/optimism/json-rpc-methods/index.md
@@ -10,11 +10,11 @@ methods, please see [Optimism Ethereum JSON-RPC API documentation](https://commu
 
 :::info
 
-The Optimism Bedrock migration supports different JSON-RPC methods. Refer to the [Optimism Bedrock documentation](https://community.optimism.io/docs/developers/bedrock/#json-rpc) for more information.
+The Optimism Bedrock migration supports different JSON-RPC methods. Refer to the [Optimism Bedrock documentation](https://docs.optimism.io/builders/node-operators/json-rpc) for more information.
 
 :::
 
-You need to be aware of the [differences between the behavior of Ethereum and Optimism](https://community.optimism.io/docs/developers/build/differences/). For example, there are differences related to:
+You need to be aware of the [differences between the behavior of Ethereum and Optimism](https://docs.optimism.io/chain/differences). For example, there are differences related to:
 
 - Opcodes
 - Transaction and transaction pools

--- a/services/reference/optimism/json-rpc-methods/index.md
+++ b/services/reference/optimism/json-rpc-methods/index.md
@@ -8,12 +8,6 @@ description: Supported standard Ethereum methods on Optimism network.
 The standard Ethereum methods documented here are supported by Infura on the Optimism network. For custom Optimism
 methods, see [Optimism Ethereum JSON-RPC API documentation](https://docs.optimism.io/builders/node-operators/json-rpc) (Bedrock release).
 
-:::info
-
-The Optimism Bedrock migration supports different JSON-RPC methods. Refer to the [Optimism Bedrock documentation](https://docs.optimism.io/stack/getting-started#the-op-stack-today) for more information.
-
-:::
-
 You need to be aware of the [differences between the behavior of Ethereum and Optimism](https://docs.optimism.io/chain/differences). For example, there are differences related to:
 
 - Opcodes

--- a/services/reference/optimism/json-rpc-methods/index.md
+++ b/services/reference/optimism/json-rpc-methods/index.md
@@ -6,11 +6,11 @@ description: Supported standard Ethereum methods on Optimism network.
 # JSON-RPC methods
 
 The standard Ethereum methods documented here are supported by Infura on the Optimism network. For custom Optimism
-methods, please see [Optimism Ethereum JSON-RPC API documentation](https://community.optimism.io/docs/developers/build/json-rpc/) (Bedrock release).
+methods, see [Optimism Ethereum JSON-RPC API documentation](https://docs.optimism.io/builders/node-operators/json-rpc) (Bedrock release).
 
 :::info
 
-The Optimism Bedrock migration supports different JSON-RPC methods. Refer to the [Optimism Bedrock documentation](https://docs.optimism.io/builders/node-operators/json-rpc) for more information.
+The Optimism Bedrock migration supports different JSON-RPC methods. Refer to the [Optimism Bedrock documentation](https://docs.optimism.io/stack/getting-started#the-op-stack-today) for more information.
 
 :::
 

--- a/snaps/how-to/debug-a-snap/common-issues.md
+++ b/snaps/how-to/debug-a-snap/common-issues.md
@@ -57,8 +57,8 @@ plugins for several other build systems:
 - [Rollup](https://www.npmjs.com/package/@metamask/rollup-plugin-snaps)
 - [Browserify](https://www.npmjs.com/package/@metamask/snaps-browserify-plugin)
 
-For examples on how to set up these build systems yourself, please see the
-[examples](https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples/examples).
+For examples on how to set up these build systems yourself, see the
+[examples](https://github.com/MetaMask/snaps/tree/main/packages/examples).
 
 We recommend running [`yarn mm-snap manifest --fix`](../../reference/cli/subcommands.md#m-manifest)
 after creating your bundle to make sure your manifest `shasum` value is correct.

--- a/wallet/concepts/convenience-libraries.md
+++ b/wallet/concepts/convenience-libraries.md
@@ -13,8 +13,7 @@ contracts, for a variety of API preferences (for example, promises, callbacks, a
 The [MetaMask Ethereum provider API](wallet-api.md#ethereum-provider-api) is very simple, and wraps
 [Ethereum JSON-RPC](wallet-api.md#json-rpc-api) formatted messages, which is why
 some developers use a convenience library for interacting with the provider, such as
-[Ethers](https://www.npmjs.com/package/ethers), [web3.js](https://www.npmjs.com/package/web3), and
-[Embark](https://github.com/embarklabs/embark).
+[Ethers](https://www.npmjs.com/package/ethers) and [web3.js](https://www.npmjs.com/package/web3).
 You can refer to those tools' documentation to use them.
 
 You can [use MetaMask SDK](../how-to/use-sdk/index.md), which provides a reliable, secure, and

--- a/wallet/concepts/convenience-libraries.md
+++ b/wallet/concepts/convenience-libraries.md
@@ -14,7 +14,7 @@ The [MetaMask Ethereum provider API](wallet-api.md#ethereum-provider-api) is ver
 [Ethereum JSON-RPC](wallet-api.md#json-rpc-api) formatted messages, which is why
 some developers use a convenience library for interacting with the provider, such as
 [Ethers](https://www.npmjs.com/package/ethers), [web3.js](https://www.npmjs.com/package/web3), and
-[Embark](https://framework.embarklabs.io/).
+[Embark](https://github.com/embarklabs/embark).
 You can refer to those tools' documentation to use them.
 
 You can [use MetaMask SDK](../how-to/use-sdk/index.md), which provides a reliable, secure, and

--- a/wallet/concepts/sdk/android.md
+++ b/wallet/concepts/sdk/android.md
@@ -33,7 +33,7 @@ The MetaMask Android SDK consists of two components:
 The client SDK communicates with the server SDK using
 [Interprocess communication (IPC)](https://developer.android.com/guide/components/processes-and-threads#IPC).
 The JSON-RPC calls are implemented using the
-[Android Interface Definition Language (AIDL)](https://developer.android.com/guide/components/aidl).
+[Android Interface Definition Language (AIDL)](https://developer.android.com/develop/background-work/services/aidl).
 Communication over IPC is encrypted using elliptic curve integrated encryption scheme (ECIES).
 
 Within MetaMask, the wallet (written in React Native) communicates with the Native Module (written


### PR DESCRIPTION
# Description

Nightly check identified these links to be addressed ([Slack for ref](https://consensys.slack.com/archives/GKX130DMX/p1727764912083769)):

- https://community.optimism.io/docs/developers/build/json-rpc/ (Status: 404)
- https://community.optimism.io/docs/developers/bedrock/ (Status: 404)
- https://community.optimism.io/docs/developers/bedrock/#json-rpc (Status: 404)
- https://community.optimism.io/docs/developers/build/differences/ (Status: 404)
- https://developer.android.com/training/dependency-injection/hilt-android (Status: 0, redirect loop)
- https://developer.android.com/guide/components/processes-and-threads#IPC (Status: 0, redirect loop)
- https://developer.android.com/guide/components/aidl (Status: 0, redirect loop)
- https://framework.embarklabs.io/ (Status: 0, ENOTFOUND error)
- https://github.com/MetaMask/snaps-monorepo/tree/main/packages/examples/examples (Status: 404)
- https://github.com/ethereum/execution-apis/commits/assembled-spec/ (Status: 429, too many requests)