### PR TITLE
fix: Remove Flask only text for onUserInput

### DIFF
--- a/snaps/reference/entry-points.md
+++ b/snaps/reference/entry-points.md
@@ -636,9 +636,6 @@ export const onUpdate: OnUpdateHandler = async () => {
 
 ## `onUserInput`
 
-:::flaskOnly
-:::
-
 To respond to [interactive UI](../features/custom-ui/interactive-ui.md) events, a Snap must export `onUserInput`.
 
 #### Parameters


### PR DESCRIPTION
# Description

Removes "Flask only" text for `onUserInput`, this export has been available in all flavors of MetaMask for a long time.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
