### PR TITLE
Revert "chore(deps): bump @metamask/profile-sync-controller (#2307)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@mdx-js/react": "^3.1.0",
         "@metamask/design-tokens": "^7.1.0",
         "@metamask/eth-sig-util": "^7.0.3",
-        "@metamask/profile-sync-controller": "^25.0.0",
+        "@metamask/profile-sync-controller": "^16.0.0",
         "@metamask/sdk": "^0.33.1",
         "@rjsf/core": "^5.24.12",
         "@rjsf/utils": "^5.24.13",
@@ -5244,22 +5244,8 @@
       "version": "0.3.1",
       "license": "MIT"
     },
-    "node_modules/@endo/cache-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@endo/cache-map/-/cache-map-1.1.0.tgz",
-      "integrity": "sha512-owFGshs/97PDw9oguZqU/px8Lv1d0KjAUtDUiPwKHNXRVUE/jyettEbRoTbNJR1OaI8biMn6bHr9kVJsOh6dXw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@endo/env-options": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@endo/env-options/-/env-options-1.1.11.tgz",
-      "integrity": "sha512-p9OnAPsdqoX4YJsE98e3NBVhIr2iW9gNZxHhAI2/Ul5TdRfoOViItzHzTqrgUVopw6XxA1u1uS6CykLMDUxarA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@endo/immutable-arraybuffer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@endo/immutable-arraybuffer/-/immutable-arraybuffer-1.1.2.tgz",
-      "integrity": "sha512-u+NaYB2aqEugQ3u7w3c5QNkPogf8q/xGgsPaqdY6pUiGWtYiTiFspKFcha6+oeZhWXWQ23rf0KrUq0kfuzqYyQ==",
+      "version": "1.1.8",
       "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5922,6 +5908,66 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keystonehq/alias-sampling": {
+      "version": "0.1.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@keystonehq/base-eth-keyring": {
+      "version": "0.14.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.0.2",
+        "@ethereumjs/util": "^8.0.0",
+        "@keystonehq/bc-ur-registry-eth": "^0.19.1",
+        "hdkey": "^2.0.1",
+        "rlp": "^3.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@keystonehq/base-eth-keyring/node_modules/rlp": {
+      "version": "3.0.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-eth": {
+      "version": "0.19.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/util": "^8.0.0",
+        "@keystonehq/bc-ur-registry": "^0.6.0",
+        "hdkey": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@keystonehq/metamask-airgapped-keyring": {
+      "version": "0.14.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.0.2",
+        "@keystonehq/base-eth-keyring": "^0.14.1",
+        "@keystonehq/bc-ur-registry-eth": "^0.19.1",
+        "@metamask/obs-store": "^9.0.0",
+        "rlp": "^2.2.6",
+        "uuid": "^8.3.2"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "license": "MIT"
@@ -6007,25 +6053,61 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@metamask/address-book-controller": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/address-book-controller/-/address-book-controller-6.1.1.tgz",
-      "integrity": "sha512-7FytPTfw20hzS8KxxH2rhWBhgQ/gmz+XzOs15DYWCMkr3nEndVP9iJpTqiOdTh6X/Sxt0GidgVo50O50M56kiA==",
+    "node_modules/@metamask/accounts-controller": {
+      "version": "30.0.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@ethereumjs/util": "^9.1.0",
         "@metamask/base-controller": "^8.0.1",
-        "@metamask/controller-utils": "^11.11.0",
-        "@metamask/utils": "^11.4.2"
+        "@metamask/eth-snap-keyring": "^13.0.0",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-internal-api": "^6.2.0",
+        "@metamask/keyring-utils": "^3.0.0",
+        "@metamask/snaps-sdk": "^7.1.0",
+        "@metamask/snaps-utils": "^9.4.0",
+        "@metamask/utils": "^11.2.0",
+        "deepmerge": "^4.2.2",
+        "ethereum-cryptography": "^2.1.2",
+        "immer": "^9.0.6",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "@metamask/keyring-controller": "^22.0.0",
+        "@metamask/network-controller": "^23.0.0",
+        "@metamask/providers": "^22.0.0",
+        "@metamask/snaps-controllers": "^12.0.0",
+        "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
       }
     },
-    "node_modules/@metamask/address-book-controller/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+    "node_modules/@metamask/accounts-controller/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "license": "MPL-2.0",
+      "peer": true,
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/accounts-controller/node_modules/@ethereumjs/util": {
+      "version": "9.1.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/accounts-controller/node_modules/@metamask/utils": {
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6034,9 +6116,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6045,10 +6125,8 @@
         "node": "^18.18 || ^20.14 || >=22"
       }
     },
-    "node_modules/@metamask/address-book-controller/node_modules/uuid": {
+    "node_modules/@metamask/accounts-controller/node_modules/@metamask/utils/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6061,8 +6139,6 @@
     },
     "node_modules/@metamask/approval-controller": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@metamask/approval-controller/-/approval-controller-7.1.3.tgz",
-      "integrity": "sha512-1xfcJoHOTf2S+0JLN82ayYvO8VwxloZDvhTqJHNaqsDSgfx6TtC50+nBBahAGQxxtiTBrI3ZwwwDATpfutWwdg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6076,13 +6152,11 @@
       }
     },
     "node_modules/@metamask/approval-controller/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -6090,9 +6164,7 @@
       }
     },
     "node_modules/@metamask/approval-controller/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6101,9 +6173,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6114,8 +6184,6 @@
     },
     "node_modules/@metamask/approval-controller/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6127,13 +6195,10 @@
       }
     },
     "node_modules/@metamask/base-controller": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/base-controller/-/base-controller-8.3.0.tgz",
-      "integrity": "sha512-DsaQIymoS6c5cDD2sysebZ/8iZwFv1mTyk31r0d8cseyRaf7MxUDj7WUf0RTxGUYiWuOy6RjXT+ySM8IJjhqVQ==",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
-        "@metamask/messenger": "^0.2.0",
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.2.0",
         "immer": "^9.0.6"
       },
       "engines": {
@@ -6141,9 +6206,7 @@
       }
     },
     "node_modules/@metamask/base-controller/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -6151,9 +6214,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6164,8 +6225,6 @@
     },
     "node_modules/@metamask/base-controller/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6177,8 +6236,6 @@
     },
     "node_modules/@metamask/browser-passworder": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/browser-passworder/-/browser-passworder-4.3.0.tgz",
-      "integrity": "sha512-RU1TVVV5DkbZRr6zPYg0NkexZ0/T2LCKNvF3A50jvUweyxDFuoNbSTN6z8K3Fy8O6/X2JQ1yyAbVzxZLq0qrGg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6190,8 +6247,6 @@
     },
     "node_modules/@metamask/browser-passworder/node_modules/@metamask/utils": {
       "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-I6bkduevXb72TIM9q2LRO63JSsF9EXduh3sBr9oybNX2hNNpr/j1tEjXrsG0Uabm4MJ1xkGAQEMwifvKZIkyxQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6211,8 +6266,6 @@
     },
     "node_modules/@metamask/browser-passworder/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6224,22 +6277,20 @@
       }
     },
     "node_modules/@metamask/controller-utils": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@metamask/controller-utils/-/controller-utils-11.12.0.tgz",
-      "integrity": "sha512-RrVWfMVV+CgiRMB7a/+pNHccQPHnafoV7naU92zbxgO5rCqsNx93TG/qR05atQVzwwXv6sBIpusrFMJb5hd3hQ==",
+      "version": "11.9.0",
       "license": "MIT",
       "dependencies": {
+        "@ethereumjs/util": "^9.1.0",
         "@metamask/eth-query": "^4.0.0",
         "@metamask/ethjs-unit": "^0.3.0",
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.2.0",
         "@spruceid/siwe-parser": "2.1.0",
         "@types/bn.js": "^5.1.5",
         "bignumber.js": "^9.1.2",
         "bn.js": "^5.2.1",
         "cockatiel": "^3.1.2",
         "eth-ens-namehash": "^2.0.8",
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21"
+        "fast-deep-equal": "^3.1.3"
       },
       "engines": {
         "node": "^18.18 || >=20"
@@ -6248,10 +6299,29 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "node_modules/@metamask/controller-utils/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/controller-utils/node_modules/@ethereumjs/util": {
+      "version": "9.1.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@metamask/controller-utils/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -6259,9 +6329,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6272,8 +6340,6 @@
     },
     "node_modules/@metamask/controller-utils/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6290,17 +6356,71 @@
         "node": "^18.18 || >=20"
       }
     },
+    "node_modules/@metamask/error-reporting-service": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/base-controller": "^8.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/eth-block-tracker": {
+      "version": "12.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/eth-json-rpc-provider": "^4.1.5",
+        "@metamask/safe-event-emitter": "^3.1.1",
+        "@metamask/utils": "^11.0.1",
+        "json-rpc-random-id": "^1.0.1",
+        "pify": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.16 || ^20 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-block-tracker/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-block-tracker/node_modules/uuid": {
+      "version": "9.0.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@metamask/eth-hd-keyring": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-hd-keyring/-/eth-hd-keyring-13.0.0.tgz",
-      "integrity": "sha512-MU9k94rYWEartYu8Mf9YfTRHwQDOLLwZ6Z/5NuBEda9L5eLczTdPD9EbqGWN4ARmQa0TtgmbmNWXGUYZ8uO/vg==",
+      "version": "12.1.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@metamask/eth-sig-util": "^8.2.0",
         "@metamask/key-tree": "^10.0.2",
-        "@metamask/keyring-utils": "^3.1.0",
         "@metamask/scure-bip39": "^2.1.1",
         "@metamask/utils": "^11.1.0",
         "ethereum-cryptography": "^2.1.2"
@@ -6311,8 +6431,6 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6325,8 +6443,6 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@ethereumjs/util/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
       "peer": true,
       "bin": {
@@ -6338,8 +6454,6 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@metamask/abi-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/abi-utils/-/abi-utils-3.0.0.tgz",
-      "integrity": "sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==",
       "license": "(Apache-2.0 AND MIT)",
       "peer": true,
       "dependencies": {
@@ -6352,8 +6466,6 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@metamask/eth-sig-util": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-8.2.0.tgz",
-      "integrity": "sha512-LZDglIh4gYGw9Myp+2aIwKrj6lIJpMC4e0m7wKJU+BxLLBFcrTgKrjdjstXGVWvuYG3kutlh9J+uNBRPJqffWQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6371,8 +6483,6 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@metamask/eth-sig-util/node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6385,9 +6495,7 @@
       }
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6396,9 +6504,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6409,8 +6515,215 @@
     },
     "node_modules/@metamask/eth-hd-keyring/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-infura": {
+      "version": "10.2.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@metamask/eth-json-rpc-provider": "^4.1.7",
+        "@metamask/json-rpc-engine": "^10.0.2",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/utils": "^11.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-infura/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-infura/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-infura/node_modules/uuid": {
+      "version": "9.0.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware": {
+      "version": "17.0.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@metamask/eth-block-tracker": "^12.0.0",
+        "@metamask/eth-json-rpc-provider": "^4.1.7",
+        "@metamask/eth-sig-util": "^8.1.2",
+        "@metamask/json-rpc-engine": "^10.0.2",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/superstruct": "^3.1.0",
+        "@metamask/utils": "^11.1.0",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "klona": "^2.0.6",
+        "pify": "^5.0.0",
+        "safe-stable-stringify": "^2.4.3"
+      },
+      "engines": {
+        "node": "^18.16 || ^20 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware/node_modules/@metamask/abi-utils": {
+      "version": "3.0.0",
+      "license": "(Apache-2.0 AND MIT)",
+      "peer": true,
+      "dependencies": {
+        "@metamask/superstruct": "^3.1.0",
+        "@metamask/utils": "^11.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware/node_modules/@metamask/eth-sig-util": {
+      "version": "8.2.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "@metamask/abi-utils": "^3.0.0",
+        "@metamask/utils": "^11.0.1",
+        "@scure/base": "~1.1.3",
+        "ethereum-cryptography": "^2.1.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-middleware/node_modules/uuid": {
+      "version": "9.0.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-provider": {
+      "version": "4.1.8",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@metamask/json-rpc-engine": "^10.0.3",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/safe-event-emitter": "^3.0.0",
+        "@metamask/utils": "^11.1.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/utils/node_modules/uuid": {
+      "version": "9.0.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6423,8 +6736,6 @@
     },
     "node_modules/@metamask/eth-query": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-query/-/eth-query-4.0.0.tgz",
-      "integrity": "sha512-j2yPO2axYGyxwdqXRRhk2zBijt1Nd/xKCIXQkzvfWac0sKP0L9mSt1ZxMOe/sOF1SwS2R+NSaq+gsQDsQvrC4Q==",
       "license": "ISC",
       "dependencies": {
         "json-rpc-random-id": "^1.0.0",
@@ -6450,9 +6761,7 @@
       }
     },
     "node_modules/@metamask/eth-simple-keyring": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-simple-keyring/-/eth-simple-keyring-11.0.0.tgz",
-      "integrity": "sha512-Z6IaAuFcAkJMG5ghnabT1yBJalz+uzIjuTVcexKg4eBlf86+es0AEh+wJPCmZ4FAFkFN34Az0FYj0J/7IsPhGw==",
+      "version": "10.0.0",
       "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
@@ -6467,8 +6776,6 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6481,8 +6788,6 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@ethereumjs/util/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
       "peer": true,
       "bin": {
@@ -6494,8 +6799,6 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@metamask/abi-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/abi-utils/-/abi-utils-3.0.0.tgz",
-      "integrity": "sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==",
       "license": "(Apache-2.0 AND MIT)",
       "peer": true,
       "dependencies": {
@@ -6508,8 +6811,6 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@metamask/eth-sig-util": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-8.2.0.tgz",
-      "integrity": "sha512-LZDglIh4gYGw9Myp+2aIwKrj6lIJpMC4e0m7wKJU+BxLLBFcrTgKrjdjstXGVWvuYG3kutlh9J+uNBRPJqffWQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6527,8 +6828,6 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@metamask/eth-sig-util/node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6541,9 +6840,7 @@
       }
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6552,9 +6849,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6565,8 +6860,192 @@
     },
     "node_modules/@metamask/eth-simple-keyring/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring": {
+      "version": "13.0.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^5.4.0",
+        "@metamask/base-controller": "^7.1.1",
+        "@metamask/eth-sig-util": "^8.2.0",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-internal-api": "^6.2.0",
+        "@metamask/keyring-internal-snap-client": "^4.1.0",
+        "@metamask/keyring-utils": "^3.0.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@metamask/utils": "^11.1.0",
+        "@types/uuid": "^9.0.8",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "@metamask/keyring-api": "^18.0.0"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/common": {
+      "version": "4.4.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/util": "^9.1.0"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/common/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "license": "MPL-2.0",
+      "peer": true,
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/common/node_modules/@ethereumjs/util": {
+      "version": "9.1.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/tx": {
+      "version": "5.4.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/rlp": "^5.0.2",
+        "@ethereumjs/util": "^9.1.0",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/tx/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "license": "MPL-2.0",
+      "peer": true,
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@ethereumjs/tx/node_modules/@ethereumjs/util": {
+      "version": "9.1.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/abi-utils": {
+      "version": "3.0.0",
+      "license": "(Apache-2.0 AND MIT)",
+      "peer": true,
+      "dependencies": {
+        "@metamask/superstruct": "^3.1.0",
+        "@metamask/utils": "^11.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/base-controller": {
+      "version": "7.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "immer": "^9.0.6"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/eth-sig-util": {
+      "version": "8.2.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "@metamask/abi-utils": "^3.0.0",
+        "@metamask/utils": "^11.0.1",
+        "@scure/base": "~1.1.3",
+        "ethereum-cryptography": "^2.1.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/utils/node_modules/@ethereumjs/common": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/util": "^8.1.0",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/@metamask/utils/node_modules/@ethereumjs/tx": {
+      "version": "4.2.0",
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/common": "^3.2.0",
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@metamask/eth-snap-keyring/node_modules/uuid": {
+      "version": "9.0.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6579,8 +7058,6 @@
     },
     "node_modules/@metamask/ethjs-unit": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-unit/-/ethjs-unit-0.3.0.tgz",
-      "integrity": "sha512-HZtg69ODXYS9+ovKUYofZuIAwq4fc2/MGazD4vBQRKWMhPu4ySdmgR0EuzbxEK4uhr18KA4pbL+mCYjyjGxY7w==",
       "license": "MIT",
       "dependencies": {
         "@metamask/number-to-bn": "^1.7.1",
@@ -6596,8 +7073,6 @@
     },
     "node_modules/@metamask/json-rpc-engine": {
       "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-10.0.3.tgz",
-      "integrity": "sha512-p01QhlLIiTFXivEJCRx0LXEvPUaUPCedI9A8qV9jcLGGNSj1UTWM9GeifoeTweOMdmpIk5Rxg10H9f0JPUC9Ig==",
       "license": "ISC",
       "dependencies": {
         "@metamask/rpc-errors": "^7.0.2",
@@ -6609,12 +7084,10 @@
       }
     },
     "node_modules/@metamask/json-rpc-engine/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -6622,9 +7095,7 @@
       }
     },
     "node_modules/@metamask/json-rpc-engine/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -6632,9 +7103,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6645,8 +7114,6 @@
     },
     "node_modules/@metamask/json-rpc-engine/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6658,8 +7125,6 @@
     },
     "node_modules/@metamask/json-rpc-middleware-stream": {
       "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-8.0.7.tgz",
-      "integrity": "sha512-s7ugj+b4QYkQ+3VjRDdsp8GfKOKrxvI6HzaZg4TJrfSV+SO/Ky4TGo4Aib1gtv3/8muCPYAPGtjFVYWVAVJ6jw==",
       "license": "ISC",
       "dependencies": {
         "@metamask/json-rpc-engine": "^10.0.3",
@@ -6672,9 +7137,7 @@
       }
     },
     "node_modules/@metamask/json-rpc-middleware-stream/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -6682,9 +7145,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6695,8 +7156,6 @@
     },
     "node_modules/@metamask/json-rpc-middleware-stream/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6708,8 +7167,6 @@
     },
     "node_modules/@metamask/key-tree": {
       "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/key-tree/-/key-tree-10.1.1.tgz",
-      "integrity": "sha512-k9/MljlUqXC86hAOp6QGUwNm9ODWuA/YkMxiEwXcChNJgQSYfPzDh+Hp6Agf3g2mLKagMbl2nkH0+4vas+Pnyw==",
       "license": "MIT",
       "dependencies": {
         "@metamask/scure-bip39": "^2.1.1",
@@ -6723,9 +7180,7 @@
       }
     },
     "node_modules/@metamask/key-tree/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -6733,9 +7188,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6746,8 +7199,6 @@
     },
     "node_modules/@metamask/key-tree/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6758,12 +7209,9 @@
       }
     },
     "node_modules/@metamask/keyring-api": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/keyring-api/-/keyring-api-21.0.0.tgz",
-      "integrity": "sha512-3U9pFBposblP7oNfSfaBViTlT9MM6biYIh7icSAIaI2guZ9iNwcpxyeGSzsvSYjQKQCp0HmYqfqw2UFj2P9rWw==",
-      "peer": true,
+      "version": "18.0.0",
       "dependencies": {
-        "@metamask/keyring-utils": "^3.1.0",
+        "@metamask/keyring-utils": "^3.0.0",
         "@metamask/superstruct": "^3.1.0",
         "@metamask/utils": "^11.1.0",
         "bitcoin-address-validation": "^2.2.3"
@@ -6773,20 +7221,15 @@
       }
     },
     "node_modules/@metamask/keyring-api/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.1.0",
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6797,34 +7240,30 @@
     },
     "node_modules/@metamask/keyring-api/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@metamask/keyring-controller": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/keyring-controller/-/keyring-controller-23.1.0.tgz",
-      "integrity": "sha512-lVtPJp8m6SKpInqtA8XLCDKlV9wzMxiJdjwn1CzYldH1TRJxzpcxHs4VbGtWztWB1PA9EIwh1lvGPBaSoEH3aQ==",
+      "version": "22.0.1",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
-        "@metamask/base-controller": "^8.3.0",
+        "@keystonehq/metamask-airgapped-keyring": "^0.14.1",
+        "@metamask/base-controller": "^8.0.1",
         "@metamask/browser-passworder": "^4.3.0",
-        "@metamask/eth-hd-keyring": "^13.0.0",
+        "@metamask/eth-hd-keyring": "^12.0.0",
         "@metamask/eth-sig-util": "^8.2.0",
-        "@metamask/eth-simple-keyring": "^11.0.0",
-        "@metamask/keyring-api": "^21.0.0",
-        "@metamask/keyring-internal-api": "^9.0.0",
-        "@metamask/utils": "^11.4.2",
+        "@metamask/eth-simple-keyring": "^10.0.0",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-internal-api": "^6.2.0",
+        "@metamask/utils": "^11.2.0",
         "async-mutex": "^0.5.0",
         "ethereumjs-wallet": "^1.0.1",
         "immer": "^9.0.6",
@@ -6837,8 +7276,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6851,8 +7288,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/@ethereumjs/util/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
       "peer": true,
       "bin": {
@@ -6864,8 +7299,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/@metamask/abi-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/abi-utils/-/abi-utils-3.0.0.tgz",
-      "integrity": "sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==",
       "license": "(Apache-2.0 AND MIT)",
       "peer": true,
       "dependencies": {
@@ -6878,8 +7311,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/@metamask/eth-sig-util": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-8.2.0.tgz",
-      "integrity": "sha512-LZDglIh4gYGw9Myp+2aIwKrj6lIJpMC4e0m7wKJU+BxLLBFcrTgKrjdjstXGVWvuYG3kutlh9J+uNBRPJqffWQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6897,8 +7328,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/@metamask/eth-sig-util/node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -6911,9 +7340,7 @@
       }
     },
     "node_modules/@metamask/keyring-controller/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6922,9 +7349,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -6935,8 +7360,6 @@
     },
     "node_modules/@metamask/keyring-controller/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6948,24 +7371,130 @@
       }
     },
     "node_modules/@metamask/keyring-internal-api": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/keyring-internal-api/-/keyring-internal-api-9.0.0.tgz",
-      "integrity": "sha512-xzPXBDyrUOOeKWY3yvf6+T8vzCRRkG6ecwujunfJGITud+weym/XczhvfscEH4ajIt4tFiqawd2bYKmBLYoayQ==",
+      "version": "6.2.0",
       "peer": true,
       "dependencies": {
-        "@metamask/keyring-api": "^21.0.0",
-        "@metamask/keyring-utils": "^3.1.0",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-utils": "^3.0.0",
         "@metamask/superstruct": "^3.1.0"
       },
       "engines": {
         "node": "^18.18 || >=20"
       }
     },
-    "node_modules/@metamask/keyring-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/keyring-utils/-/keyring-utils-3.1.0.tgz",
-      "integrity": "sha512-ZsmtlCKZQo27xDXbPFM06u0NgTRwIVFJsHju2vPX4XGtEGh1Rd/gNGu8TePJGuTWbgvUVEvnk29c0njudbMprA==",
+    "node_modules/@metamask/keyring-internal-snap-client": {
+      "version": "4.1.0",
       "peer": true,
+      "dependencies": {
+        "@metamask/base-controller": "^7.1.1",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-internal-api": "^6.2.0",
+        "@metamask/keyring-snap-client": "^5.0.0",
+        "@metamask/keyring-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/@metamask/base-controller": {
+      "version": "7.1.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "immer": "^9.0.6"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/@metamask/keyring-snap-client": {
+      "version": "5.0.0",
+      "peer": true,
+      "dependencies": {
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/keyring-utils": "^3.0.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@types/uuid": "^9.0.8",
+        "uuid": "^9.0.1",
+        "webextension-polyfill": "^0.12.0"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "@metamask/providers": "^19.0.0"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/@metamask/providers": {
+      "version": "19.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/json-rpc-engine": "^10.0.2",
+        "@metamask/json-rpc-middleware-stream": "^8.0.6",
+        "@metamask/object-multiplex": "^2.0.0",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/safe-event-emitter": "^3.1.1",
+        "@metamask/utils": "^11.0.1",
+        "detect-browser": "^5.2.0",
+        "extension-port-stream": "^4.1.0",
+        "fast-deep-equal": "^3.1.3",
+        "is-stream": "^2.0.0",
+        "readable-stream": "^3.6.2"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      },
+      "peerDependencies": {
+        "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/keyring-internal-snap-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/keyring-utils": {
+      "version": "3.0.0",
       "dependencies": {
         "@ethereumjs/tx": "^5.4.0",
         "@metamask/superstruct": "^3.1.0",
@@ -6978,20 +7507,14 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@ethereumjs/common": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-4.4.0.tgz",
-      "integrity": "sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0"
       }
     },
     "node_modules/@metamask/keyring-utils/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
-      "peer": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -7001,10 +7524,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@ethereumjs/tx": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-5.4.0.tgz",
-      "integrity": "sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
@@ -7017,10 +7537,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -7030,20 +7547,15 @@
       }
     },
     "node_modules/@metamask/keyring-utils/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.1.0",
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7054,10 +7566,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@metamask/utils/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -7065,10 +7574,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@metamask/utils/node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
       "license": "MPL-2.0",
-      "peer": true,
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -7078,10 +7584,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@metamask/utils/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -7094,10 +7597,7 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/@metamask/utils/node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^2.0.0",
@@ -7109,8 +7609,77 @@
     },
     "node_modules/@metamask/keyring-utils/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@metamask/network-controller": {
+      "version": "23.5.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/base-controller": "^8.0.1",
+        "@metamask/controller-utils": "^11.9.0",
+        "@metamask/error-reporting-service": "^1.0.0",
+        "@metamask/eth-block-tracker": "^12.0.1",
+        "@metamask/eth-json-rpc-infura": "^10.2.0",
+        "@metamask/eth-json-rpc-middleware": "^17.0.1",
+        "@metamask/eth-json-rpc-provider": "^4.1.8",
+        "@metamask/eth-query": "^4.0.0",
+        "@metamask/json-rpc-engine": "^10.0.3",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/swappable-obj-proxy": "^2.3.0",
+        "@metamask/utils": "^11.2.0",
+        "async-mutex": "^0.5.0",
+        "fast-deep-equal": "^3.1.3",
+        "immer": "^9.0.6",
+        "loglevel": "^1.8.1",
+        "reselect": "^5.1.1",
+        "uri-js": "^4.4.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": "^18.18 || >=20"
+      }
+    },
+    "node_modules/@metamask/network-controller/node_modules/@metamask/rpc-errors": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@metamask/utils": "^11.0.1",
+        "fast-safe-stringify": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.20 || ^20.17 || >=22"
+      }
+    },
+    "node_modules/@metamask/network-controller/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/network-controller/node_modules/@metamask/utils/node_modules/uuid": {
+      "version": "9.0.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7121,19 +7690,8 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@metamask/messenger": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@metamask/messenger/-/messenger-0.2.0.tgz",
-      "integrity": "sha512-Ktv9aselR1KH2Nnpj7kulragl4kdCUtLZcuQeAxClV7atn6HmJBmuIYLlTawnRwr8guiKqscAs7EiQQvU0DLiA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18 || >=20"
-      }
-    },
     "node_modules/@metamask/number-to-bn": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@metamask/number-to-bn/-/number-to-bn-1.7.1.tgz",
-      "integrity": "sha512-qCN+Au4amvcVii2LdOJNndYhdmk5Lk9tlStJhKpZ8tGeYQDJTghqYXJuSUVPHvfl6FUfKY1i1Or2j2EbnEerSQ==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "5.2.1",
@@ -7155,6 +7713,19 @@
         "node": "^16.20 || ^18.16 || >=20"
       }
     },
+    "node_modules/@metamask/obs-store": {
+      "version": "9.1.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^3.0.0",
+        "readable-stream": "^3.6.2"
+      },
+      "engines": {
+        "node": "^14.21 || ^16.20 || ^18.16 || >=20",
+        "yarn": "^1.22.22"
+      }
+    },
     "node_modules/@metamask/onboarding": {
       "version": "1.0.1",
       "license": "MIT",
@@ -7164,8 +7735,6 @@
     },
     "node_modules/@metamask/permission-controller": {
       "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@metamask/permission-controller/-/permission-controller-11.0.6.tgz",
-      "integrity": "sha512-BGznKBEiSZMsF7TuyBUp5xt93nfhGHyl4xAs1rvJUNUWVSUtry+mb1A6H8bq82/T4ZrxNhrnx3ISYr99ZDo7rA==",
       "license": "MIT",
       "dependencies": {
         "@metamask/base-controller": "^8.0.0",
@@ -7186,12 +7755,10 @@
       }
     },
     "node_modules/@metamask/permission-controller/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7199,9 +7766,7 @@
       }
     },
     "node_modules/@metamask/permission-controller/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -7209,9 +7774,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7222,8 +7785,6 @@
     },
     "node_modules/@metamask/permission-controller/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7234,14 +7795,12 @@
       }
     },
     "node_modules/@metamask/phishing-controller": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/phishing-controller/-/phishing-controller-13.1.0.tgz",
-      "integrity": "sha512-idjxMIStvkl7YR9Kj9wyKkcexDdhJNtFRgn1bPJSPTTylm2YGpoePTNNVx0nEu7TSXvJ+YME0qfvb6tOw1xDVA==",
+      "version": "12.5.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@metamask/base-controller": "^8.0.1",
-        "@metamask/controller-utils": "^11.11.0",
+        "@metamask/base-controller": "^8.0.0",
+        "@metamask/controller-utils": "^11.7.0",
         "@noble/hashes": "^1.4.0",
         "@types/punycode": "^2.1.0",
         "ethereum-cryptography": "^2.1.2",
@@ -7254,8 +7813,6 @@
     },
     "node_modules/@metamask/post-message-stream": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/post-message-stream/-/post-message-stream-10.0.0.tgz",
-      "integrity": "sha512-nFepq24aGQw81hkSgCIEBYFpNocnLZpIArCEICdT74pLTMXLgm4G8aHSszF+sOOvnMKW8zV56og9ImZSondIjA==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -7267,9 +7824,7 @@
       }
     },
     "node_modules/@metamask/post-message-stream/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -7278,9 +7833,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7291,8 +7844,6 @@
     },
     "node_modules/@metamask/post-message-stream/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7304,16 +7855,15 @@
       }
     },
     "node_modules/@metamask/profile-sync-controller": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/profile-sync-controller/-/profile-sync-controller-25.0.0.tgz",
-      "integrity": "sha512-4bQsp/ECAczG+UJUT0/LVcg2pW9Agb81H4/gbSrAv06WRHISlN+FjeL3oQsjwK7y54n5OnA4U3uT4h1/Pu9lCg==",
+      "version": "16.0.0",
       "license": "MIT",
       "dependencies": {
-        "@metamask/base-controller": "^8.3.0",
-        "@metamask/snaps-sdk": "^9.0.0",
-        "@metamask/snaps-utils": "^11.0.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/hashes": "^1.8.0",
+        "@metamask/base-controller": "^8.0.1",
+        "@metamask/keyring-api": "^18.0.0",
+        "@metamask/snaps-sdk": "^7.1.0",
+        "@metamask/snaps-utils": "^9.4.0",
+        "@noble/ciphers": "^0.5.2",
+        "@noble/hashes": "^1.4.0",
         "immer": "^9.0.6",
         "loglevel": "^1.8.1",
         "siwe": "^2.3.2"
@@ -7322,17 +7872,16 @@
         "node": "^18.18 || >=20"
       },
       "peerDependencies": {
-        "@metamask/address-book-controller": "^6.1.1",
-        "@metamask/keyring-controller": "^23.0.0",
+        "@metamask/accounts-controller": "^30.0.0",
+        "@metamask/keyring-controller": "^22.0.0",
+        "@metamask/network-controller": "^23.0.0",
         "@metamask/providers": "^22.0.0",
-        "@metamask/snaps-controllers": "^14.0.0",
+        "@metamask/snaps-controllers": "^12.0.0",
         "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
       }
     },
     "node_modules/@metamask/providers": {
-      "version": "22.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-22.1.1.tgz",
-      "integrity": "sha512-z7ODqHkbhSfG6SK9gJ/SAxS/NnfjpScKgQEHiNCPnPWK4Lx5ej8IsXieEWvssrVlQechiPrHieFim7C8drK78A==",
+      "version": "22.1.0",
       "license": "MIT",
       "dependencies": {
         "@metamask/json-rpc-engine": "^10.0.2",
@@ -7355,12 +7904,10 @@
       }
     },
     "node_modules/@metamask/providers/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7368,9 +7915,7 @@
       }
     },
     "node_modules/@metamask/providers/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -7378,9 +7923,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7391,8 +7934,6 @@
     },
     "node_modules/@metamask/providers/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7422,8 +7963,6 @@
     },
     "node_modules/@metamask/scure-bip39": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/scure-bip39/-/scure-bip39-2.1.1.tgz",
-      "integrity": "sha512-1K8aBsAqr6+8jWhguVl06n8e+zjV9sUnys+5PLyVU4mb8LbulQ60F6cq7iQys3xX/yCwKt1+7c7j2nuTEpW+ZQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.3.2",
@@ -7435,8 +7974,6 @@
     },
     "node_modules/@metamask/scure-bip39/node_modules/@noble/hashes": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -7646,43 +8183,39 @@
       "license": "MPL-2.0"
     },
     "node_modules/@metamask/slip44": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/slip44/-/slip44-4.3.0.tgz",
-      "integrity": "sha512-9+qLDEOKlK2eSDNhHxVmxvTLeoaN3sS2kZh/EzSDNktcWwQ8Mh7lUTaAsXFtDOHRos5788piSUGsp4XAIRi8mQ==",
+      "version": "4.2.0",
       "license": "ISC",
       "engines": {
         "node": "^18.16 || >=20"
       }
     },
     "node_modules/@metamask/snaps-controllers": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@metamask/snaps-controllers/-/snaps-controllers-14.2.2.tgz",
-      "integrity": "sha512-gSqa8t6oRo782fQJWO+uL1IyhYfKyrZBrfD3KS0afb9Z85LPz73y83icfY3nWL5hJ7WJvVGwe8eCOgH0AfjSsg==",
+      "version": "12.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "@metamask/approval-controller": "^7.1.3",
-        "@metamask/base-controller": "^8.1.0",
+        "@metamask/base-controller": "^8.0.1",
         "@metamask/json-rpc-engine": "^10.0.2",
         "@metamask/json-rpc-middleware-stream": "^8.0.7",
         "@metamask/key-tree": "^10.1.1",
         "@metamask/object-multiplex": "^2.1.0",
         "@metamask/permission-controller": "^11.0.6",
-        "@metamask/phishing-controller": "^13.1.0",
+        "@metamask/phishing-controller": "^12.5.0",
         "@metamask/post-message-stream": "^10.0.0",
-        "@metamask/rpc-errors": "^7.0.3",
+        "@metamask/rpc-errors": "^7.0.2",
         "@metamask/snaps-registry": "^3.2.3",
-        "@metamask/snaps-rpc-methods": "^13.5.0",
-        "@metamask/snaps-sdk": "^9.3.0",
-        "@metamask/snaps-utils": "^11.5.0",
-        "@metamask/utils": "^11.4.2",
+        "@metamask/snaps-rpc-methods": "^12.4.0",
+        "@metamask/snaps-sdk": "^7.1.0",
+        "@metamask/snaps-utils": "^9.4.0",
+        "@metamask/utils": "^11.4.0",
         "@xstate/fsm": "^2.0.0",
         "async-mutex": "^0.5.0",
+        "browserify-zlib": "^0.2.0",
         "concat-stream": "^2.0.0",
-        "cron-parser": "^4.5.0",
         "fast-deep-equal": "^3.1.3",
         "get-npm-tarball-url": "^2.0.3",
-        "immer": "^9.0.21",
+        "immer": "^9.0.6",
         "luxon": "^3.5.0",
         "nanoid": "^3.3.10",
         "readable-stream": "^3.6.2",
@@ -7691,10 +8224,10 @@
         "tar-stream": "^3.1.7"
       },
       "engines": {
-        "node": "^20 || >=22"
+        "node": "^18.16 || >=20"
       },
       "peerDependencies": {
-        "@metamask/snaps-execution-environments": "^10.2.1"
+        "@metamask/snaps-execution-environments": "^8.1.0"
       },
       "peerDependenciesMeta": {
         "@metamask/snaps-execution-environments": {
@@ -7703,13 +8236,11 @@
       }
     },
     "node_modules/@metamask/snaps-controllers/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7717,9 +8248,7 @@
       }
     },
     "node_modules/@metamask/snaps-controllers/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -7728,9 +8257,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7741,8 +8268,6 @@
     },
     "node_modules/@metamask/snaps-controllers/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7755,8 +8280,6 @@
     },
     "node_modules/@metamask/snaps-registry": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@metamask/snaps-registry/-/snaps-registry-3.2.3.tgz",
-      "integrity": "sha512-XO5zk2DMLlixk5tKydIxYn0seSU453oR8PAoorVkgvCRmprdGC4qNqxfDZ7t1xf5qquqHvRaNHQ/Ir5cAwxXyw==",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@metamask/superstruct": "^3.1.0",
@@ -7769,9 +8292,7 @@
       }
     },
     "node_modules/@metamask/snaps-registry/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -7779,9 +8300,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7792,8 +8311,6 @@
     },
     "node_modules/@metamask/snaps-registry/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7804,33 +8321,30 @@
       }
     },
     "node_modules/@metamask/snaps-rpc-methods": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@metamask/snaps-rpc-methods/-/snaps-rpc-methods-13.5.1.tgz",
-      "integrity": "sha512-rYtqm/hC2mLGFtZNGA2sgIYJBbxi78bHZb//3Ztls3QFUVAKQICqNdGcLaGsMS8wGRW7YjQt15UjguQerlGvVw==",
+      "version": "12.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "@metamask/key-tree": "^10.1.1",
         "@metamask/permission-controller": "^11.0.6",
-        "@metamask/rpc-errors": "^7.0.3",
-        "@metamask/snaps-sdk": "^9.3.0",
-        "@metamask/snaps-utils": "^11.5.0",
+        "@metamask/rpc-errors": "^7.0.2",
+        "@metamask/snaps-sdk": "^7.1.0",
+        "@metamask/snaps-utils": "^9.4.0",
         "@metamask/superstruct": "^3.2.1",
-        "@metamask/utils": "^11.4.2",
-        "@noble/hashes": "^1.7.1"
+        "@metamask/utils": "^11.4.0",
+        "@noble/hashes": "^1.7.1",
+        "luxon": "^3.5.0"
       },
       "engines": {
-        "node": "^20 || >=22"
+        "node": "^18.16 || >=20"
       }
     },
     "node_modules/@metamask/snaps-rpc-methods/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7838,9 +8352,7 @@
       }
     },
     "node_modules/@metamask/snaps-rpc-methods/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -7849,9 +8361,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7862,8 +8372,6 @@
     },
     "node_modules/@metamask/snaps-rpc-methods/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7875,28 +8383,24 @@
       }
     },
     "node_modules/@metamask/snaps-sdk": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/snaps-sdk/-/snaps-sdk-9.3.0.tgz",
-      "integrity": "sha512-o/XxzQNl59HjsesNAAK1UqVNQmujloAxCNfIii/z4wLFNe7+sg7Swsw4My5jR6xRLgzSaSBwW3dczYdVTpA06g==",
+      "version": "7.1.0",
       "license": "ISC",
       "dependencies": {
         "@metamask/key-tree": "^10.1.1",
         "@metamask/providers": "^22.1.0",
-        "@metamask/rpc-errors": "^7.0.3",
+        "@metamask/rpc-errors": "^7.0.2",
         "@metamask/superstruct": "^3.2.1",
-        "@metamask/utils": "^11.4.2"
+        "@metamask/utils": "^11.4.0"
       },
       "engines": {
-        "node": "^20 || >=22"
+        "node": "^18.16 || >=20"
       }
     },
     "node_modules/@metamask/snaps-sdk/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7904,9 +8408,7 @@
       }
     },
     "node_modules/@metamask/snaps-sdk/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -7914,9 +8416,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -7927,8 +8427,6 @@
     },
     "node_modules/@metamask/snaps-sdk/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7939,22 +8437,20 @@
       }
     },
     "node_modules/@metamask/snaps-utils": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@metamask/snaps-utils/-/snaps-utils-11.5.0.tgz",
-      "integrity": "sha512-XKYnfj8eXdYmUn8M4rYq+OOp09qIUJ943g9iZWl/hS4tCEx9zbe0LzFs3zYy38QTlDptj6gY7m9Z3+JitH8UGA==",
+      "version": "9.4.0",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/types": "^7.23.0",
-        "@metamask/base-controller": "^8.1.0",
+        "@metamask/base-controller": "^8.0.1",
         "@metamask/key-tree": "^10.1.1",
         "@metamask/permission-controller": "^11.0.6",
-        "@metamask/rpc-errors": "^7.0.3",
+        "@metamask/rpc-errors": "^7.0.2",
         "@metamask/slip44": "^4.2.0",
         "@metamask/snaps-registry": "^3.2.3",
-        "@metamask/snaps-sdk": "^9.3.0",
+        "@metamask/snaps-sdk": "^7.1.0",
         "@metamask/superstruct": "^3.2.1",
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.4.0",
         "@noble/hashes": "^1.7.1",
         "@scure/base": "^1.1.1",
         "chalk": "^4.1.2",
@@ -7966,20 +8462,18 @@
         "marked": "^12.0.1",
         "rfdc": "^1.3.0",
         "semver": "^7.5.4",
-        "ses": "^1.14.0",
+        "ses": "^1.12.0",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": "^20 || >=22"
+        "node": "^18.16 || >=20"
       }
     },
     "node_modules/@metamask/snaps-utils/node_modules/@metamask/rpc-errors": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-7.0.3.tgz",
-      "integrity": "sha512-nrEaeBawm8yFU7hetJKok/CUs0tQsWtTqp3OLbFhPUMXYqU7uI5LAV5vi9o7rTjFkUyof7Nzbw5bea5+1ou+dg==",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "@metamask/utils": "^11.4.2",
+        "@metamask/utils": "^11.0.1",
         "fast-safe-stringify": "^2.0.6"
       },
       "engines": {
@@ -7987,9 +8481,7 @@
       }
     },
     "node_modules/@metamask/snaps-utils/node_modules/@metamask/utils": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.8.0.tgz",
-      "integrity": "sha512-EJqiuvVBAjV1vd1kBhmVmRtGfadrBfY3ImcAMjl+8MSSByTB3VNwvlIBLQdp+TwdAomUdenJCx2BvOSQykm8Hg==",
+      "version": "11.4.0",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -7997,9 +8489,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
-        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -8010,8 +8500,6 @@
     },
     "node_modules/@metamask/snaps-utils/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8026,6 +8514,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@metamask/swappable-obj-proxy": {
+      "version": "2.3.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/utils": {
@@ -8125,14 +8621,23 @@
         "mux-embed": "^5.8.3"
       }
     },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+    "node_modules/@ngraveio/bc-ur": {
+      "version": "1.1.13",
       "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
+      "peer": true,
+      "dependencies": {
+        "@keystonehq/alias-sampling": "^0.1.1",
+        "assert": "^2.0.0",
+        "bignumber.js": "^9.0.1",
+        "cbor-sync": "^1.0.4",
+        "crc": "^3.8.0",
+        "jsbi": "^3.1.5",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "0.5.3",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -8828,8 +9333,6 @@
     },
     "node_modules/@spruceid/siwe-parser": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.0.tgz",
-      "integrity": "sha512-tFQwY2oQLa4qvHE6npKsVgVdVLQOCGP1zJM3yjZOHut43LqCwdSwitZndFLrJHZLpqru9FnmYHRakvsPvrI+qA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
@@ -9164,9 +9667,7 @@
       }
     },
     "node_modules/@types/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "version": "5.1.6",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9402,8 +9903,6 @@
     },
     "node_modules/@types/deep-freeze-strict": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.2.tgz",
-      "integrity": "sha512-VvMETBojHvhX4f+ocYTySQlXMZfxKV3Jyb7iCWlWaC+exbedkv6Iv2bZZqI736qXjVguH6IH7bzwMBMfTT+zuQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -9523,12 +10022,6 @@
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
-      "license": "MIT"
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "license": "MIT",
@@ -9578,8 +10071,6 @@
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9596,8 +10087,6 @@
     },
     "node_modules/@types/punycode": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.4.tgz",
-      "integrity": "sha512-trzh6NzBnq8yw5e35f8xe8VTYjqM3NE7bohBtvDVf/dtUer3zYTLK1Ka3DG3p7bdtoaOHZucma6FfVKlQ134pQ==",
       "license": "MIT",
       "peer": true
     },
@@ -9691,8 +10180,6 @@
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
-      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9757,6 +10244,11 @@
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/webxr": {
       "version": "0.5.23",
@@ -10077,8 +10569,6 @@
     },
     "node_modules/@xstate/fsm": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-2.1.0.tgz",
-      "integrity": "sha512-oJlc0iD0qZvAM7If/KlyJyqUt7wVI8ocpsnlWzAPl97evguPbd+oJbRM9R4A1vYJffYH96+Bx44nLDE6qS8jQg==",
       "license": "MIT",
       "peer": true
     },
@@ -10156,8 +10646,6 @@
     },
     "node_modules/aes-js": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "license": "MIT",
       "peer": true
     },
@@ -10575,8 +11063,6 @@
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10638,6 +11124,11 @@
         "follow-redirects": "1.5.10",
         "is-buffer": "^2.0.2"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -10857,17 +11348,13 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "version": "2.5.4",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
     },
     "node_modules/base-x": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10876,10 +11363,7 @@
     },
     "node_modules/base58-js": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
-      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -10947,10 +11431,7 @@
     },
     "node_modules/bech32": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -10960,9 +11441,7 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "version": "9.3.0",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -10990,10 +11469,7 @@
     },
     "node_modules/bitcoin-address-validation": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-2.2.3.tgz",
-      "integrity": "sha512-1uGCGl26Ye8JG5qcExtFLQfuib6qEZWNDo1ZlLlwp/z7ygUFby3IxolgEfgMGaC+LG9csbVASLcH8fRLv7DIOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base58-js": "^1.0.0",
         "bech32": "^2.0.0",
@@ -11002,8 +11478,6 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
       "license": "MIT",
       "peer": true
     },
@@ -11275,8 +11749,6 @@
     },
     "node_modules/bs58": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11285,8 +11757,6 @@
     },
     "node_modules/bs58check": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11306,9 +11776,7 @@
       }
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
       "funding": [
         {
           "type": "github",
@@ -11324,9 +11792,10 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-alloc": {
@@ -11639,6 +12108,11 @@
       "dependencies": {
         "custom-media-element": "~1.4.5"
       }
+    },
+    "node_modules/cbor-sync": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -12052,8 +12526,6 @@
     },
     "node_modules/cockatiel": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
-      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -12740,8 +13212,6 @@
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
         "node >= 6.0"
       ],
@@ -13040,6 +13510,14 @@
         }
       }
     },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "license": "Apache-2.0",
@@ -13097,8 +13575,6 @@
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
       "license": "MIT",
       "dependencies": {
         "luxon": "^3.2.1"
@@ -14248,8 +14724,6 @@
     },
     "node_modules/deep-freeze-strict": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-freeze-strict/-/deep-freeze-strict-1.1.1.tgz",
-      "integrity": "sha512-QemROZMM2IvhAcCFvahdX2Vbm4S/txeq5rFYU9fh4mQP79WTMW5c/HkQ2ICl1zuzcDZdPZ6zarDxQeQMsVYoNA==",
       "license": "public domain"
     },
     "node_modules/deep-is": {
@@ -14653,6 +15127,18 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/eciesjs/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/editions": {
@@ -15473,8 +15959,6 @@
     },
     "node_modules/eth-ens-namehash": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==",
       "license": "ISC",
       "dependencies": {
         "idna-uts46-hx": "^2.3.1",
@@ -15520,8 +16004,6 @@
     },
     "node_modules/ethereumjs-util": {
       "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -15537,8 +16019,6 @@
     },
     "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15561,9 +16041,6 @@
     },
     "node_modules/ethereumjs-wallet": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "deprecated": "New package name format for new versions: @ethereumjs/wallet. Please update.",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15579,8 +16056,6 @@
     },
     "node_modules/ethereumjs-wallet/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15871,8 +16346,6 @@
     },
     "node_modules/extension-port-stream": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-4.2.0.tgz",
-      "integrity": "sha512-i5IgiPVMVrHN+Zx8PRjvFsOw8L1A3sboVwPZghDjW9Yp1BMmBDE6mCcTNu4xMXPYduBOwI3CBK7wd72LcOyD6g==",
       "license": "ISC",
       "dependencies": {
         "readable-stream": "^3.6.2 || ^4.4.2"
@@ -15912,8 +16385,6 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT",
       "peer": true
     },
@@ -15950,8 +16421,6 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
@@ -16540,8 +17009,6 @@
     },
     "node_modules/get-npm-tarball-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/get-npm-tarball-url/-/get-npm-tarball-url-2.1.0.tgz",
-      "integrity": "sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -17261,6 +17728,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hdkey": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bs58check": "^2.1.2",
+        "ripemd160": "^2.0.2",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^4.0.0"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "license": "MIT",
@@ -17693,8 +18171,6 @@
     },
     "node_modules/idna-uts46-hx": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "license": "MIT",
       "dependencies": {
         "punycode": "2.1.0"
@@ -17705,8 +18181,6 @@
     },
     "node_modules/idna-uts46-hx/node_modules/punycode": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18333,8 +18807,6 @@
     },
     "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
@@ -18906,8 +19378,6 @@
     },
     "node_modules/js-sha3": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -18923,6 +19393,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "3.2.5",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/jsc-safe-url": {
       "version": "0.2.4",
@@ -18955,8 +19430,6 @@
     },
     "node_modules/json-rpc-random-id": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==",
       "license": "ISC"
     },
     "node_modules/json-schema-compare": {
@@ -19088,8 +19561,6 @@
     },
     "node_modules/keccak": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
-      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -19101,6 +19572,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/keccak/node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -19436,8 +19912,6 @@
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -19496,9 +19970,7 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "version": "3.6.1",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -19699,8 +20171,6 @@
     },
     "node_modules/marked": {
       "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -22863,9 +23333,7 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "version": "5.1.0",
       "license": "MIT",
       "peer": true
     },
@@ -22972,6 +23440,28 @@
       },
       "peerDependencies": {
         "webpack": ">=5"
+      }
+    },
+    "node_modules/node-polyfill-webpack-plugin/node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/node-polyfill-webpack-plugin/node_modules/readable-stream": {
@@ -24008,6 +24498,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pirates": {
@@ -26774,6 +27275,31 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/react-spring/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/react-spring/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -27072,8 +27598,6 @@
     },
     "node_modules/readable-web-to-node-stream": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27087,10 +27611,31 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/readable-web-to-node-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27800,6 +28345,11 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -27912,8 +28462,6 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -27939,8 +28487,6 @@
     },
     "node_modules/rlp": {
       "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
@@ -28110,6 +28656,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -28271,8 +28825,6 @@
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
       "license": "MIT",
       "peer": true
     },
@@ -28283,8 +28835,6 @@
     },
     "node_modules/secp256k1": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
-      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -28296,13 +28846,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/secp256k1/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -28567,14 +29110,10 @@
       }
     },
     "node_modules/ses": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ses/-/ses-1.14.0.tgz",
-      "integrity": "sha512-T07hNgOfVRTLZGwSS50RnhqrG3foWP+rM+Q5Du4KUQyMLFI3A8YA4RKl0jjZzhihC1ZvDGrWi/JMn4vqbgr/Jg==",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@endo/cache-map": "^1.1.0",
-        "@endo/env-options": "^1.1.11",
-        "@endo/immutable-arraybuffer": "^1.1.2"
+        "@endo/env-options": "^1.1.8"
       }
     },
     "node_modules/set-function-length": {
@@ -28649,10 +29188,7 @@
     },
     "node_modules/sha256-uint8array": {
       "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
-      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -29133,9 +29669,7 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "version": "2.22.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -29336,8 +29870,6 @@
     },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
       "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
@@ -29373,8 +29905,6 @@
     },
     "node_modules/strnum": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "funding": [
         {
           "type": "github",
@@ -29932,29 +30462,12 @@
     },
     "node_modules/tar-stream": {
       "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/b4a": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
-      "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
       }
     },
     "node_modules/term-size": {
@@ -30196,27 +30709,10 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/text-decoder/node_modules/b4a": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
-      "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
       }
     },
     "node_modules/textextensions": {
@@ -30723,8 +31219,6 @@
     },
     "node_modules/ulid": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
-      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -31167,8 +31661,6 @@
     },
     "node_modules/utf8": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
       "license": "MIT",
       "peer": true
     },
@@ -31225,8 +31717,6 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -31425,8 +31915,6 @@
     },
     "node_modules/webextension-polyfill": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
-      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
       "license": "MPL-2.0",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@mdx-js/react": "^3.1.0",
     "@metamask/design-tokens": "^7.1.0",
     "@metamask/eth-sig-util": "^7.0.3",
-    "@metamask/profile-sync-controller": "^25.0.0",
+    "@metamask/profile-sync-controller": "^16.0.0",
     "@metamask/sdk": "^0.33.1",
     "@rjsf/core": "^5.24.12",
     "@rjsf/utils": "^5.24.13",


### PR DESCRIPTION
This reverts commit e72345c55b9d31acb0dbd516e586b8966d27a172.

The profile-sync-controller update was passing Vercel preview deployment in the dependabot PR (#2307), but failing production deployment once merged into main.