### PR TITLE
Update react-native.md

### DIFF
--- a/sdk/quickstart/react-native.md
+++ b/sdk/quickstart/react-native.md
@@ -208,4 +208,4 @@ function App() {
 See the following examples on GitHub for more information:
 
 - [React Native demo](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/reactNativeDemo)
-- [Expo demo](https://github.com/MetaMask/metamask-sdk/tree/main/packages/examples/expo-demo)
+- Expo Demo is currently unavailable. 


### PR DESCRIPTION
Expo Demo repo had been deleted and was a broken link.

# Description

Removed line 211, expo repo no longer exists. Updated it stating example is currently unavailable. 

## Issue(s) fixed

Broken Link

Fixes #

Removed link

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
