### PR TITLE
Snaps: add `snap_getInterfaceContext`

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,11 @@ The latest major MetaMask documentation updates are listed by the month they wer
 For a comprehensive list of recent product changes, visit the "Release Notes" section at the bottom
 of the [MetaMask developer page](https://metamask.io/developer/).
 
+## December 2024
+
+- Documented [`snap_getInterfaceContext`](/snaps/reference/snaps-api/#snap_getinterfacecontext).
+  ([#1772](https://github.com/MetaMask/metamask-docs/pull/1772))
+
 ## November 2024
 
 - Documented [Unichain Sepolia](/services/reference/unichain) support. ([#1725](https://github.com/MetaMask/metamask-docs/pull/1725))

--- a/snaps/features/custom-ui/interactive-ui.md
+++ b/snaps/features/custom-ui/interactive-ui.md
@@ -58,17 +58,13 @@ The following is an example flow:
 5. Custom logic sends the funds.
 6. `snap_updateInterface` is called again, replacing the whole UI with a success message.
 
-## Get an interactive interface's state
+## Get an interactive interface's state and context
 
-At any point you can retrieve an interactive interface's state.
-To do this, call the [`snap_getInterfaceState`](../../reference/snaps-api.md#snap_getinterfacestate)
-method with the ID of the interface.
-
-### Get an interactive interface's context
-
-At any point you can retrieve an interactive interface's context.
-To do this, call the [`snap_getInterfaceContext`](../../reference/snaps-api.md#snap_getinterfacecontext)
-method with the ID of the interface.
+At any point, you can retrieve an interactive interface's state and context.
+To retrieve its state, call the [`snap_getInterfaceState`](../../reference/snaps-api.md#snap_getinterfacestate)
+method with the interface ID.
+To retrieve its context, call [`snap_getInterfaceContext`](../../reference/snaps-api.md#snap_getinterfacecontext)
+with the interface ID.
 
 ## Example
 

--- a/snaps/features/custom-ui/interactive-ui.md
+++ b/snaps/features/custom-ui/interactive-ui.md
@@ -64,6 +64,12 @@ At any point you can retrieve an interactive interface's state.
 To do this, call the [`snap_getInterfaceState`](../../reference/snaps-api.md#snap_getinterfacestate)
 method with the ID of the interface.
 
+### Get an interactive interface's context
+
+At any point you can retrieve an interactive interface's context.
+To do this, call the [`snap_getInterfaceContext`](../../reference/snaps-api.md#snap_getinterfacecontext)
+method with the ID of the interface.
+
 ## Example
 
 See the [`@metamask/interactive-ui-example-snap`](https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/interactive-ui)

--- a/snaps/reference/snaps-api.md
+++ b/snaps/reference/snaps-api.md
@@ -986,6 +986,52 @@ console.log(state)
 */
 ```
 
+### `snap_getInterfaceContext`
+
+Gets the context of an interactive interface by its ID.
+For use in [interactive UI](../features/custom-ui/interactive-ui.md).
+
+#### Parameters
+
+- `id` - The ID of the interface.
+
+#### Returns
+
+An object of type `InterfaceContext` if a custom context object was passed when creating or updating the interface, or `null`.
+
+#### Example
+
+```js title="index.js"
+const interfaceId = await snap.request({
+  method: "snap_createInterface",
+  params: {
+    ui: (
+      <Box>
+        <Heading>Hello, world!</Heading>
+        <Text>Welcome to my Snap homepage!</Text>
+      </Box>
+    ),
+    context: { 
+      key: "value"
+    }
+  },
+})
+
+const context = await snap.request({
+  method: "snap_getInterfaceContext",
+  params: {
+    id: interfaceId,
+  },
+})
+
+console.log(context)
+/*
+{
+  "key": "value"
+}
+*/
+```
+
 ### `snap_resolveInterface`
 
 Resolves an interactive interface.


### PR DESCRIPTION
# Description

Added the method to Snaps API, and added a reference in the Snaps Custom UI Feature page

## Issue(s) fixed

Fixes #1770 

## Preview

https://metamask-docs-git-snaps-add-getinterf-54ee1c-consensys-ddffed67.vercel.app/snaps/reference/snaps-api/#snap_getinterfacecontext

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
