### PR TITLE
feat(ref): act-1567 - added wss tab to code example section

### DIFF
--- a/src/components/ParserOpenRPC/RequestBox/styles.module.css
+++ b/src/components/ParserOpenRPC/RequestBox/styles.module.css
@@ -14,6 +14,10 @@
   justify-content: space-between;
 }
 
+.addIndent {
+  padding: 10px 95px 10px 16px;
+}
+
 .cardHeading {
   color: #fff;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -369,3 +369,30 @@ button:hover {
     font-size: 14px;
   }
 }
+
+.react-dropdown-select.select-lang {
+  min-width: 100px;
+  background: #292a36;
+  border: 1px solid #848C96;
+  padding-left: 10px;
+  border-radius: 6px;
+  color: #fff;
+}
+
+.react-dropdown-select.select-lang .react-dropdown-select-item {
+  background: #292a36;
+  color: #fff;
+  border: 0;
+}
+
+.react-dropdown-select.select-lang .react-dropdown-select-item:hover {
+  background: #141618;
+}
+
+.react-dropdown-select.select-lang .react-dropdown-select-item:not(:first-child) {
+  border-top: 1px solid #848c96;
+}
+
+.react-dropdown-select.select-lang .react-dropdown-select-dropdown-handle{
+  color: #fff;
+}


### PR DESCRIPTION
## Description

- UI: added `WSS` tab to code samples section for service reference pages

## Test

- Go to the page services **/services/reference/linea/json-rpc-methods/eth_accounts/** and check the UI for dropdown with options `curl` and `wss`

![Screenshot 2024-11-14 at 13 57 47](https://github.com/user-attachments/assets/0381d649-3746-46e9-b830-4c3101ecd0cd)
