### PR TITLE
fix: don't show 'install MetaMask' when inside app

### DIFF
--- a/src/components/NavbarWallet/index.tsx
+++ b/src/components/NavbarWallet/index.tsx
@@ -49,7 +49,11 @@ const NavbarWalletComponent: FC = ({
   } = useContext(MetamaskProviderContext);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [copyMessage, setCopyMessage] = useState(COPY_TEXT);
+
+  const isMobile = sdk.platformManager?.isMobile ?? false;
   const isExtensionActive = sdk.isExtensionActive();
+  const showInstallButton = !isExtensionActive && !isMobile;
+
   const dialogRef = useRef<HTMLUListElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [userAccount, setUserAccount] = useState(
@@ -119,7 +123,7 @@ const NavbarWalletComponent: FC = ({
 
   const handleConnectWallet = () => {
     trackClickForSegment({
-      eventName: !isExtensionActive ? "Install MetaMask" : "Connect Wallet",
+      eventName: showInstallButton ? "Install MetaMask" : "Connect Wallet",
       clickType: "Navbar",
       userExperience: "B",
       responseStatus: null,
@@ -142,7 +146,7 @@ const NavbarWalletComponent: FC = ({
   return !userAccount ? (
     <Button
       testId={
-        !isExtensionActive
+        showInstallButton
           ? "navbar-cta-install-metamask"
           : "navbar-cta-connect-wallet"
       }
@@ -150,7 +154,7 @@ const NavbarWalletComponent: FC = ({
       onClick={handleConnectWallet}
       className={styles.navbarButton}
     >
-      {!isExtensionActive ? "Install MetaMask" : "Connect MetaMask"}
+      {showInstallButton ? "Install MetaMask" : "Connect MetaMask"}
     </Button>
   ) : (
     <div className={styles.navbarWallet}>


### PR DESCRIPTION
## Issue(s) fixed
The CTA in the header would always suggest the user install metamask on mobile. This changes the logic ot be inline with the faucet page.

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
