### PR TITLE
Adjust fonts in RPC reference

### DIFF
--- a/src/components/ParserOpenRPC/DetailsBox/index.tsx
+++ b/src/components/ParserOpenRPC/DetailsBox/index.tsx
@@ -48,7 +48,7 @@ export default function DetailsBox({
       {summary !== null && (
         <p
           style={{ marginBottom: '0.5rem' }}
-          className={clsx('padding-bottom--md', styles.borderBottomLine)}>
+          className={clsx('padding-bottom--md', styles.borderBottomLine, styles.methodSummary)}>
           <strong>Summary: </strong>
           <span className={styles.summaryText}>
             <MDContent content={summary} />
@@ -56,7 +56,7 @@ export default function DetailsBox({
         </p>
       )}
       {description !== null && (
-        <div className="padding-top--md">
+        <div className={clsx("padding-top--md", styles.methodDescription)}>
           <MDContent content={description} />
         </div>
       )}
@@ -68,7 +68,7 @@ export default function DetailsBox({
       </Heading>
       <div className={styles.paramContainer}>
         {params.length === 0 ? (
-          <div className="padding-vert--md">This method doesn't accept any parameters.</div>
+          <div className={clsx("padding-vert--md", styles.noParamsDescription)}>This method doesn't accept any parameters.</div>
         ) : (
           params && renderParamSchemas(params, components)
         )}

--- a/src/components/ParserOpenRPC/DetailsBox/styles.module.scss
+++ b/src/components/ParserOpenRPC/DetailsBox/styles.module.scss
@@ -73,6 +73,7 @@
 .enumWrapper {
   border: 1px solid var(--general-gray-light);
   margin-bottom: 2rem;
+  font-size: 1.4rem;
 }
 
 .enumItem {
@@ -137,6 +138,14 @@
     height: 2.3rem;
     line-height: 0.85;
   }
+}
+
+.methodSummary {
+  font-style: italic;
+}
+
+.methodDescription, .noParamsDescription {
+  font-size: 1.6rem;
 }
 
 html[data-theme='dark'] {

--- a/src/components/ParserOpenRPC/ModalDrawer/styles.module.scss
+++ b/src/components/ParserOpenRPC/ModalDrawer/styles.module.scss
@@ -56,6 +56,7 @@
   font-size: 1.8rem;
   line-height: 1;
   font-weight: 500;
+  font-family: var(--ifm-font-family-base);
 }
 
 .modalTitleContainer {


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Minor fixes to font issues in interactive RPC reference:

- Reduce font size of method description
- Italicize method summary
- Reduce font size of parameter description when there are no parameters
- Reduce font size of enum values
- Change customization box titles from monospace to non-monospace font

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #1923

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://metamask-docs-git-1923-adjust-rpc-ref-9af636-consensys-ddffed67.vercel.app/wallet/reference/json-rpc-methods/wallet_watchasset/

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
