### PR TITLE
fix(ref): fix for removing empty string fields

### DIFF
--- a/src/components/ParserOpenRPC/InteractiveBox/index.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/index.tsx
@@ -57,11 +57,23 @@ function sortObjectKeysByArray(
   return result;
 }
 
+function removeEmptyStrings(obj) {
+  for (const key in obj) {
+    if (obj[key] === "") {
+      delete obj[key];
+    }
+  }
+  return obj;
+}
+
 function removeEmptyArrays(obj: any, params: any[]) {
   const newObj = JSON.parse(JSON.stringify(obj));
   for (const key in newObj) {
     const currentParam = params.find(item => item.name === key)
     if (newObj.hasOwnProperty(key)) {
+      if (!Array.isArray(newObj[key]) && typeof newObj[key] === "object") {
+        newObj[key] = removeEmptyStrings(newObj[key]);
+      }
       if (currentParam && currentParam.required) {
         return newObj
       }


### PR DESCRIPTION
## Description

- Fix for removing empty string fields (issue link - https://github.com/MetaMask/metamask-docs/issues/1684)

## Test

- Go to the page **/wallet/reference/json-rpc-methods/eth_sendtransaction/**
- Connect your wallet
- Click on the "Customize request" button and check that the parameters are filled with the default data (screen 1)
- Delete the value from the `to` parameter and check that it has been completely removed from the request example and also that the `data` param has become required (according to the condition in the JSON schema = screen 3) - an asterisk has appeared next to it (screen 2)

![Screenshot 2024-10-30 at 12 35 58](https://github.com/user-attachments/assets/c76e23ea-1d2d-4b91-9423-e79ec9d11ad8)

![Screenshot 2024-10-30 at 12 36 53](https://github.com/user-attachments/assets/a7126b4d-f152-4764-9bcf-aadfee498644)

![Screenshot 2024-10-30 at 12 51 39](https://github.com/user-attachments/assets/fc4ea0a1-7a8a-4b4d-80ce-8e8e57021fbc)


