### PR TITLE
Upgrade GitHub Action to crowdin/github-action@v2

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Synchronize with Crowdin
-        uses: crowdin/github-action@v1
+        uses: crowdin/github-action@v2
         with:
           upload_sources: true
           upload_translations: true


### PR DESCRIPTION
The new version includes multiple performance, reliability, and security improvements for syncing translations.
 Release notes:https://github.com/crowdin/github-action/releases/tag/v2.11.0

Change:
uses: crowdin/github-action@v1-> uses: crowdin/github-action@v2