### PR TITLE
Add hoodi support.

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,6 +11,7 @@ of the [MetaMask developer page](https://metamask.io/developer/).
 
 ## April 2025
 
+- Documented [Ethereum Hoodi testnet](/services/get-started/endpoints/#ethereum) support. [#1977](https://github.com/MetaMask/metamask-docs/pull/1977)
 - Documented [how to use deeplinks](/sdk/guides/use-deeplinks).
   ([#1928](https://github.com/MetaMask/metamask-docs/pull/1928))
 - Documented [MetaMask SDK + Dynamic SDK integration](/sdk/quickstart/javascript-dynamic).

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,7 +11,7 @@ of the [MetaMask developer page](https://metamask.io/developer/).
 
 ## April 2025
 
-- Documented [Ethereum Hoodi testnet](/services/get-started/endpoints/#ethereum) support. [#1977](https://github.com/MetaMask/metamask-docs/pull/1977)
+- Documented [Ethereum Hoodi testnet](/services/get-started/endpoints/#ethereum) support. ([#1977](https://github.com/MetaMask/metamask-docs/pull/1977))
 - Documented [how to use deeplinks](/sdk/guides/use-deeplinks).
   ([#1928](https://github.com/MetaMask/metamask-docs/pull/1928))
 - Documented [MetaMask SDK + Dynamic SDK integration](/sdk/quickstart/javascript-dynamic).

--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -66,12 +66,20 @@ Ensure that you replace `<YOUR-API-KEY>` with an API key from your [MetaMask Dev
 
 ## Ethereum
 
+:::warning Holesky deprecation
+The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
+Switch to the Hoodi testnet, now available on Infura via
+[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
+:::
+
 | Network           | Description             | URL                                            |
 |-------------------|-------------------------|------------------------------------------------|
 | Mainnet           | JSON-RPC over HTTPS     | `https://mainnet.infura.io/v3/<YOUR-API-KEY>`  |
 | Mainnet           | JSON-RPC over WebSocket | `wss://mainnet.infura.io/ws/v3/<YOUR-API-KEY>` |
 | Testnet (Holesky) | JSON-RPC over HTTPS     | `https://holesky.infura.io/v3/<YOUR-API-KEY>`  |
 | Testnet (Holesky) | JSON-RPC over WebSocket | `wss://holesky.infura.io/ws/v3/<YOUR-API-KEY>` |
+| Testnet (Hoodi)   | JSON-RPC over HTTPS     | `https://hoodi.infura.io/v3/<YOUR-API-KEY>`    |
+| Testnet (Hoodi)   | JSON-RPC over WebSocket | `wss://hoodi.infura.io/ws/v3/<YOUR-API-KEY>`   |
 | Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://sepolia.infura.io/v3/<YOUR-API-KEY>`  |
 | Testnet (Sepolia) | JSON-RPC over WebSocket | `wss://sepolia.infura.io/ws/v3/<YOUR-API-KEY>` |
 

--- a/services/reference/ethereum/index.md
+++ b/services/reference/ethereum/index.md
@@ -6,6 +6,12 @@ import CardList from '@site/src/components/CardList'
 
 # Ethereum
 
+:::warning Holesky deprecation
+The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
+Switch to the Hoodi testnet, now available on Infura via
+[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
+:::
+
 Ethereum is a decentralized, open-source blockchain network with [Turing-complete](https://en.wikipedia.org/wiki/Turing_completeness)
 smart contract functionality. Ether (ETH) is the native cryptocurrency.
 

--- a/services/reference/ethereum/json-rpc-methods/index.md
+++ b/services/reference/ethereum/json-rpc-methods/index.md
@@ -2,6 +2,12 @@
 title: JSON-RPC methods
 ---
 
+:::warning Holesky deprecation
+The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
+Switch to the Hoodi testnet, now available on Infura via
+[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
+:::
+
 import ErrorCodes from "../../_partials/error-codes.mdx";
 
 <ErrorCodes />


### PR DESCRIPTION
# Description

Added Hoodi testnet support and added a deprecation notice for Holesky

## Preview
https://metamask-docs-git-hoodi-consensys-ddffed67.vercel.app/services/get-started/endpoints/#ethereum

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.
