### PR TITLE
fix: update search bar key color to address contrast issues

### DIFF
--- a/src/scss/theme/_doc-search.scss
+++ b/src/scss/theme/_doc-search.scss
@@ -1,7 +1,7 @@
 [data-theme='light'] .DocSearch {
   /* --docsearch-primary-color: var(--ifm-color-primary); */
   /* --docsearch-text-color: var(--ifm-font-color-base); */
-  --docsearch-muted-color: var(--ifm-color-secondary-darkest);
+  --docsearch-muted-color: var(--general-gray-dark);
   --docsearch-container-background: rgba(10, 10, 10, 0.9);
   /* Modal */
   --docsearch-modal-background: var(--ifm-color-secondary-lighter);


### PR DESCRIPTION
# Description

Update the key color to a darker one to address contrast issues

## Issue(s) fixed

- [ACCESS-36 - Metamask documentation home | Search box](https://consensyssoftware.atlassian.net/browse/ACCESS-36)

## Preview

**Before**
<img width="622" height="158" alt="docs metamask io_" src="https://github.com/user-attachments/assets/2cf98806-3352-4e8e-b0e3-2a2c7fb1871d" />

**After**
<img width="622" height="158" alt="localhost_3003_" src="https://github.com/user-attachments/assets/7a8b7b5d-51aa-4233-a29a-207170941d71" />

## Checklist

Complete this checklist before merging your PR:

- [x] If this PR contains a major change to the documentation content, I have added an entry to the top of the ["What's new?"](https://github.com/MetaMask/metamask-docs/blob/main/docs/whats-new.md) page.
- [x] The proposed changes have been reviewed and approved by a member of the documentation team.


[ACCESS-36]: https://consensyssoftware.atlassian.net/browse/ACCESS-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ