### PR TITLE
Update Link Snap component href param to include mailto:

### DIFF
--- a/snaps/features/custom-ui/index.md
+++ b/snaps/features/custom-ui/index.md
@@ -678,7 +678,7 @@ Outputs a clickable link.
 
 #### Props
 
-- `href`: `string` - The URL to point to. This must be an HTTPS URL.
+- `href`: `string` - The URL to point to. Supported schemes are `https:` and `mailto:`. `http:` is not allowed.
 - `children`: `Array<string | Bold | Italic>` - The link text.
 
 #### Example


### PR DESCRIPTION
# Description

Updates the <Link> component in Snaps Custom UI to correct the information for the href param.

## Issue(s) fixed

No issue filed.

## Preview

https://metamask-docs-git-update-link-schemes-metamask-web.vercel.app/snaps/features/custom-ui/#link

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page. N/A
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
