### PR TITLE
Fix grammar and wording

### DIFF
--- a/services/concepts/gas.md
+++ b/services/concepts/gas.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 # Gas
 
 Gas is a unit used to measure the computational effort required to perform an action on a blockchain network, such as
-executing a smart contract or sending a transaction. To perform an action, users must pay in units of gas, which is
+executing a smart contract or sending a transaction. To perform an action, users must pay in units of gas, which are
 calculated based on the computational resources required for the action, and to compensate the miners who execute the
 request.
 

--- a/services/reference/ipfs/http-api-methods/add.md
+++ b/services/reference/ipfs/http-api-methods/add.md
@@ -69,4 +69,4 @@ On success, the call to this endpoint will return with 200 and the following bod
 
 - `Name` - Name of the object.
 - `Hash` - Hash of the uploaded object.
-- `Size` - Integer indication size in bytes.
+- `Size` - Integer indicating size in bytes.

--- a/wallet/connect/metamask-sdk/mobile/ios.md
+++ b/wallet/connect/metamask-sdk/mobile/ios.md
@@ -32,7 +32,7 @@ users to easily connect with their MetaMask Mobile wallet.
 <Tabs>
 <TabItem value="CocoaPods">
 
-To add the SDK as a CocoaPods dependency to your project, add the following entry to our Podfile:
+To add the SDK as a CocoaPods dependency to your project, add the following entry to your Podfile:
 
 ```text
 pod "metamask-ios-sdk"


### PR DESCRIPTION
Changes:
- gas.md: Changed "which is" to "which are" to match plural "units of gas"
- add.md: Changed "indication" to "indicating" to fix verb form
- ios.md: Changed "our Podfile" to "your Podfile" for consistent user addressing