### PR TITLE
Discontinue support for the Ethereum Holesky testnet.

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,10 @@ The latest major MetaMask documentation updates are listed by the month they wer
 For a comprehensive list of recent product changes, visit the "Release Notes" section at the bottom
 of the [MetaMask developer page](https://metamask.io/developer/).
 
+## May 2025
+
+- Discontinue Infura support for the Ethereum Holesky testnet. ([#1996](https://github.com/MetaMask/metamask-docs/pull/1996))
+
 ## April 2025
 
 - Documented [Ethereum Hoodi testnet](/services/get-started/endpoints/#ethereum) support. ([#1977](https://github.com/MetaMask/metamask-docs/pull/1977))

--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -66,18 +66,10 @@ Ensure that you replace `<YOUR-API-KEY>` with an API key from your [MetaMask Dev
 
 ## Ethereum
 
-:::warning Holesky deprecation
-The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
-Switch to the Hoodi testnet, now available on Infura via
-[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
-:::
-
 | Network           | Description             | URL                                            |
 |-------------------|-------------------------|------------------------------------------------|
 | Mainnet           | JSON-RPC over HTTPS     | `https://mainnet.infura.io/v3/<YOUR-API-KEY>`  |
 | Mainnet           | JSON-RPC over WebSocket | `wss://mainnet.infura.io/ws/v3/<YOUR-API-KEY>` |
-| Testnet (Holesky) | JSON-RPC over HTTPS     | `https://holesky.infura.io/v3/<YOUR-API-KEY>`  |
-| Testnet (Holesky) | JSON-RPC over WebSocket | `wss://holesky.infura.io/ws/v3/<YOUR-API-KEY>` |
 | Testnet (Hoodi)   | JSON-RPC over HTTPS     | `https://hoodi.infura.io/v3/<YOUR-API-KEY>`    |
 | Testnet (Hoodi)   | JSON-RPC over WebSocket | `wss://hoodi.infura.io/ws/v3/<YOUR-API-KEY>`   |
 | Testnet (Sepolia) | JSON-RPC over HTTPS     | `https://sepolia.infura.io/v3/<YOUR-API-KEY>`  |

--- a/services/reference/ethereum/index.md
+++ b/services/reference/ethereum/index.md
@@ -6,12 +6,6 @@ import CardList from '@site/src/components/CardList'
 
 # Ethereum
 
-:::warning Holesky deprecation
-The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
-Switch to the Hoodi testnet, now available on Infura via
-[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
-:::
-
 Ethereum is a decentralized, open-source blockchain network with [Turing-complete](https://en.wikipedia.org/wiki/Turing_completeness)
 smart contract functionality. Ether (ETH) is the native cryptocurrency.
 

--- a/services/reference/ethereum/json-rpc-methods/index.md
+++ b/services/reference/ethereum/json-rpc-methods/index.md
@@ -2,12 +2,6 @@
 title: JSON-RPC methods
 ---
 
-:::warning Holesky deprecation
-The Holesky testnet will be deprecated from the Infura service on May 1, 2025.
-Switch to the Hoodi testnet, now available on Infura via
-[Decentralized Infrastructure Network (DIN)](https://www.infura.io/solutions/decentralized-infrastructure-service).
-:::
-
 import ErrorCodes from "../../_partials/error-codes.mdx";
 
 <ErrorCodes />


### PR DESCRIPTION
# Description

Infura no longer provides access to the Ethereum Holesky testnet

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.
