### PR TITLE
feat(ref): act-1557 - ui improvements for ref pages

### DIFF
--- a/src/components/CustomReferencePage/index.tsx
+++ b/src/components/CustomReferencePage/index.tsx
@@ -29,7 +29,7 @@ function transformItems(items, dynamicItems) {
       }
     }
     if (newItem.href) {
-      if (newItem.href.endsWith("index")) {
+      if (newItem.href.endsWith("/index")) {
         newItem.href = newItem.href.slice(0, -5);
       }
       if (!newItem.href.startsWith("/")) {

--- a/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/RenderParams.tsx
@@ -26,6 +26,8 @@ const renderSchema = (schemaItem, schemas, name) => {
         type="object"
         required={schemaItem.required || !!item.required}
         description={item.description || item.title || ""}
+        pattern={item.pattern}
+        defaultVal={item.default}
       />
       <div className="padding-bottom--md">
         <CollapseBox>
@@ -56,6 +58,8 @@ const renderSchema = (schemaItem, schemas, name) => {
         type="array"
         required={schemaItem.required || !!item.required}
         description={schemaItem.description || item.description || item.title || ""}
+        pattern={schemaItem.pattern}
+        defaultVal={schemaItem.default}
       />
       <div className="padding-bottom--md">
         <CollapseBox>
@@ -82,6 +86,8 @@ const renderSchema = (schemaItem, schemas, name) => {
         type={type}
         required={schemaItem.required || !!item.required}
         description={item.description || item.title || ""}
+        pattern={item.pattern}
+        defaultVal={item.default}
       />
       <div className="padding-bottom--md">
         <CollapseBox>
@@ -106,10 +112,10 @@ const renderSchema = (schemaItem, schemas, name) => {
   const renderEnum = (enumValues) => {
     return (
       <div className={styles.enumWrapper}>
-        <div className="padding--md">Possible enum values</div>
+        <span className={styles.propItemLabel}>Enum:</span>
         {enumValues.map((value, index) => (
-          <div key={index} className={styles.enumItem}>
-            <div className={styles.enumTitle}>{value}</div>
+          <div key={index} className={styles.propItemValue}>
+            {`"${value}"`}
           </div>
         ))}
       </div>
@@ -126,6 +132,8 @@ const renderSchema = (schemaItem, schemas, name) => {
           description={
             schemaItem.description || schemaItem.schema.description || schemaItem.schema.title || ""
           }
+          pattern={schemaItem.schema.pattern || schemaItem.pattern}
+          defaultVal={schemaItem.schema.default || schemaItem.default}
         />
         {schemaItem.schema.enum && renderEnum(schemaItem.schema.enum)}
       </div>
@@ -139,6 +147,8 @@ const renderSchema = (schemaItem, schemas, name) => {
         type={schemaItem.enum ? "enum" : schemaItem.type}
         required={!!schemaItem.required}
         description={schemaItem.description || schemaItem.title}
+        pattern={schemaItem.pattern}
+        defaultVal={schemaItem.default}
       />
       {schemaItem.enum && renderEnum(schemaItem.enum)}
     </div>
@@ -150,8 +160,9 @@ export const renderParamSchemas = (inputSchema, schemas) => {
     <>
       {inputSchema.map((item, i) => {
         return (
-          <div key={`${i}`} className={styles.borderTopLine}>
+          <div key={`${i}`}>
             {renderSchema(item, schemas, item.name)}
+            {i < inputSchema.length - 1 && <hr className={styles.paramSeparator} />}
           </div>
         );
       })}

--- a/src/components/ParserOpenRPC/DetailsBox/SchemaProperty.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/SchemaProperty.tsx
@@ -7,6 +7,8 @@ interface SchemaPropertyProps {
   type?: string;
   required?: boolean;
   description?: string;
+  pattern?: string;
+  defaultVal?: string;
 }
 
 interface TagProps {
@@ -18,6 +20,8 @@ export const SchemaProperty = ({
   type,
   required,
   description,
+  pattern,
+  defaultVal
 }: SchemaPropertyProps) => {
   return (
     <div className="padding-vert--md">
@@ -33,6 +37,18 @@ export const SchemaProperty = ({
       </div>
       <p className="margin--none">
         <MDContent content={description} />
+        {pattern && (
+          <div className={styles.propItemWrapper}>
+            <span className={styles.propItemLabel}>Pattern: </span>
+            <span className={styles.propItemValue}>{pattern}</span>
+          </div>
+        )}
+        {defaultVal && (
+          <div className={styles.propItemWrapper}>
+            <span className={styles.propItemLabel}>Default: </span>
+            <span className={styles.propItemValue}>{defaultVal}</span>
+          </div>
+        )}
       </p>
     </div>
   );

--- a/src/components/ParserOpenRPC/DetailsBox/index.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/index.tsx
@@ -49,13 +49,20 @@ export default function DetailsBox({
       )}
       <Heading as="h1">{method}</Heading>
       {summary !== null && (
-        <p style={{ marginBottom: "0.5rem" }}>
+        <p
+          style={{ marginBottom: "0.5rem" }}
+          className={clsx("padding-bottom--md", styles.borderBottomLine)}
+        >
           <strong>Summary: </strong>
-          <MDContent content={summary} />
+          <span className={styles.summaryText}>
+            <MDContent content={summary} />
+          </span>
         </p>
       )}
       {description !== null && (
-        <MDContent content={description} />
+        <div className="padding-top--md">
+          <MDContent content={description} />
+        </div>
       )}
       {extraContent && <div className="padding-top--lg">{extraContent}</div>}
       <Heading
@@ -67,27 +74,29 @@ export default function DetailsBox({
       >
         Parameters
       </Heading>
-      {params.length === 0 ? (
-        <div>This method does not accept any parameters</div>
-      ) : (
-        <>{params && renderParamSchemas(params, components)}</>
-      )}
+      <div className={styles.paramContainer}>
+        {params.length === 0 ? (
+          <div className="padding-vert--md">
+            This method doesn't accept any parameters.
+          </div>
+        ) : (
+          params && renderParamSchemas(params, components)
+        )}
+      </div>
       <Heading
         as="h2"
-        className={clsx(
-          styles.secondaryHeading,
-          styles.borderBottomLine,
-          "padding-top--lg padding-vert--md",
-        )}
+        className={clsx(styles.secondaryHeading, "padding-top--lg padding-vert--md")}
       >
         Returns
       </Heading>
-      {result?.description && (
-        <div className="padding-vert--md">
-          <MDContent content={result.description} />
-        </div>
-      )}
-      {result && renderResultSchemas(result, components)}
+      <div className={styles.paramContainer}>
+        {result?.description && (
+          <div className="padding-vert--md">
+            <MDContent content={result.description} />
+          </div>
+        )}
+        {result && renderResultSchemas(result, components)}
+      </div>
     </>
   );
 }

--- a/src/components/ParserOpenRPC/DetailsBox/styles.module.css
+++ b/src/components/ParserOpenRPC/DetailsBox/styles.module.css
@@ -1,13 +1,60 @@
-.paramWrapper {
-  border-bottom: 1px solid #848c96;
-  padding-bottom: 1.5rem;
-  margin-bottom: 1rem;
+:root {
+  --prop-item-bg: #24272A;
+  --prop-item-color: #BBC0C5;
+  --prop-item-border-color: #848C96;
 }
 
-.borderWrapper {
-  border-bottom: 1px solid #848c96;
-  padding-top: 2rem;
-  padding-bottom: 1rem;
+:root[data-theme="light"] {
+  --prop-item-bg: #fff;
+  --prop-item-color: #6A737D;
+  --prop-item-border-color: #BBC0C5;
+}
+
+.propItemWrapper {
+  display: flex;
+  align-items: center;
+  padding: 10px 0 0;
+}
+
+.propItemLabel {
+  padding-right: 4px;
+}
+
+.propItemValue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 24px;
+  padding: 2px 8px;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 500;
+  color: var(--prop-item-color);
+  background-color: var(--prop-item-bg);
+  border-radius: 999px;
+  border: 1px solid var(--prop-item-border-color);
+  margin: 2px 4px;
+}
+
+.summaryText {
+  font-style: italic;
+  color: #6a737d;
+  font-weight: 400;
+}
+
+.paramContainer {
+  border: 1px solid #848c96;
+  border-radius: 8px;
+  padding: .5rem 1rem;
+  margin-top: 1rem;
+}
+
+.paramSeparator {
+  border: 0;
+  border-top: 1px solid #848c96;
+  margin: 1rem 0 .5rem;
+  width: 100%;
 }
 
 .textAltColor {
@@ -35,23 +82,9 @@
 }
 
 .enumWrapper {
-  border: 1px solid #848c96;
-  border-radius: 8px;
-  margin-bottom: 2rem;
-}
-
-.enumItem {
-  border-top: 1px solid #848c96;
-  padding: 16px;
-}
-
-.enumTitle {
-  display: inline-block;
-  font-size: 12px;
-  line-height: 1;
-  padding: 4px;
-  border: 1px solid #bbc0c5;
-  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  padding-bottom: 10px;
 }
 
 .secondaryHeading {

--- a/src/components/ParserOpenRPC/ErrorsBox/index.tsx
+++ b/src/components/ParserOpenRPC/ErrorsBox/index.tsx
@@ -22,7 +22,7 @@ export default function ErrorsBox({ errors }: ErrorsBoxProps) {
     <>
       <Heading
         as="h2"
-        className={clsx(styles.secondaryHeading, "padding-vert--md")}
+        className={clsx(styles.secondaryHeading, "padding-bottom--md padding-top--lg")}
       >
         Errors
       </Heading>

--- a/src/components/ParserOpenRPC/ErrorsBox/styles.module.css
+++ b/src/components/ParserOpenRPC/ErrorsBox/styles.module.css
@@ -2,6 +2,7 @@
   border: 1px solid #848c96;
   border-radius: 8px;
   overflow: hidden;
+  margin-bottom: 1.5rem;
 }
 
 .errRow {

--- a/src/components/ParserOpenRPC/RequestBox/styles.module.css
+++ b/src/components/ParserOpenRPC/RequestBox/styles.module.css
@@ -18,9 +18,16 @@
   color: #fff;
 }
 
-.codeWrapper {
+.codeWrapper pre {
   max-height: 328px;
   overflow-y: auto;
+}
+
+.codeWrapper button {
+  opacity: 1 !important;
+  position: relative;
+  top: -55px;
+  right: 5px;
 }
 
 .cardFooter {


### PR DESCRIPTION
## Description

- Improved styles for the **summary** section
- Added border for the **params** section
- Copy buttons moved to the upper right corner in **example request** section
- Added `pattern` and `default` value display to parameter description (if this data is in schema)
- Improved styles for `enum` values

## Test

- Go to the ref page (**/services/reference/linea/json-rpc-methods/eth_call/**) and check the style changes

![Screenshot 2024-10-23 at 16 15 25](https://github.com/user-attachments/assets/f0f0a461-85e2-4e55-985f-d45756f8b3b0)

![Screenshot 2024-10-23 at 16 17 06](https://github.com/user-attachments/assets/98ccb265-6261-48ac-b988-bd2e8ec40bf5)
