### PR TITLE
fix(docs): fix for display param item description

### DIFF
--- a/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
@@ -124,7 +124,7 @@ const renderSchema = (schemaItem, schemas, name) => {
           type={schemaItem.schema.enum ? "enum" : schemaItem.schema.type}
           required={!!schemaItem.required}
           description={
-            schemaItem.schema.description || schemaItem.schema.title || ""
+            schemaItem.description || schemaItem.schema.description || schemaItem.schema.title || ""
           }
         />
         {schemaItem.schema.enum && renderEnum(schemaItem.schema.enum)}


### PR DESCRIPTION
## Description

- Fix for displaying parameter element description

## Test

- Go to the page **/services/reference/linea/json-rpc-methods/eth_getblockbyhash/** and check that the `hydratedTransactions` parameter description is displayed correctly

![Screenshot 2024-10-22 at 15 12 28](https://github.com/user-attachments/assets/a58c5c90-b04e-4a62-892f-9313098e6a56)

