### PR TITLE
Removes WS from Blast & Mantle Sepolia

### DIFF
--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -44,7 +44,6 @@ Ensure that you replace `<YOUR-API-KEY>` with an API key from your [Infura dashb
 | Mainnet           | JSON-RPC over HTTPS     | `https://blast-mainnet.infura.io/v3/<YOUR-API-KEY>`  |
 | Mainnet           | JSON-RPC over WebSocket | `wss://blast-mainnet.infura.io/ws/v3/<YOUR-API-KEY>` |
 | Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://blast-sepolia.infura.io/v3/<YOUR-API-KEY>`  |
-| Testnet (Sepolia) | JSON-RPC over WebSocket | `wss://blast-sepolia.infura.io/ws/v3/<YOUR-API-KEY>` |
 
 ## Binance Smart Chain
 
@@ -108,7 +107,6 @@ Include your authentication details when [making IPFS requests](/reference/ipfs/
 | Mainnet           | JSON-RPC over HTTPS     | `https://mantle-mainnet.infura.io/v3/<YOUR-API-KEY>`  |
 | Mainnet           | JSON-RPC over WebSocket | `wss://mantle-mainnet.infura.io/ws/v3/<YOUR-API-KEY>` |
 | Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://mantle-sepolia.infura.io/v3/<YOUR-API-KEY>`  |
-| Testnet (Sepolia) | JSON-RPC over WebSocket | `wss://mantle-sepolia.infura.io/ws/v3/<YOUR-API-KEY>` |
 
 ## opBNB
 


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Websocket is only supported on Blast and Mantle Mainnet, not Sepolia.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Duplicates https://github.com/INFURA/docs/pull/309 from Infura docs.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
