### PR TITLE
fix: Correct typographical errors in "create-api.md" and "troubleshoot.md"

### DIFF
--- a/developer-tools/dashboard/get-started/create-api.md
+++ b/developer-tools/dashboard/get-started/create-api.md
@@ -37,7 +37,7 @@ requiring an API key secret or JWTs with each API request.
 
 We recommend the following best practices when creating your API keys:
 
-- Group API key endpoints by environment. For example, create seperate API keys for production or development environments.
+- Group API key endpoints by environment. For example, create separate API keys for production or development environments.
 - Group API key endpoints by groups or individuals [sharing the API key](../how-to/project-sharing.md).
 - Limit the number of networks or services per API key only to the necessary endpoints.
 - Group the API key endpoints based on shared security considerations such as

--- a/developer-tools/dashboard/how-to/troubleshoot.md
+++ b/developer-tools/dashboard/how-to/troubleshoot.md
@@ -7,7 +7,7 @@ sidebar_position: 9
 
 ### Suspicious activity detected during registration
 
-If you receive a "Suspicious activity detected" message during registration, it might be for of one of the following
+If you receive a "Suspicious activity detected" message during registration, it might be for one of the following
 reasons:
 
 - You have another account: Infura does not allow users to create multiple accounts, so if


### PR DESCRIPTION
#### Description
- Fixed typographical errors in the "create-api.md" and "troubleshoot.md" files.
- In "create-api.md", corrected the word "seperate" to "separate".
- In "troubleshoot.md", corrected the word "of" (which was extra) in the sentence "might be for of one of the following reasons."

#### Issue(s) fixed
- There are no specific issue numbers mentioned, but this can be linked to issues related to typographical errors in the documentation.

#### Preview
- The changes have been previewed in the respective documentation files.

#### Checklist
- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
