### PR TITLE
Fix Flask label rendering

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,9 @@
 {
   "extends": "stylelint-config-standard",
   "rules": {
-    "selector-class-pattern": null
+    "selector-class-pattern": null,
+    "selector-pseudo-class-no-unknown": [true, {
+      "ignorePseudoClasses": ["global"]
+    }]
   }
 }

--- a/src/theme/DocSidebarItem/index.module.css
+++ b/src/theme/DocSidebarItem/index.module.css
@@ -1,5 +1,7 @@
-.flaskOnly > a.menu__link::after,
-.flaskOnly > .menu__list-item-collapsible > a.menu__link::after {
+.flaskOnly > :global(a.menu__link::after),
+.flaskOnly
+  > :global(.menu__list-item-collapsible)
+  > :global(a.menu__link::after) {
   content: "Flask";
   margin-left: 0.5em;
   background-color: var(--mm-flask-background-color);

--- a/src/theme/DocSidebarItem/index.module.css
+++ b/src/theme/DocSidebarItem/index.module.css
@@ -1,7 +1,5 @@
-.flaskOnly > :global(a.menu__link::after),
-.flaskOnly
-  > :global(.menu__list-item-collapsible)
-  > :global(a.menu__link::after) {
+.flaskOnly :global(a.menu__link::after),
+.flaskOnly :global(.menu__list-item-collapsible a.menu__link::after) {
   content: "Flask";
   margin-left: 0.5em;
   background-color: var(--mm-flask-background-color);


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Pages with metadata prop `flask_only: true` should have a purple Flask label appended to it in the sidebar. Changes made to the file [`src/theme/DocSidebarItem/index.module.css`](https://github.com/MetaMask/metamask-docs/pull/1563/files#diff-f7bad57c07ee936f19154bacc2b7060bca158c909ebddbb39e664649f5f0c127) in https://github.com/MetaMask/metamask-docs/pull/1563 break the rendering of the sidebar label. This PR reverts those changes and updates the stylelint config to recognize the `:global` pseudo-class.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

Before ([current site](https://docs.metamask.io/snaps/)):

![Screenshot 2024-10-18 at 7 12 43 PM](https://github.com/user-attachments/assets/11c5468b-a0d6-4f3e-9d79-9f1d3b8d84ef)

After ([PR preview](https://metamask-docs-4geuhdiga-metamask-web.vercel.app/snaps/)):

![Screenshot 2024-10-18 at 7 26 27 PM](https://github.com/user-attachments/assets/c03db542-6b67-4afc-b92f-6c38a156320a)

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
