### PR TITLE
Update link format 

### DIFF
--- a/wallet/how-to/run-devnet.md
+++ b/wallet/how-to/run-devnet.md
@@ -90,7 +90,7 @@ Follow these steps to connect MetaMask to Hardhat Network.
 ## Reset your local nonce calculation
 
 If you restart your development network, you can accidentally confuse MetaMask
-because it calculates the next [nonce](send-transactions.md#nonce) based on both the
+because it calculates the next [nonce](/send-transactions.md#nonce) based on both the
 network state _and_ the known sent transactions.
 
 To clear MetaMask's transaction queue and reset its nonce calculation, go to **Settings > Advanced**


### PR DESCRIPTION
Update link format in run-devnet.md

Changed in wallet/how-to/run-devnet.md:
Old: [nonce] (send-transactions.md#nonce)
New: [nonce] (/send-transactions.md#nonce)

Added leading forward slash to fix internal documentation link path and maintain consistency with MetaMask's documentation system.