### PR TITLE
Pressing enter is no longer allowed in interactive component

### DIFF
--- a/src/components/ParserOpenRPC/InteractiveBox/templates/BaseInputTemplate.tsx
+++ b/src/components/ParserOpenRPC/InteractiveBox/templates/BaseInputTemplate.tsx
@@ -83,6 +83,11 @@ export const BaseInputTemplate = ({
               type={isNumber ? 'number' : (schema.type as string)}
               pattern={schema.pattern}
               onChange={onInputChange}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                }
+              }}
               onFocus={() => {
                 setIsFocused(true)
               }}


### PR DESCRIPTION
# Description

Prevent Form Reset on Enter Key Press in RPC Parameter Customization

## Problem
When customizing parameters in the interactive RPC API reference, pressing the Enter key would unexpectedly reset all parameters back to their default values. This created friction in the user experience as users naturally expect to be able to press Enter when entering values in input fields.

## Solution
Added an `onKeyDown` event handler to the input elements in the `BaseInputTemplate` component to prevent the default form submission behavior when the Enter key is pressed.

## Testing
1. Open any RPC method documentation page
2. Click "Customize request" to open the parameter customization form
3. Enter values in any input field
4. Press Enter while typing - values should remain unchanged
5. Verify that form submission occurs

## Issue(s) fixed

Fixes #1924

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.
