### PR TITLE
Adjust hero desktop font size

### DIFF
--- a/src/components/Hero/Hero.module.scss
+++ b/src/components/Hero/Hero.module.scss
@@ -87,6 +87,7 @@
   color: var(--developer-purple-light);
   margin-top: 4rem;
   font-family: var(--ifm-heading-font-family);
+  word-wrap: normal;
   @include bp('tablet') {
     margin-top: 1.4rem;
   }

--- a/src/scss/commons/_typescale.scss
+++ b/src/scss/commons/_typescale.scss
@@ -181,7 +181,7 @@ a.text-decoration-underline {
   }
 
   @include bp('desktop') {
-    font-size: 6rem;
+    font-size: 5.5rem;
     line-height: 113.333%;
   }
 }


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

The main "MetaMask developer documentation" title has an awkward line break in "documentation" for narrow/vertical viewport sizes (e.g., 1200x1920 or 1280x720). This PR adjusts the desktop font size to the largest that doesn't have the line break for those standard sizes.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->
Current:
![Screenshot 2025-03-06 at 8 08 09 AM](https://github.com/user-attachments/assets/e3a620f2-7a57-4e0b-a28f-6d2335c3e3b8)

Adjusted:
![Screenshot 2025-03-06 at 8 09 10 AM](https://github.com/user-attachments/assets/8237b9e1-af55-4fd9-baa3-955a7e7eab27)

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
