### PR TITLE
Grammar and consistency improvements

### DIFF
--- a/services/reference/palm/index.md
+++ b/services/reference/palm/index.md
@@ -8,7 +8,7 @@ import CardList from '@site/src/components/CardList'
 
 The [Palm Network](https://palm.io/) is an Ethereum Virtual Machine-compatible Polygon Supernet. The Palm Network is for
 creators, fans, and leaders in various industries such as art, technology, sports, and entertainment. The network
-provides support to developers in their quest to build new and user-friendly tools that contributes to the growth of
+provides support to developers in their quest to build new and user-friendly tools that contribute to the growth of
 the Web3 ecosystem.
 
 :::info See also

--- a/snaps/reference/wallet-api-for-snaps.md
+++ b/snaps/reference/wallet-api-for-snaps.md
@@ -125,7 +125,7 @@ await window.ethereum.request({
     "enabled": true,
     "blocked": false
   },
-  "npm:foo-Snap": {
+  "npm:foo-snap": {
     "version": "1.0.5",
     "id": "npm:foo-snap",
     "enabled": true,

--- a/snaps/reference/wallet-api-for-snaps.md
+++ b/snaps/reference/wallet-api-for-snaps.md
@@ -91,7 +91,7 @@ The SemVer version ranges use the same semantics as npm `package.json` ranges.
 An object mapping the IDs of permitted Snaps to their metadata:
 
 - `id`: `string` - The ID of the Snap.
-- `initialPermissions`: `string` - The initial permissions of the Snap, which will be request when
+- `initialPermissions`: `string` - The initial permissions of the Snap, which will be requested when
   the Snap is installed.
 - `version`: `string` - The version of the Snap.
 - `enabled`: `boolean` - Indicates whether the Snap is enabled.
@@ -125,7 +125,7 @@ await window.ethereum.request({
     "enabled": true,
     "blocked": false
   },
-  "npm:fooSnap": {
+  "npm:foo-Snap": {
     "version": "1.0.5",
     "id": "npm:foo-snap",
     "enabled": true,

--- a/wallet/how-to/sign-data/index.md
+++ b/wallet/how-to/sign-data/index.md
@@ -195,7 +195,7 @@ It's often used for signature challenges that are authenticated on a web server,
 </p>
 
 Some other signers implement `personal_sign` as `eth_sign`, because the Go Ethereum client changed
-the behavior of their `eth_sign` method.
+the behavior of its `eth_sign` method.
 Because MetaMask supports existing applications, MetaMask implements both `personal_sign` and `eth_sign`.
 You might need to check what method your supported signers use for a given implementation.
 


### PR DESCRIPTION
Changes:
- Fixed verb agreement ("contributes" -> "contribute") for plural subject "tools"
- Corrected passive voice ("request" -> "requested") in permissions description
- Fixed package naming convention ("fooSnap" -> "foo-Snap") for consistency
- Updated possessive pronoun ("their" -> "its") for singular subject

These changes improve grammatical correctness and maintain consistent terminology throughout the documentation.
