### PR TITLE
Fix broken internal links.

### DIFF
--- a/delegation-toolkit/concepts/delegation/caveat-enforcers.md
+++ b/delegation-toolkit/concepts/delegation/caveat-enforcers.md
@@ -6,7 +6,7 @@ keywords: [caveats, caveat enforcers, delegation]
 # Caveat enforcers
 
 The MetaMask Delegation Toolkit provides *caveat enforcers*, which are smart contracts that implement rules and restrictions (*caveats*) on delegations.
-They serve as the underlying mechanism that enables conditional execution within the [Delegation Framework](index.md#delegation-framework).
+They serve as the underlying mechanism that enables conditional execution within the [Delegation Framework](./index.md#delegation-framework).
 
 A caveat enforcer acts as a gate that validates whether a delegation can be used for a particular execution. When a delegate attempts to execute an action on behalf of a delegator, each caveat enforcer specified in the delegation evaluates whether the execution meets its defined criteria.
 
@@ -164,7 +164,7 @@ For other restriction patterns, you can also [create custom caveat enforcers](/t
 
 ## Attenuating authority with redelegations
 
-When creating chains of delegations via [redelegations](index.md#delegation-types), it's important to understand how authority flows and can be restricted.
+When creating chains of delegations via [redelegations](./index.md#delegation-types), it's important to understand how authority flows and can be restricted.
 
 Caveats applied to a chain of delegations are *accumulative*—they stack on top of each other:
 

--- a/delegation-toolkit/concepts/erc7715.md
+++ b/delegation-toolkit/concepts/erc7715.md
@@ -61,4 +61,4 @@ The ERC-7715 permissions lifecycle is as follows:
 
 4. **Redeem permissions** - Once the permission is granted, the session account can redeem the permission, executing on the user's behalf.
 
-See [how to perform executions on a MetaMask user's behalf](../guides/erc7715/execute-on-metamask-user-behalf.md) to get started with the ERC-7715 lifecycle.
+See [how to perform executions on a MetaMask user's behalf](../guides/erc7715/execute-on-metamask-users-behalf.md) to get started with the ERC-7715 lifecycle.

--- a/embedded-wallets/dashboard/advanced/key-export.mdx
+++ b/embedded-wallets/dashboard/advanced/key-export.mdx
@@ -447,6 +447,6 @@ async function safeKeyExport() {
 
 ## Next Steps
 
-- **[User Details in ID Token](./user-details)** - Configure user data in JWT tokens
-- **[Session Management](./session-management)** - Control session duration and behavior
-- **[Project Settings](../project-settings)** - Configure basic project information
+- **[User Details in ID Token](../user-details)** - Configure user data in JWT tokens
+- **[Session Management](../session-management)** - Control session duration and behavior
+- **[Project Settings](../../project-settings)** - Configure basic project information

--- a/embedded-wallets/dashboard/advanced/session-management.mdx
+++ b/embedded-wallets/dashboard/advanced/session-management.mdx
@@ -355,6 +355,6 @@ console.log('Expires At:', new Date(decoded.payload.exp * 1000))
 
 ## Next Steps
 
-- **[Key Export Settings](./key-export)** - Configure private key export permissions
-- **[User Details in ID Token](./user-details)** - Manage user data in JWT tokens
-- **[Project Settings](../project-settings)** - Configure basic project information
+- **[Key Export Settings](../key-export)** - Configure private key export permissions
+- **[User Details in ID Token](../user-details)** - Manage user data in JWT tokens
+- **[Project Settings](../../project-settings)** - Configure basic project information

--- a/embedded-wallets/dashboard/advanced/user-details.mdx
+++ b/embedded-wallets/dashboard/advanced/user-details.mdx
@@ -613,6 +613,6 @@ class UserDataCache {
 
 ## Next Steps
 
-- **[Session Management](./session-management)** - Configure session duration and behavior
-- **[Key Export Settings](./key-export)** - Control private key export permissions
-- **[Project Settings](../project-settings)** - Configure basic project information
+- **[Session Management](../session-management)** - Configure session duration and behavior
+- **[Key Export Settings](../key-export)** - Control private key export permissions
+- **[Project Settings](../../project-settings)** - Configure basic project information

--- a/embedded-wallets/dashboard/project-settings.mdx
+++ b/embedded-wallets/dashboard/project-settings.mdx
@@ -238,8 +238,8 @@ Archiving preserves all project data and allows for restoration. If you need to 
 
 For comprehensive project configuration, explore these related settings:
 
-- **[Whitelist Settings](./whitelist)** - Configure domain and URL authorization for enhanced security
-- **[Advanced Project Settings](./advanced/session-management)** - Access session management, key export, user data, and testing configurations
+- **[Whitelist Settings](../whitelist)** - Configure domain and URL authorization for enhanced security
+- **[Advanced Project Settings](../advanced/session-management)** - Access session management, key export, user data, and testing configurations
 
 ### Quick Start Guide
 

--- a/embedded-wallets/dashboard/whitelist.mdx
+++ b/embedded-wallets/dashboard/whitelist.mdx
@@ -302,6 +302,6 @@ https://*.api.myapp.com
 
 ## Next Steps
 
-- **[Project Settings](./project-settings)** - Configure basic project information
-- **[Advanced Project Settings](./advanced/session-management)** - Access advanced configuration options
-- **[Session Management](./advanced/session-management)** - Control session duration and behavior
+- **[Project Settings](../project-settings)** - Configure basic project information
+- **[Advanced Project Settings](../advanced/session-management)** - Access advanced configuration options
+- **[Session Management](../advanced/session-management)** - Control session duration and behavior

--- a/embedded-wallets/sdk/react/advanced/custom-authentication.mdx
+++ b/embedded-wallets/sdk/react/advanced/custom-authentication.mdx
@@ -58,7 +58,7 @@ You can only configure implicit login via modal, for JWT based logins, you need 
 
 For the modal custom authentication, you need to pass the `modalConfig` object to the `Web3AuthOptions` object within the constructor.
 
-> **Read more about the `modalConfig` object in the [Whitelabel](./whitelabel) section.**
+> **Read more about the `modalConfig` object in the [Whitelabel](../whitelabel) section.**
 
 ### Usage
 

--- a/embedded-wallets/sdk/react/advanced/whitelabel.mdx
+++ b/embedded-wallets/sdk/react/advanced/whitelabel.mdx
@@ -249,4 +249,4 @@ export default web3AuthContextConfig
 
 For complete control over the authentication interface, you can bypass the Web3Auth modal entirely and use the `connectTo` function. This allows you to create custom buttons that connect directly to specific auth providers.
 
-See the [Custom Authentication](./custom-authentication) section for detailed implementation instructions.
+See the [Custom Authentication](../custom-authentication) section for detailed implementation instructions.

--- a/gator_versioned_docs/version-0.13.0/concepts/delegation/caveat-enforcers.md
+++ b/gator_versioned_docs/version-0.13.0/concepts/delegation/caveat-enforcers.md
@@ -5,7 +5,7 @@ description: Learn about caveat enforcers and how they restrict delegations.
 # Caveat enforcers
 
 The MetaMask Delegation Toolkit provides *caveat enforcers*, which are smart contracts that implement rules and restrictions (*caveats*) on delegations.
-They serve as the underlying mechanism that enables conditional execution within the [Delegation Framework](index.md#delegation-framework).
+They serve as the underlying mechanism that enables conditional execution within the [Delegation Framework](./index.md#delegation-framework).
 
 A caveat enforcer acts as a gate that validates whether a delegation can be used for a particular execution. When a delegate attempts to execute an action on behalf of a delegator, each caveat enforcer specified in the delegation evaluates whether the execution meets its defined criteria.
 
@@ -163,7 +163,7 @@ For other restriction patterns, you can also [create custom caveat enforcers](/t
 
 ## Attenuating authority with redelegations
 
-When creating chains of delegations via [redelegations](index.md#delegation-types), it's important to understand how authority flows and can be restricted.
+When creating chains of delegations via [redelegations](./index.md#delegation-types), it's important to understand how authority flows and can be restricted.
 
 Caveats applied to a chain of delegations are *accumulative*—they stack on top of each other:
 

--- a/services/concepts/bundler.md
+++ b/services/concepts/bundler.md
@@ -16,7 +16,7 @@ owned accounts (EOAs) only, use standard Ethereum JSON-RPC methods.
 AA moves validation and fee-payment logic into smart contracts. Instead of sending raw transactions
 from an EOA, clients submit [user operations (UserOps)](#user-operations) to a bundler. The
 bundler collects and simulates these operations, then executes them through a
-[shared coordination contract (EntryPoint)](#entrypoint-contracts) on the network.
+[shared coordination contract (EntryPoint)](#entrypoint-contract) on the network.
 
 Smart accounts are smart contract-based wallets that serve as the foundation of AA. They embed custom
 logic for authentication, authorization, network fee payment, nonce management and execution.
@@ -47,7 +47,7 @@ validate and execute user operations (UserOps) from smart accounts. At a high le
 The bundler supports calling multiple EntryPoint versions (v0.6 and v0.7/v0.8) through the same set
 of RPC methods, allowing it to handle both older and modern smart account schemes.
 
-Use the [`eth_supportedEntryPoints`](../reference/ethereum/json-rpc-methods/bundler/eth_supportedentrypoints)
+Use the [`eth_supportedEntryPoints`](../reference/ethereum/json-rpc-methods/bundler/eth_supportedentrypoints.mdx)
 method to fetch the EntryPoint addresses supported by the bundler.
 
 ## Supported methods
@@ -56,19 +56,19 @@ The following bundler methods are available on the [supported networks](#support
 
 - [`eth_sendUserOperation`](../reference/ethereum/json-rpc-methods/bundler/eth_senduseroperation.mdx):
     Submits a user operation to be included onchain.
-- [`eth_estimateUserOperationGas`](../reference/ethereum/json-rpc-methods/bundler/eth_estimateuseroperationgas):
+- [`eth_estimateUserOperationGas`](../reference/ethereum/json-rpc-methods/bundler/eth_estimateuseroperationgas.mdx):
     Simulates the user operation and estimates the appropriate gas limits.
-- [`eth_getUserOperationReceipt`](../reference/ethereum/json-rpc-methods/bundler/eth_getuseroperationreceipt):
+- [`eth_getUserOperationReceipt`](../reference/ethereum/json-rpc-methods/bundler/eth_getuseroperationreceipt.mdx):
     Fetches the receipt of a user operation.
-- [`eth_getUserOperationByHash`](../reference/ethereum/json-rpc-methods/bundler/eth_getuseroperationbyhash):
+- [`eth_getUserOperationByHash`](../reference/ethereum/json-rpc-methods/bundler/eth_getuseroperationbyhash.mdx):
     Fetches the user operation by hash.
-- [`eth_supportedEntryPoints`](../reference/ethereum/json-rpc-methods/bundler/eth_supportedentrypoints):
+- [`eth_supportedEntryPoints`](../reference/ethereum/json-rpc-methods/bundler/eth_supportedentrypoints.mdx):
     Fetches the EntryPoint addresses supported by the bundler.
-- [`pimlico_getUserOperationGasPrice`](../reference/ethereum/json-rpc-methods/bundler/pimlico_getuseroperationgasprice):
+- [`pimlico_getUserOperationGasPrice`](../reference/ethereum/json-rpc-methods/bundler/pimlico_getuseroperationgasprice.mdx):
     Returns the gas prices that must be used for the user operation.
-- [`pimlico_getUserOperationStatus`](../reference/ethereum/json-rpc-methods/bundler/pimlico_getuseroperationstatus):
+- [`pimlico_getUserOperationStatus`](../reference/ethereum/json-rpc-methods/bundler/pimlico_getuseroperationstatus.mdx):
     Returns the user operation status.
-- [`pimlico_simulateAssetChanges`](../reference/ethereum/json-rpc-methods/bundler/pimlico_simulateassetchanges):
+- [`pimlico_simulateAssetChanges`](../reference/ethereum/json-rpc-methods/bundler/pimlico_simulateassetchanges.mdx):
     Simulates a user operation to predict the asset changes it will cause.
 
 ## Supported networks

--- a/src/pages/tutorials/upgrade-eoa-to-smart-account.md
+++ b/src/pages/tutorials/upgrade-eoa-to-smart-account.md
@@ -494,4 +494,4 @@ You have successfully used the SDK to upgrade a MetaMask EOA to a MetaMask smart
 
 - View the `feat-mm-sdk-final` branch of the [`MetaMask/7702-livestream-demo`](https://github.com/MetaMask/7702-livestream-demo/tree/feat-mm-sdk-final) repository for the completed implementation of this tutorial.
 - Watch the [live coding session](https://www.youtube.com/watch?v=crMqCb8RPEE) on YouTube, in which the MetaMask DevRel team walks through setting up EIP-7702 functionality from the initial template.
-- See the [Delegation Toolkit EIP-7702 quickstart](/delegation-toolkit/get-started/smart-account-quickstart/eip7702.md) to learn how to use the Delegation Toolkit to upgrade an EOA to a MetaMask smart account.
+- See the [Delegation Toolkit EIP-7702 quickstart](/delegation-toolkit/get-started/smart-account-quickstart/eip7702) to learn how to use the Delegation Toolkit to upgrade an EOA to a MetaMask smart account.


### PR DESCRIPTION
# Description

Fixes internal broken links in the doc. Some of these appear to be false positives.

## Issue(s) fixed

Fixes #2366 2366

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken internal doc links/anchors and file extensions across multiple pages to ensure correct navigation.
> 
> - **Delegation Toolkit docs**:
>   - Update relative links to `./index.md#...` in `concepts/delegation/caveat-enforcers.md` (and versioned copy).
>   - Fix ERC-7715 guide link to `execute-on-metamask-users-behalf.md` and related paths.
> - **Embedded Wallets (Dashboard)**:
>   - Correct "Next Steps" link paths in `advanced/key-export.mdx`, `advanced/session-management.mdx`, `advanced/user-details.mdx`, `project-settings.mdx`, and `whitelist.mdx` (adjust directory levels).
> - **Embedded Wallets (React SDK)**:
>   - Fix cross-links between `advanced/custom-authentication.mdx` and `advanced/whitelabel.mdx` to use correct parent paths.
> - **Services > Bundler**:
>   - Fix anchor from `#entrypoint-contracts` to `#entrypoint-contract`.
>   - Add `.mdx` extensions for JSON-RPC method reference links; fix `eth_supportedEntryPoints` reference path.
> - **Tutorials**:
>   - Remove `.md` suffix from EIP-7702 quickstart link path in `upgrade-eoa-to-smart-account.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ab7c68bb12fa059d815dd4c8c7fe77dc65cb9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->