### PR TITLE
Fix typos and spelling errors

### DIFF
--- a/services/concepts/web3-libraries.md
+++ b/services/concepts/web3-libraries.md
@@ -24,7 +24,7 @@ The following image shows how a Web3 library can connect to your node (in this e
   </div>
 </div>
 
-Some popular Ethereum compatible Web3 libraries include (but are not limited to) the following.
+Some popular Ethereum-compatible Web3 libraries include (but are not limited to) the following.
 
 | Language   | Library                                                                                             |
 | :--------- | :-------------------------------------------------------------------------------------------------- |

--- a/services/reference/_partials/trace-methods/_trace_block-response.mdx
+++ b/services/reference/_partials/trace-methods/_trace_block-response.mdx
@@ -42,7 +42,7 @@ import TabItem from "@theme/TabItem"
       "traceAddress": [0],
       "transactionHash": "0x91eeabc671e2dd2b1c8ddebb46ba59e8cb3e7d189f80bcc868a9787728c6e59e",
       "transactionPosition": 0,
-      "type": "suicide"
+      "type": "selfdestruct"
     },
     {
       "action": {


### PR DESCRIPTION
changed: 

Ethereum compatible Web3 - Ethereum-compatible Web3

suicide - selfdestruct (This is an outdated term in Ethereum. Since 2015, the term "suicide" has been replaced with "selfdestruct" in Ethereum documentation and code)