### PR TITLE
feat(linea): updated net_ & web3_ reference pages

### DIFF
--- a/services/reference/linea/json-rpc-methods/net_listening.mdx
+++ b/services/reference/linea/json-rpc-methods/net_listening.mdx
@@ -1,40 +1,13 @@
 ---
 title: "net_listening"
+hide_title: true
+hide_table_of_contents: true
 ---
 
-import Tabs from "@theme/Tabs"
-import TabItem from "@theme/TabItem"
+import ParserOpenRPC from "@site/src/components/ParserOpenRPC"
+import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc"
 
-import Description from "/services/reference/_partials/_net_listening-description.mdx"
-
-<Description />
-
-## Parameters
-
-import Params from "/services/reference/_partials/_net_listening-parameters.mdx"
-
-<Params />
-
-## Returns
-
-import Returns from "/services/reference/_partials/_net_listening-returns.mdx"
-
-<Returns />
-
-## Example
-
-import Example from "/services/reference/_partials/_net_listening-example.mdx"
-
-<Example />
-
-### Request
-
-import Request from "./_net_listening-request.mdx"
-
-<Request />
-
-### Response
-
-import Response from "/services/reference/_partials/_net_listening-response.mdx"
-
-<Response />
+<ParserOpenRPC
+  network={NETWORK_NAMES.linea}
+  method="net_listening"
+/>

--- a/services/reference/linea/json-rpc-methods/net_peercount.mdx
+++ b/services/reference/linea/json-rpc-methods/net_peercount.mdx
@@ -1,40 +1,13 @@
 ---
 title: "net_peerCount"
+hide_title: true
+hide_table_of_contents: true
 ---
 
-import Tabs from "@theme/Tabs"
-import TabItem from "@theme/TabItem"
+import ParserOpenRPC from "@site/src/components/ParserOpenRPC"
+import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc"
 
-import Description from "/services/reference/_partials/_net_peercount-description.mdx"
-
-<Description />
-
-## Parameters
-
-import Params from "/services/reference/_partials/_net_peercount-parameters.mdx"
-
-<Params />
-
-## Returns
-
-import Returns from "/services/reference/_partials/_net_peercount-returns.mdx"
-
-<Returns />
-
-## Example
-
-import Example from "/services/reference/_partials/_net_peercount-example.mdx"
-
-<Example />
-
-### Request
-
-import Request from "./_net_peercount-request.mdx"
-
-<Request />
-
-### Response
-
-import Response from "/services/reference/_partials/_net_peercount-response.mdx"
-
-<Response />
+<ParserOpenRPC
+  network={NETWORK_NAMES.linea}
+  method="net_peerCount"
+/>

--- a/services/reference/linea/json-rpc-methods/web3_clientversion.mdx
+++ b/services/reference/linea/json-rpc-methods/web3_clientversion.mdx
@@ -1,40 +1,13 @@
 ---
 title: "web3_clientVersion"
+hide_title: true
+hide_table_of_contents: true
 ---
 
-import Tabs from "@theme/Tabs"
-import TabItem from "@theme/TabItem"
+import ParserOpenRPC from "@site/src/components/ParserOpenRPC"
+import { NETWORK_NAMES } from "@site/src/plugins/plugin-json-rpc"
 
-import Description from "/services/reference/_partials/_web3_clientversion-description.mdx"
-
-<Description />
-
-## Parameters
-
-import Params from "/services/reference/_partials/_web3_clientversion-parameters.mdx"
-
-<Params />
-
-## Returns
-
-import Returns from "/services/reference/_partials/_web3_clientversion-returns.mdx"
-
-<Returns />
-
-## Example
-
-import Example from "/services/reference/_partials/_web3_clientversion-example.mdx"
-
-<Example />
-
-### Request
-
-import Request from "./_web3_clientversion-request.mdx"
-
-<Request />
-
-### Response
-
-import Response from "/services/reference/_partials/_web3_clientversion-response.mdx"
-
-<Response />
+<ParserOpenRPC
+  network={NETWORK_NAMES.linea}
+  method="web3_clientVersion"
+/>


### PR DESCRIPTION
## Description
- Updated `net_listening` , `net_peerCount` , `web3_clientVersion`  reference pages with dynamic component <ParserOpenRPC />

## Test
- Go to pages **services/reference/linea/json-rpc-methods/net_listening/** 
- Copy the request (in the section example request) and paste it into the terminal (don't forget to substitute your real prod API key) and execute the request

![Screenshot 2024-10-24 at 17 12 01](https://github.com/user-attachments/assets/d621f0c0-65cb-4e1d-9c88-43b7d77bc019)
