### PR TITLE
Fix grammatical issues in `notifications.md` and `secure-dapp.md`

### DIFF
--- a/snaps/features/notifications.md
+++ b/snaps/features/notifications.md
@@ -31,7 +31,7 @@ display the notification in the user's OS.
 :::note
 We recommend using `type: "inApp"` because there's no guarantee that native notifications are
 displayed to the user.
-You can also call `snap_notify` twice, which each notification type, to trigger both an in-app and
+You can also call `snap_notify` twice, with each notification type, to trigger both an in-app and
 native notification.
 :::
 

--- a/wallet/how-to/secure-dapp.md
+++ b/wallet/how-to/secure-dapp.md
@@ -14,7 +14,7 @@ The following security advice isn't exhaustive.
 
 ## Use HTTPS
 
-HTTPS can protect your dapp against attackers who might try to eavesdrop or tamper the communication
+HTTPS can protect your dapp against attackers who might try to eavesdrop or tamper with the communication
 channel between your dapp and your users.
 HTTPS encrypts data transmitted between the web server and the user's browser, making it
 difficult for attackers to intercept or modify the data.


### PR DESCRIPTION
### Description

This pull request includes minor corrections to the documentation files `notifications.md` and `secure-dapp.md` to fix grammatical issues and improve readability.

### Changes made:
1. **`notifications.md`:**
   - Corrected a grammatical error by replacing "which" with "with" in a sentence explaining the use of `snap_notify`.

2. **`secure-dapp.md`:**
   - Improved sentence structure by adding "with" to clarify the context in a sentence about the benefits of HTTPS.

### Preview

Changes can be reviewed in the following files:
- [`notifications.md`](link-to-preview)
- [`secure-dapp.md`](link-to-preview)

### Checklist

- [x] Fixes grammatical issues.
- [ ] Reviewed and approved by a documentation team member.
