### PR TITLE
Add dashboard team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # so the listed codeowners apply only if there is no later match.
 
 # Default owner for all other files
-* @MetaMask/activation @MetaMask/tech-writers
+* @MetaMask/dashboard @MetaMask/tech-writers
 
 # All other Markdown files
 *.md @MetaMask/tech-writers


### PR DESCRIPTION
# Description

- Replace `Activation` with `Dashboard` team CODEOWNERS
