### PR TITLE
Add tech-writers as default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,22 +2,7 @@
 # so the listed codeowners apply only if there is no later match.
 
 # Default owner for all other files
-* @MetaMask/activation
-
-# Docusaurus configuration
-docusaurus.config.js @MetaMask/activation @MetaMask/tech-writers
-
-# GitHub workflows and templates
-/.github/ @MetaMask/activation @MetaMask/tech-writers
-
-# Static image and video files
-/static/ @MetaMask/activation @MetaMask/tech-writers
-
-# Vercel configuration
-vercel.json @MetaMask/activation @MetaMask/tech-writers
-
-# Sidebar files
-*-sidebar.js @MetaMask/activation @MetaMask/tech-writers
+* @MetaMask/activation @MetaMask/tech-writers
 
 # All other Markdown files
 *.md @MetaMask/tech-writers


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Add technical writers group as additional default codeowner for all files.

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
