### PR TITLE
Change GTM plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,9 +204,9 @@ const config = {
     './src/plugins/launchdarkly',
     './src/plugins/sentry',
     [
-      '@docusaurus/plugin-google-gtag',
+      '@docusaurus/plugin-google-tag-manager',
       {
-        trackingID: 'GTM-5FGPLC2Q',
+        containerId: 'GTM-5FGPLC2Q',
       },
     ],
   ],


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

GTM was previously configured via [plugin-google-gtag](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) in #2124 (similar to [web3auth docs](https://github.com/Web3Auth/web3auth-docs/blob/master/docusaurus.config.ts#L216)).

However, growth marketing is detecting issues with this configuration ([Slack thread](https://consensys.slack.com/archives/C04R631UMM0/p1751379640991669?thread_ts=1750956985.531859&cid=C04R631UMM0)):
> I am seeing some activity on the GA4 account, meaning data is being pushed, but some pages are still untagged, and I am having trouble debugging on GTM. It could be because it is still propagating, but I need to check tomorrow to confirm. Can you please confirm the tag was properly set up on Docusaurus? I also created the custom definitions for the events parameters which could take up to 48h to propagate.

The [plugin-google-tag-manager](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-tag-manager) plugin is more explicitly documented for use with GTM-X container IDs to convert to the GTM.js script, and other sites (such as [Linea](https://github.com/Consensys/doc.linea/blob/main/docusaurus.config.js#L292)) use that plugin.

Since we are on a time crunch for this ticket, this PR changes the plugin back to the GTM plugin. cc @shahbaz17 

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
