### PR TITLE
Remove Browserify bundler option

### DIFF
--- a/snaps/reference/cli/options.md
+++ b/snaps/reference/cli/options.md
@@ -14,37 +14,6 @@ This reference describes the syntax of the Snaps command line interface (CLI) co
 You can specify these options in the
 [configuration file](../../learn/about-snaps/files.md#configuration-file).
 
-### `bundler`
-
-<Tabs>
-<TabItem value="Syntax">
-
-```javascript
-bundler: <BUNDLER>,
-```
-
-</TabItem>
-<TabItem value="Example">
-
-```javascript
-bundler: "webpack",
-```
-
-</TabItem>
-</Tabs>
-
-The bundler to use.
-The options are `"webpack"` and `"browserify"`.
-The default is `"webpack"`.
-
-:::caution important
-We recommend using the Webpack bundler.
-The Browserify-based configuration is deprecated and will be removed in the future.
-This reference describes the configuration options for Webpack.
-For Browserify, see the
-[legacy options](https://github.com/MetaMask/snaps/tree/455366f19281801ed4220431100e45237dd5cf1e/packages/snaps-cli#legacy-options).
-:::
-
 ### `customizeWebpackConfig`
 
 <Tabs>


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Remove `bundler` option because Webpack is the default, and only value used. Browserify is no longer supported and we can remove mention of it.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #1971

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
