### PR TITLE
Re-add Segment events for RPC interactive reference

### DIFF
--- a/src/components/ParserOpenRPC/AuthBox/index.tsx
+++ b/src/components/ParserOpenRPC/AuthBox/index.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import clsx from 'clsx'
 import Button from '@site/src/components/elements/buttons/button'
 import styles from './styles.module.scss'
+import { trackClickForSegment } from '@site/src/lib/segmentAnalytics'
 import { MetamaskProviderContext } from '@site/src/theme/Root'
 
 interface AuthBoxProps {
@@ -11,6 +12,14 @@ interface AuthBoxProps {
 export const AuthBox = ({ theme }: AuthBoxProps) => {
   const { metaMaskWalletIdConnectHandler } = useContext(MetamaskProviderContext)
   const connectHandler = () => {
+    trackClickForSegment({
+      eventName: 'Connect wallet',
+      clickType: 'Connect wallet',
+      userExperience: 'B',
+      responseStatus: null,
+      responseMsg: null,
+      timestamp: Date.now(),
+    })
     metaMaskWalletIdConnectHandler()
   }
   return (

--- a/src/lib/segmentAnalytics.js
+++ b/src/lib/segmentAnalytics.js
@@ -1,0 +1,32 @@
+export const trackClickForSegment = ({
+  eventName,
+  clickType,
+  userExperience,
+  responseStatus,
+  responseMsg,
+  timestamp,
+}) => {
+  if (window.analytics) {
+    window.analytics.track(`CTA ${clickType} Clicked`, {
+      ...(eventName && { event_name: eventName }),
+      ...(userExperience && { user_experience: userExperience }),
+      ...(responseStatus && { response_status: responseStatus }),
+      ...(responseMsg && { response_msg: responseMsg }),
+      ...(timestamp && { timestamp: timestamp }),
+    });
+  }
+};
+
+export const trackInputChangeForSegment = ({
+  eventName,
+  userExperience,
+  timestamp,
+}) => {
+  if (window.analytics) {
+    window.analytics.track("Input changed", {
+      ...(eventName && { event_name: eventName }),
+      ...(userExperience && { user_experience: userExperience }),
+      ...(timestamp && { timestamp: timestamp }),
+    });
+  }
+};


### PR DESCRIPTION
# Description

Add Segment events for tracking usage of the OpenRPC interactive component. Previously removed in #2119, these events still might useful to track going forward.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
