### PR TITLE
feat(ref): improved eth_decrypt method flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@intercom/messenger-js-sdk": "^0.0.14",
         "@mdx-js/react": "^3.0.0",
         "@metamask/design-tokens": "^1.11.1",
+        "@metamask/eth-sig-util": "^7.0.3",
         "@metamask/profile-sync-controller": "^0.9.6",
         "@metamask/sdk": "^0.31.1",
         "@rjsf/core": "^5.22.1",
@@ -4178,6 +4179,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-7.0.3.tgz",
       "integrity": "sha512-PAtGnOkYvh90k2lEZldq/FK7GTLF6WxE+2bV85PoA3pqlJnmJCAY62tuvxHSwnVngSKlc4mcNvjnUg2eYO6JGg==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "@metamask/abi-utils": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@intercom/messenger-js-sdk": "^0.0.14",
     "@mdx-js/react": "^3.0.0",
     "@metamask/design-tokens": "^1.11.1",
+    "@metamask/eth-sig-util": "^7.0.3",
     "@metamask/profile-sync-controller": "^0.9.6",
     "@metamask/sdk": "^0.31.1",
     "@rjsf/core": "^5.22.1",

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -65,6 +65,8 @@ interface IMetamaskProviderContext {
   userAPIKey?: string;
   setUserAPIKey?: (key: string) => void;
   fetchLineaEns?: (walletId: string) => Promise<void>;
+  userEncPublicKey?: string;
+  setUserEncPublicKey?: (key: string) => void;
 }
 
 export const MetamaskProviderContext = createContext<IMetamaskProviderContext>({
@@ -90,6 +92,8 @@ export const MetamaskProviderContext = createContext<IMetamaskProviderContext>({
   userAPIKey: "",
   setUserAPIKey: () => {},
   fetchLineaEns: () => new Promise(() => {}),
+  userEncPublicKey: undefined,
+  setUserEncPublicKey: () => {},
 });
 
 const sdk = new MetaMaskSDK({
@@ -122,6 +126,7 @@ export const LoginProvider = ({ children }) => {
   const [needsMfa, setNeedsMfa] = useState<boolean>(false);
   const [walletAuthUrl, setWalletAuthUrl] = useState<string>("");
   const [userAPIKey, setUserAPIKey] = useState("");
+  const [userEncPublicKey, setUserEncPublicKey] = useState(undefined);
   const { siteConfig } = useDocusaurusContext();
   const { DASHBOARD_URL, GF_SURVEY_KEY, LINEA_ENS_URL } = siteConfig?.customFields || {};
 
@@ -289,6 +294,8 @@ export const LoginProvider = ({ children }) => {
           userAPIKey,
           setUserAPIKey,
           fetchLineaEns,
+          userEncPublicKey,
+          setUserEncPublicKey,
         } as IMetamaskProviderContext
       }
     >


### PR DESCRIPTION
## Description

- Improvements to the interactive flow of the `eth_decrypt` method

## Test

1) go to the **/wallet/reference/json-rpc-methods/eth_getencryptionpublickey/** page to get the public key
  1.1 connect to the mm browser extension (click on the "Connect Wallet" button)
  1.2 click on the "Run request" button
  1.3 confirm the request in the extension by clicking on "Provide"
  
![Screenshot 2024-12-03 at 14 50 14](https://github.com/user-attachments/assets/a7b0e3fd-4bb3-408e-8991-14fccd8f8956)

![Screenshot 2024-12-03 at 14 51 50](https://github.com/user-attachments/assets/30248ca3-7292-4db1-8da5-7389d0acd5cd)


2) Go to the page **/wallet/reference/json-rpc-methods/eth_decrypt/**
  2.1 click on the "Run request" button and in the extension that opens, click on the lock icon/"Decrypt message"
  2.2 check that the message also appeared in the response section
  
![Screenshot 2024-12-03 at 14 53 57](https://github.com/user-attachments/assets/9f96e548-a07f-40a8-858c-25463d193691)

![Screenshot 2024-12-03 at 15 07 33](https://github.com/user-attachments/assets/b71f6cdc-ece7-4e2c-b7a3-b933ba3a0e62)

