### PR TITLE
feat(ref): improvements for primary btns

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -47,9 +47,15 @@ a.button {
   justify-content: center;
   align-items: center;
   min-width: 145px;
+  transition-property: "box-shadow", "background-color";
+  transition-duration: 0.2s;
+  transition-timing-function: ease;
 
   &.primary {
     background-color: var(--button-primary-background-color);
+    --button-color: #141618;
+    --button-primary-background-color: #1098fc;
+    --button-hover-background-color: #26a2fc;
   }
 
   &.secondary {

--- a/src/components/NavbarWallet/index.tsx
+++ b/src/components/NavbarWallet/index.tsx
@@ -73,7 +73,6 @@ const NavbarWalletComponent: FC = ({
       thin
       onClick={metaMaskWalletIdConnectHandler}
       className={styles.navbarButton}
-      textColor="light"
     >
       {!isExtensionActive ? "Install MetaMask" : "Connect MetaMask"}
     </Button>

--- a/src/components/ParserOpenRPC/ProjectsBox/index.tsx
+++ b/src/components/ParserOpenRPC/ProjectsBox/index.tsx
@@ -126,10 +126,9 @@ const ProjectsBox = () => {
                   thin
                   className={styles.connectButton}
                   onClick={metaMaskWalletConnectionHandler}
-                  textColor="light"
                   isLoading={isWalletLinking}
                 >
-                  Connect Wallet
+                  Connect MetaMask
                 </Button>
               </>
             )}

--- a/src/components/ParserOpenRPC/ProjectsBox/styles.module.scss
+++ b/src/components/ParserOpenRPC/ProjectsBox/styles.module.scss
@@ -64,4 +64,5 @@
   order: 100;
   margin-left: 12px;
   font-weight: 500;
+  min-width: 155px;
 }


### PR DESCRIPTION
## Description

- Added the same "Connect MetaMask" label to the connect buttons in the navigation and on the page
- Improvements to the primary button (black text, blue background, and light hover effect)

![Screenshot 2024-10-07 at 16 51 37](https://github.com/user-attachments/assets/6795beaa-e6fa-46c1-bb38-cc33418de07d)
