### PR TITLE
Update metadata for Twitter image preview

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,6 +205,48 @@ const config = {
           name: "keywords",
           content: "MetaMask, SDK, Wallet, API, Dapp, App, Connect, Delegation, Toolkit, Documentation, Smart, Account, Snaps, Infura, Services, Dashboard",
         },
+        // Twitter-specific meta tags
+        {
+          name: "twitter:card",
+          content: "summary_large_image",
+        },
+        {
+          name: "twitter:image",
+          content: "https://docs.metamask.io/img/metamaskog.jpeg",
+        },
+        {
+          name: "twitter:image:alt",
+          content: "MetaMask Developer Documentation",
+        },
+        {
+          name: "twitter:site",
+          content: "@MetaMask",
+        },
+        {
+          name: "twitter:creator",
+          content: "@MetaMask",
+        },
+        // Open Graph meta tags for better social sharing
+        {
+          property: "og:image",
+          content: "https://docs.metamask.io/img/metamaskog.jpeg",
+        },
+        {
+          property: "og:image:width",
+          content: "1200",
+        },
+        {
+          property: "og:image:height",
+          content: "630",
+        },
+        {
+          property: "og:image:alt",
+          content: "MetaMask Developer Documentation",
+        },
+        {
+          property: "og:type",
+          content: "website",
+        },
       ],
       image: '/img/metamaskog.jpeg',
       colorMode: {


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

X.com images still not working after #2111 fix. This PR adds more Twitter-specific properties to the metadata.

The preview link still works to display the image in the X.com post composer.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://metamask-docs-9lv3y4ybe-consensys-ddffed67.vercel.app/

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
