### PR TITLE
Fix typos in documentation

### DIFF
--- a/developer-tools/dashboard/get-started/create-api.md
+++ b/developer-tools/dashboard/get-started/create-api.md
@@ -13,7 +13,7 @@ Based on your plan, Infura allows for the following amount of API keys:
 - Developer plan - Allows up to five API keys.
 - Team plans and higher - No limit on the number of API keys.
 
-For more information, see to the [Infura pricing page](https://www.infura.io/pricing).
+For more information, see the [Infura pricing page](https://www.infura.io/pricing).
 
 :::
 

--- a/wallet/reference/sdk-js-options.md
+++ b/wallet/reference/sdk-js-options.md
@@ -117,7 +117,7 @@ The metadata options are:
 - `iconUrl` - URL of the dapp's icon
 
 :::tip important
-Setting `dappMetaData` creates a clear and trustworthy user experience when connecting your dapp to
+Setting `dappMetadata` creates a clear and trustworthy user experience when connecting your dapp to
 MetaMask Mobile.
 MetaMask Mobile displays this metadata in the connection modal to help users identify and verify the
 connection request.


### PR DESCRIPTION


Changes:
1. developer-tools/dashboard/get-started/create-api.md:
- Changed: "see to the" → "see the"
- Reason: Correct English grammar for documentation references

2. wallet/reference/sdk-js-options.md:
- Changed: "dappMetaData" → "dappMetadata" 
- Reason: Fixed camelCase naming convention in JavaScript

These changes improve documentation accuracy and maintain consistent code style conventions without affecting functionality.