### PR TITLE
feat(ref): added linea reference feehistory page

### DIFF
--- a/services/reference/linea/json-rpc-methods/eth_feehistory.mdx
+++ b/services/reference/linea/json-rpc-methods/eth_feehistory.mdx
@@ -1,40 +1,13 @@
 ---
 title: "eth_feeHistory"
+hide_title: true
+hide_table_of_contents: true
 ---
 
-import Tabs from "@theme/Tabs"
-import TabItem from "@theme/TabItem"
+import ParserOpenRPC from "@site/src/components/ParserOpenRPC"
+import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc"
 
-import Description from "/services/reference/_partials/_eth_feehistory-description.mdx"
-
-<Description />
-
-## Parameters
-
-import Params from "/services/reference/_partials/_eth_feehistory-parameters.mdx"
-
-<Params />
-
-## Returns
-
-import Returns from "/services/reference/_partials/_eth_feehistory-returns.mdx"
-
-<Returns />
-
-## Example
-
-import Example from "/services/reference/_partials/_eth_feehistory-example.mdx"
-
-<Example />
-
-### Request
-
-import Request from "./_eth_feehistory-request.mdx"
-
-<Request />
-
-### Response
-
-import Response from "/services/reference/_partials/_eth_feehistory-response.mdx"
-
-<Response />
+<ParserOpenRPC
+  network={NETWORK_NAMES.linea}
+  method="eth_feeHistory"
+/>

--- a/src/components/ParserOpenRPC/DetailsBox/MDContent.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/MDContent.tsx
@@ -47,7 +47,11 @@ const parseLists = (text: string) => {
 const parseMarkdown = (content: string) => {
   return parseLists(
     content
-      .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>')
+      .replace(/\[(.*?)\]\((.*?)\)/g, (match, text, url) => {
+        const isExternal = /^(https?:\/\/)/.test(url);
+        const targetAttr = isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
+        return `<a href="${url}"${targetAttr}>${text}</a>`;
+      })
       .replace(/`(.*?)`/g, '<code>$1</code>')
       .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
       .replace(/\*(.*?)\*/g, '<em>$1</em>')

--- a/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { SchemaProperty } from "./SchemaProperty";
 import { CollapseBox } from "../CollapseBox/CollapseBox";
-import { MDContent } from "./MDContent";
 import styles from "./styles.module.css";
 
 const getRefSchemaFromComponents = (initRef, components) => {
@@ -25,7 +24,7 @@ const renderSchema = (schemaItem, schemas, name) => {
       <SchemaProperty
         title={itemName || item.title}
         type="object"
-        required={!!item.required}
+        required={schemaItem.required || !!item.required}
         description={item.description || item.title || ""}
       />
       <div className="padding-bottom--md">
@@ -55,8 +54,8 @@ const renderSchema = (schemaItem, schemas, name) => {
       <SchemaProperty
         title={itemName || item.title}
         type="array"
-        required={!!item.required}
-        description={item.description || item.title || ""}
+        required={schemaItem.required || !!item.required}
+        description={schemaItem.description || item.description || item.title || ""}
       />
       <div className="padding-bottom--md">
         <CollapseBox>
@@ -81,7 +80,7 @@ const renderSchema = (schemaItem, schemas, name) => {
       <SchemaProperty
         title={itemName || item.title}
         type={type}
-        required={!!item.required}
+        required={schemaItem.required || !!item.required}
         description={item.description || item.title || ""}
       />
       <div className="padding-bottom--md">
@@ -104,30 +103,13 @@ const renderSchema = (schemaItem, schemas, name) => {
   if (schemaItem.allOf) return renderCombinations(schemaItem, name, "allOf");
   if (schemaItem.anyOf) return renderCombinations(schemaItem, name, "anyOf");
 
-  const renderEnum = (enumValues, title, description) => {
-    const getDescription = (item, title) => {
-      let regex = new RegExp(`\`${item}\`: ([^;]+)(;|$)`);
-      if (title === "subscriptionType") {
-        regex = new RegExp(`\`${item}\` - ([^.;]+)[.;]?`);
-      }
-      const match = description.match(regex);
-      return match ? match[1] : "";
-    };
-    const blockEnum =
-      title &&
-      description &&
-      (title === "Block tag" || title === "subscriptionType");
+  const renderEnum = (enumValues) => {
     return (
       <div className={styles.enumWrapper}>
         <div className="padding--md">Possible enum values</div>
         {enumValues.map((value, index) => (
           <div key={index} className={styles.enumItem}>
             <div className={styles.enumTitle}>{value}</div>
-            {blockEnum && (
-              <div style={{ paddingTop: "10px" }}>
-                <MDContent content={getDescription(value, title)} />
-              </div>
-            )}
           </div>
         ))}
       </div>
@@ -145,12 +127,7 @@ const renderSchema = (schemaItem, schemas, name) => {
             schemaItem.schema.description || schemaItem.schema.title || ""
           }
         />
-        {schemaItem.schema.enum &&
-          renderEnum(
-            schemaItem.schema.enum,
-            schemaItem.schema.title,
-            schemaItem.schema.description,
-          )}
+        {schemaItem.schema.enum && renderEnum(schemaItem.schema.enum)}
       </div>
     );
   }
@@ -161,14 +138,9 @@ const renderSchema = (schemaItem, schemas, name) => {
         title={name || schemaItem.title}
         type={schemaItem.enum ? "enum" : schemaItem.type}
         required={!!schemaItem.required}
-        description={
-          schemaItem.enum && schemaItem.title === "Block tag"
-            ? ""
-            : schemaItem.description || schemaItem.title
-        }
+        description={schemaItem.description || schemaItem.title}
       />
-      {schemaItem.enum &&
-        renderEnum(schemaItem.enum, schemaItem.title, schemaItem.description)}
+      {schemaItem.enum && renderEnum(schemaItem.enum)}
     </div>
   );
 };

--- a/src/components/ParserOpenRPC/DetailsBox/index.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/index.tsx
@@ -50,6 +50,7 @@ export default function DetailsBox({
       <Heading as="h1">{method}</Heading>
       {summary !== null && (
         <p style={{ marginBottom: "0.5rem" }}>
+          <strong>Summary: </strong>
           <MDContent content={summary} />
         </p>
       )}

--- a/src/components/ParserOpenRPC/InteractiveBox/index.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/index.tsx
@@ -57,7 +57,7 @@ function sortObjectKeysByArray(
   return result;
 }
 
-function removeEmptyArrays(obj, params) {
+function removeEmptyArrays(obj: any, params: any[]) {
   const newObj = JSON.parse(JSON.stringify(obj));
   for (const key in newObj) {
     const currentParam = params.find(item => item.name === key)

--- a/src/components/ParserOpenRPC/InteractiveBox/index.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/index.tsx
@@ -57,14 +57,18 @@ function sortObjectKeysByArray(
   return result;
 }
 
-function removeEmptyArrays<T extends Record<string, any>>(obj: T): T {
+function removeEmptyArrays(obj, params) {
   const newObj = JSON.parse(JSON.stringify(obj));
   for (const key in newObj) {
+    const currentParam = params.find(item => item.name === key)
     if (newObj.hasOwnProperty(key)) {
+      if (currentParam && currentParam.required) {
+        return newObj
+      }
       if (Array.isArray(newObj[key]) && newObj[key].length === 0) {
         delete newObj[key];
       } else if (newObj[key] !== null && typeof newObj[key] === "object") {
-        newObj[key] = removeEmptyArrays(newObj[key]);
+        newObj[key] = removeEmptyArrays(newObj[key], params);
       }
     }
   }
@@ -206,7 +210,7 @@ export default function InteractiveBox({
   }, []);
 
   const onChangeHandler = (data) => {
-    const validData = removeEmptyArrays(data);
+    const validData = removeEmptyArrays(data, params);
     if (isOpen) {
       setCurrentFormData(validData);
       onParamChange(validData);

--- a/src/components/ParserOpenRPC/InteractiveBox/templates/ArrayFieldTemplate.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/templates/ArrayFieldTemplate.tsx
@@ -140,7 +140,7 @@ export const ArrayFieldTemplate = ({
               const baseInputTemplateProps = {
                 ...el.children.props,
                 isArray: true,
-                value: formData,
+                value: formData[i] || null,
               };
               const { index, hasRemove, onDropIndexClick, schema } = el;
               const isNumber =

--- a/src/components/ParserOpenRPC/InteractiveBox/templates/BaseInputTemplate.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/templates/BaseInputTemplate.tsx
@@ -35,8 +35,9 @@ export const BaseInputTemplate = ({
     [],
   );
   const onInputChange = (e) => {
-    setInputValue(e?.target?.value);
-    debouncedOnChange(e);
+    const value = isNumber ? Number((+e?.target?.value || 0)) : e?.target?.value;
+    setInputValue(value);
+    isNumber ? debouncedOnChange(value, true) : debouncedOnChange(e);
   };
   const onInputNumberChange = (value) => {
     setInputValue(value);
@@ -44,9 +45,7 @@ export const BaseInputTemplate = ({
   };
 
   useEffect(() => {
-    if (!isArray) {
-      setInputValue(value);
-    }
+    setInputValue(value);
   }, [value, isFormReseted]);
 
   return (

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -482,6 +482,4 @@ export const AUTH_WALLET_TOKEN = "auth.wallet.token";
 export const AUTH_WALLET_PROJECTS = "auth.wallet.projects";
 export const LINEA_DEV_URL = "https://linea-mainnet.dev.infura.org";
 export const LINEA_PROD_URL = "https://linea-mainnet.infura.io";
-export const LINEA_REQUEST_URL = process.env.VERCEL_ENV === "production"
-    ? LINEA_PROD_URL
-    : LINEA_DEV_URL;
+export const LINEA_REQUEST_URL = LINEA_PROD_URL;


### PR DESCRIPTION
## Description

- Updated `eth_feehistory` reference page with dynamic component `<ParserOpenRPC />`
- Added fixes for init values ​​for array in the parameters table
- Refactored enum parameter description
- Set prod value for the endpoint of linea-mainnet network

## Test

- Go to page **services/reference/linea/json-rpc-methods/eth_feehistory/**
- Check default values in the params table (click "customize request" btn)
- Copy the request (in the section example request) and paste it into the terminal (**don't forget to substitute your real prod API key**) and execute the request

![Screenshot 2024-10-14 at 13 32 00](https://github.com/user-attachments/assets/fe7100f4-df22-41db-be76-60fdddcf9476)

