### PR TITLE
remove max-width on container for ulta-wide displays

### DIFF
--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -210,10 +210,6 @@ body {
   @include bp('tablet') {
     max-width: none;
   }
-
-  @include bp('desktop') {
-    max-width: var(--site-container-max-width);
-  }
 }
 
 // Page Padding (Header Height)


### PR DESCRIPTION
# Description

- Remove `max-width` causing ultra wide displays to break
