### PR TITLE
Remove Flask admonitions for Signature Insights in more places

### DIFF
--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -397,9 +397,6 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
 
 ## `onSignature`
 
-:::flaskOnly
-:::
-
 To provide [signature insights](../features/signature-insights.md) before a user signs a message, a
 Snap must expose the `onSignature` entry point.
 Whenever a [signing method](/wallet/concepts/signing-methods) is called, such as `personal_sign` or

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -255,6 +255,28 @@ If you specify `allowedOrigins`, you should not specify `dapps` or `snaps`.
 If you want to grant a dapp or Snap an automatic connection to your Snap, skipping the need for
 users to confirm a connection, you can use [`initialConnections`](#initial-connections).
 
+### `endowment:signature-insight`
+
+To provide [signature insights](../features/signature-insights.md), a Snap must request the
+`endowment:signature-insight` permission.
+This permission grants a Snap read-only access to raw signature payloads, before they're accepted
+for signing by the user, by exposing the [`onSignature`](./entry-points.md#onsignature) entry point.
+
+This permission requires an object with an `allowSignatureOrigin` property to signal if the Snap
+should pass the `signatureOrigin` property as part of the `onSignature` parameters.
+This property represents the signature initiator origin.
+The default is `false`.
+
+Specify this permission in the manifest file as follows:
+
+```json title="snap.manifest.json"
+"initialPermissions": {
+  "endowment:signature-insight": {
+    "allowSignatureOrigin": true
+  }
+},
+```
+
 ### `endowment:transaction-insight`
 
 To provide [transaction insights](../features/transaction-insights.md) before a user signs a
@@ -280,31 +302,6 @@ Specify this permission in the manifest file as follows:
     "allowTransactionOrigin": true
   }
 }
-```
-
-### `endowment:signature-insight`
-
-:::flaskOnly
-:::
-
-To provide [signature insights](../features/signature-insights.md), a Snap must request the
-`endowment:signature-insight` permission.
-This permission grants a Snap read-only access to raw signature payloads, before they're accepted
-for signing by the user, by exposing the [`onSignature`](./entry-points.md#onsignature) entry point.
-
-This permission requires an object with an `allowSignatureOrigin` property to signal if the Snap
-should pass the `signatureOrigin` property as part of the `onSignature` parameters.
-This property represents the signature initiator origin.
-The default is `false`.
-
-Specify this permission in the manifest file as follows:
-
-```json title="snap.manifest.json"
-"initialPermissions": {
-  "endowment:signature-insight": {
-    "allowSignatureOrigin": true
-  }
-},
 ```
 
 ### `endowment:webassembly`


### PR DESCRIPTION
# Description

A couple more areas where Signature Insights were still incorrectly tagged as "Flask Only" 

Also fixed the ordering on Snaps Entry Points

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page. N/A
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
