### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         uses: ConsenSys/github-actions/docs-build@main
 
@@ -30,7 +30,7 @@ jobs:
       matrix:
         folder: ['docs']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Case check action
         uses: ConsenSys/github-actions/docs-case-check@main
         with:
@@ -41,7 +41,7 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Lint
         uses: ConsenSys/github-actions/docs-lint-all@main
 
@@ -52,7 +52,7 @@ jobs:
       matrix:
         file-extensions: ['.md', '.mdx']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Vale
         uses: Consensys/github-actions/docs-spelling-check@main
         with:
@@ -65,7 +65,7 @@ jobs:
       matrix:
         file-extensions: ['.md', '.mdx']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: LinkCheck
         uses: ConsenSys/github-actions/docs-link-check@main
         with:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Synchronize with Crowdin
         uses: crowdin/github-action@v1

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Dependency review
         uses: ConsenSys/github-actions/js-dependency-review@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@
       permissions:
         contents: read
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: LinkCheck mdx files
           uses: ConsenSys/github-actions/docs-link-check@main
           with:
@@ -32,7 +32,7 @@
       permissions:
         contents: read
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: LinkCheck md files
           uses: ConsenSys/github-actions/docs-link-check@main
           with:

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: MetaMask Security Code Scanner
         uses: ConsenSys/github-actions/mm-security-scanner@main
         with:

--- a/.github/workflows/trivy-cache.yml
+++ b/.github/workflows/trivy-cache.yml
@@ -14,6 +14,6 @@ jobs:
     name: Run trivy scanner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Trivy Cache
         uses: ConsenSys/github-actions/trivy-update-cache@main

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run trivy scanner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Trivy
         uses: ConsenSys/github-actions/trivy@main
         with:


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0