### PR TITLE
docs: fix broken links

### DIFF
--- a/delegation-toolkit/guides/configure-toolkit.md
+++ b/delegation-toolkit/guides/configure-toolkit.md
@@ -135,7 +135,7 @@ const environment: DeleGatorEnvironment = getDelegatorEnvironment(11155111);
 
 You can deploy the contracts using any method, but the toolkit provides a convenient [`deployDelegatorEnvironment`](../reference/delegation/index.md#deploydelegatorenvironment) function. This function simplifies deploying the Delegation Framework contracts to your desired EVM chain.
 
-This function requires a Viem [Public Client](https://viem.sh/docs/clients/public.html), [Wallet Client](https://viem.sh/docs/clients/wallet.html), and [Chain](https://viem.sh/docs/glossary/types#chain)
+This function requires a Viem [Public Client](https://viem.sh/docs/clients/public), [Wallet Client](https://viem.sh/docs/clients/wallet), and [Chain](https://viem.sh/docs/glossary/types#chain)
 to deploy the contracts and resolve the `DeleGatorEnvironment`. 
 
 Your wallet must have a sufficient native token balance to deploy the contracts.


### PR DESCRIPTION
https://viem.sh/docs/clients/public.html and https://viem.sh/docs/clients/wallet.html - broken
https://viem.sh/docs/clients/public and https://viem.sh/docs/clients/wallet - works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken Viem Public/Wallet Client links by updating URLs in the configure toolkit guide.
> 
> - **Docs**:
>   - Update Viem client links in `delegation-toolkit/guides/configure-toolkit.md` from `/clients/public.html` and `/clients/wallet.html` to `/clients/public` and `/clients/wallet`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 909367d8a2eacf2fdae66c4b9dfd138a7141d8b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->