### PR TITLE
refactor: remove redundant CardSection theme state

### DIFF
--- a/src/components/CardSection.tsx
+++ b/src/components/CardSection.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { CSSProperties, JSX, useState, useEffect } from 'react'
+import { CSSProperties, JSX } from 'react'
 import { useColorMode } from '@docusaurus/theme-common'
 import Card, { CardItem } from '@site/src/components/Card'
 
@@ -19,11 +19,7 @@ export default function CardSection({
   colorPalette,
 }: CardSectionProps): JSX.Element {
   const { colorMode } = useColorMode()
-  const [theme, setTheme] = useState('')
-
-  useEffect(() => {
-    setTheme(colorMode)
-  }, [colorMode])
+  const theme = colorMode
 
   return (
     <section className={styles.wrapper}>


### PR DESCRIPTION
Remove the unnecessary useState/useEffect pair in CardSection and rely directly on colorMode, avoiding redundant state updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove redundant theme state in `CardSection` by using `colorMode` directly and deleting the `useState`/`useEffect` pair.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e5239583f7d195af126091f8a2d6f7d082ff2ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->