### PR TITLE
Add infuraAPIKey in the Next.js Guide

### DIFF
--- a/sdk/connect/javascript-wagmi.md
+++ b/sdk/connect/javascript-wagmi.md
@@ -146,7 +146,11 @@ For example:
 const config = createConfig({
   ssr: true, // Make sure to enable this for server-side rendering (SSR) applications.
   chains: [mainnet, linea, lineaSepolia],
-  connectors: [metaMask()],
+  connectors: [
+    metaMask({
+      infuraAPIKey: process.env.NEXT_PUBLIC_INFURA_API_KEY!,
+    }),
+  ],
   transports: {
     [mainnet.id]: http(),
     [linea.id]: http(),


### PR DESCRIPTION

# Description

Adding `infuraAPIKey`, [suggested](https://docs.google.com/document/d/13IQdvA0dkLyjmF1HYN4eESMd4jkB4Ly2ScTcbelZIJ4/edit?tab=t.0#task=zbTT5a-Vp1YKCIgU) by the Dashboard team.

## Preview

https://metamask-docs-git-fix-missing-keys-step-consensys-ddffed67.vercel.app/sdk/connect/javascript-wagmi/#3-configure-your-project

## Checklist

Complete this checklist before merging your PR:

- [ ] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [ ] The proposed changes have been reviewed and approved by a member of the documentation team.
