### PR TITLE
Remove SDK node.js snippet

### DIFF
--- a/sdk/connect/javascript.md
+++ b/sdk/connect/javascript.md
@@ -77,27 +77,6 @@ const result = await ethereum.request({
 ```
 
 </TabItem>
-<TabItem value="Node.js">
-
-```javascript
-import { MetaMaskSDK } from "@metamask/sdk"
-
-const MMSDK = new MetaMaskSDK({
-  dappMetadata: {
-    name: "Node.js dapp",
-  },
-  infuraAPIKey: process.env.INFURA_API_KEY,
-})
-
-// Connect and get accounts
-const accounts = await MMSDK.connect()
-console.log("Connected accounts:", accounts)
-
-// Access provider
-const provider = MMSDK.getProvider()
-```
-
-</TabItem>
 </Tabs>
 
 ### 3. Configure the SDK


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Remove Node.js snippet from SDK JS guide. The SDK cannot run in Node.js because it's designed to work only in browser environments. The SDK requires:

- Access to the window object (which doesn't exist in Node.js)
- A user interface to connect MetaMask and request accounts
- Interaction with MetaMask extension or MetaMask mobile via browser

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
