### PR TITLE
grammar and spelling errors

### DIFF
--- a/src/components/Faucet/Faq.tsx
+++ b/src/components/Faucet/Faq.tsx
@@ -69,7 +69,7 @@ export default function Faq({ network, className, classNameHeading, isLimitedUse
           {isLimitedUserPlan && (
             <Accordion>
               <Text as="h3" className={styles.accordionHeader}>
-                Why must my address have Ethereum Mainnet activity to claim Linea ETH?x
+                Why must my address have Ethereum Mainnet activity to claim Linea ETH?
               </Text>
               <Text as="p" className={styles.accordionContainer}>
                 MetaMask requires an address with Ethereum Mainnet activity to safeguard the faucet

--- a/wallet/how-to/use-non-evm-networks/starknet/send-starknet-transactions.md
+++ b/wallet/how-to/use-non-evm-networks/starknet/send-starknet-transactions.md
@@ -169,7 +169,7 @@ The following is a full, simplified example of connecting to a Starknet account 
         params: {
           snapId: "npm:@consensys/starknet-snap",
           request: {
-            method: "starkNet_executeTxn"
+            method: "starkNet_executeTxn",
             params: requestParams
           }
         }


### PR DESCRIPTION
ETH?x - ETH?

"starkNet_executeTxn" - "starkNet_executeTxn",