### PR TITLE
Fixed typos and corrected broken links

### DIFF
--- a/snaps/get-started/install-flask.md
+++ b/snaps/get-started/install-flask.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 # Install MetaMask Flask
 
 To get started building your own Snaps, install the MetaMask Flask browser extension on
-[Google Chrome](https://chromewebstore.google.com/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk)
+[Google Chrome](https://chromewebstore.google.com/detail/metamask-flask-development/ljfoeinjpaedjfecbmggjgodbgkmjkjk)
 or
 [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/metamask-flask/).
 

--- a/snaps/how-to/allow-automatic-connections.md
+++ b/snaps/how-to/allow-automatic-connections.md
@@ -105,7 +105,7 @@ const MetaMaskFound = async (providerDetail) => {
 
 ## When to use initial connections
 
-The following scenarios showcase `initialConnection`'s usefulness, in order from most to least useful:
+The following scenarios showcase `initialConnections`'s usefulness, in order from most to least useful:
 
 #### Snap used by multiple dapps
 

--- a/snaps/how-to/get-allowlisted.md
+++ b/snaps/how-to/get-allowlisted.md
@@ -9,7 +9,7 @@ Once you have built your Snap, tested it, and published it to npm, you can make 
 
 If your Snap only uses [open permissions](#open-permissions), anyone can install it on the MetaMask extension.
 However, third-party Snaps that use
-[protected permissions](#open-permissions)
+[protected permissions](#protected-permissions)
 must be put on an allowlist before users can install them.
 This means that at this time, for Snaps that use protected permissions, only those that are reviewed by MetaMask can be installed.
 In the future, this system will be opened up.


### PR DESCRIPTION
# Description

This pull request addresses the following issues:

1. **Fixed URL typo in MetaMask Flask link (snaps/get-started/install-flask.md)**  
   The first link to the MetaMask Flask extension for Chrome contained a typo in the URL:
   - **Incorrect**: `metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk`
   - **Correct**: `metamask-flask-development/ljfoeinjpaedjfecbmggjgodbgkmjkjk`

   This fix is important because the incorrect URL would lead to a broken link, preventing users from accessing the correct MetaMask Flask extension.

2. **Fixed inconsistency in the "initialConnection" field name (snaps/how-to/allow-automatic-connections.md)**  
   The field name "initialConnection" was used inconsistently. It should be "initialConnections" to match the correct JSON configuration field name. This change ensures that the documentation is accurate and consistent with the actual implementation.

3. **Corrected broken Markdown link to "protected permissions" (snaps/how-to/get-allowlisted.md)**  
   The Markdown link in this section was incorrect:
   - **Incorrect**: `[protected permissions](#open-permissions)`
   - **Correct**: `[protected permissions](#protected-permissions)`

   This fix is necessary as the original link led to the wrong section, causing confusion for users trying to find information about protected permissions. The link now correctly directs to the section discussing protected permissions.

---

These fixes improve the accuracy and usability of the documentation by ensuring users can access the correct information.

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.
