### PR TITLE
fix: "environment" typos across the repository

### DIFF
--- a/delegation-toolkit/concepts/environment.md
+++ b/delegation-toolkit/concepts/environment.md
@@ -206,7 +206,7 @@ import {
 // remove-end
 
 // add-start
-+ const evniroment: DeleGatorEnvironment = {
++ const environment: DeleGatorEnvironment = {
 +  SimpleFactory: "0x124..",
 +  // ...
 +  implementations: {

--- a/delegation-toolkit/how-to/create-delegation/create-custom-caveat-enforcer.md
+++ b/delegation-toolkit/how-to/create-delegation/create-custom-caveat-enforcer.md
@@ -92,7 +92,7 @@ import {
 import { toHex } from "viem";
 import { delegatorSmartAccount } from "./config.ts";
 
-const environment = delegatorSmartAccount.enviroment;
+const environment = delegatorSmartAccount.environment;
 
 // Replace this with the address where the AfterTimestampEnforcer.sol contract is deployed.
 const afterTimestampEnforcer = "0x22Ae4c4919C3aB4B5FC309713Bf707569B74876F";

--- a/gator_versioned_docs/version-0.10.1/how-to/create-delegation/create-custom-caveat-enforcer.md
+++ b/gator_versioned_docs/version-0.10.1/how-to/create-delegation/create-custom-caveat-enforcer.md
@@ -92,7 +92,7 @@ import {
 import { toHex } from "viem";
 import { delegatorSmartAccount } from "./config.ts";
 
-const environment = delegatorSmartAccount.enviroment;
+const environment = delegatorSmartAccount.environment;
 
 // Replace this with the address where the AfterTimestampEnforcer.sol contract is deployed.
 const afterTimestampEnforcer = "0x22Ae4c4919C3aB4B5FC309713Bf707569B74876F";

--- a/gator_versioned_docs/version-0.10.2/how-to/create-delegation/create-custom-caveat-enforcer.md
+++ b/gator_versioned_docs/version-0.10.2/how-to/create-delegation/create-custom-caveat-enforcer.md
@@ -92,7 +92,7 @@ import {
 import { toHex } from "viem";
 import { delegatorSmartAccount } from "./config.ts";
 
-const environment = delegatorSmartAccount.enviroment;
+const environment = delegatorSmartAccount.environment;
 
 // Replace this with the address where the AfterTimestampEnforcer.sol contract is deployed.
 const afterTimestampEnforcer = "0x22Ae4c4919C3aB4B5FC309713Bf707569B74876F";

--- a/gator_versioned_docs/version-0.11.0/how-to/create-delegation/create-custom-caveat-enforcer.md
+++ b/gator_versioned_docs/version-0.11.0/how-to/create-delegation/create-custom-caveat-enforcer.md
@@ -92,7 +92,7 @@ import {
 import { toHex } from "viem";
 import { delegatorSmartAccount } from "./config.ts";
 
-const environment = delegatorSmartAccount.enviroment;
+const environment = delegatorSmartAccount.environment;
 
 // Replace this with the address where the AfterTimestampEnforcer.sol contract is deployed.
 const afterTimestampEnforcer = "0x22Ae4c4919C3aB4B5FC309713Bf707569B74876F";


### PR DESCRIPTION
# Description

Nothing fancy, just fixed "environment" typos in some .md files
