### PR TITLE
Add tech writers as static folder codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@ docusaurus.config.js @MetaMask/activation @MetaMask/tech-writers
 # GitHub workflows and templates
 /.github/ @MetaMask/activation @MetaMask/tech-writers
 
+# Static image and video files
+/static/ @MetaMask/activation @MetaMask/tech-writers
+
 # Vercel configuration
 vercel.json @MetaMask/activation @MetaMask/tech-writers
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .docusaurus
 .cache-loader
 .idea
+.yarn
 
 # Misc
 .DS_Store


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

The `static` folder contains static image and video files that tech writers and engineering teams regularly update. For example, see #1659. This adds tech writers as codeowners to that folder to unblock us from merging such PRs. Also adds `.yarn` to `.gitignore`.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
