### PR TITLE
Fix broken dashboard API doc links in basefeehistory.md

### DIFF
--- a/services/reference/gas-api/api-reference/basefeehistory.md
+++ b/services/reference/gas-api/api-reference/basefeehistory.md
@@ -31,7 +31,7 @@ Array of historical base fees.
 
 ### Request
 
-Include your [API key](../../../../../developer-tools/dashboard/get-started/create-api.md)
+Include your [API key](/developer-tools/dashboard/get-started/create-api)
 and optional [API key secret](../../../../../developer-tools/dashboard/how-to/secure-an-api/api-key-secret.md)
 to authorize your account to use the APIs.
 

--- a/services/reference/gas-api/api-reference/basefeehistory.md
+++ b/services/reference/gas-api/api-reference/basefeehistory.md
@@ -31,8 +31,8 @@ Array of historical base fees.
 
 ### Request
 
-Include your [API key](../../../../../developer-tools/dashboard/get-started/create-api)
-and optional [API key secret](../../../../../developer-tools/dashboard/how-to/secure-an-api/api-key-secret/)
+Include your [API key](../../../../../developer-tools/dashboard/get-started/create-api.md)
+and optional [API key secret](../../../../../developer-tools/dashboard/how-to/secure-an-api/api-key-secret.md)
 to authorize your account to use the APIs.
 
 :::tip

--- a/services/reference/gas-api/api-reference/basefeehistory.md
+++ b/services/reference/gas-api/api-reference/basefeehistory.md
@@ -32,7 +32,7 @@ Array of historical base fees.
 ### Request
 
 Include your [API key](/developer-tools/dashboard/get-started/create-api)
-and optional [API key secret](../../../../../developer-tools/dashboard/how-to/secure-an-api/api-key-secret.md)
+and optional [API key secret](/developer-tools/dashboard/how-to/secure-an-api/api-key-secret)
 to authorize your account to use the APIs.
 
 :::tip


### PR DESCRIPTION
Updated two documentation links in basefeehistory.md to point to the correct files:
- Changed the API key link to get-started/create-api.md
- Changed the API key secret link to how-to/secure-an-api/api-key-secret.md
This ensures users are directed to the correct setup and security documentation.