### PR TITLE
[Delegation toolkit] Improve code snippets

### DIFF
--- a/delegation-toolkit/guides/delegation/check-delegation-state.md
+++ b/delegation-toolkit/guides/delegation/check-delegation-state.md
@@ -82,14 +82,18 @@ const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnf
 
 ```typescript
 import { createDelegation } from '@metamask/delegation-toolkit'
+import { parseUnits } from 'viem'
+
+// startDate should be in seconds.
+const startDate = Math.floor(Date.now() / 1000);
 
 export const delegation = createDelegation({
   scope: {
     type: 'erc20PeriodTransfer',
     tokenAddress: '0xb4aE654Aca577781Ca1c5DE8FbE60c2F423f37da',
-    periodAmount: 1000000000000000000n,
+    periodAmount: parseUnits('10', 6),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   to: delegateAccount,
   from: delegatorAccount,

--- a/delegation-toolkit/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/delegation-toolkit/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -137,9 +137,10 @@ Before creating a delegation, ensure that the delegator account (in this example
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit"
+import { parseUnits } from "viem"
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
@@ -148,7 +149,8 @@ const delegation = createDelegation({
   scope: {
     type: "erc20TransferAmount",
     tokenAddress,
-    maxAmount: 10000000n,
+    // 10 USDC 
+    maxAmount: parseUnits("10", 6),
   },
 })
 ```
@@ -175,7 +177,7 @@ Bob can now redeem the delegation. The redeem transaction is sent to the `Delega
 To prepare the calldata for the redeem transaction, use the [`redeemDelegations`](../../reference/delegation/index.md#redeemdelegations) method from `DelegationManager`.
 Since Bob is redeeming a single delegation chain, use the [`SingleDefault`](../../concepts/delegation/index.md#execution-modes) execution mode.
 
-Bob can redeem the delegation by submitting a user operation if his account is a smart account, or a regular transaction if his account is an EOA:
+Bob can redeem the delegation by submitting a user operation if his account is a smart account, or a regular transaction if his account is an EOA. In this example, Bob transfers 1 USDC from Alice’s account to his own.
 
 <Tabs>
 <TabItem value="Redeem with a smart account">
@@ -184,10 +186,14 @@ Bob can redeem the delegation by submitting a user operation if his account is a
 import { createExecution, ExecutionMode } from "@metamask/delegation-toolkit"
 import { DelegationManager } from "@metamask/delegation-toolkit/contracts"
 import { zeroAddress } from "viem"
+import { callData } from "./config.ts"
 
 const delegations = [signedDelegation]
 
-const executions = createExecution({ target: zeroAddress })
+// USDC address on Ethereum Sepolia.
+const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+
+const executions = createExecution({ target: tokenAddress, callData })
 
 const redeemDelegationCalldata = DelegationManager.encode.redeemDelegations({
   delegations: [delegations],
@@ -215,10 +221,14 @@ const userOperationHash = await bundlerClient.sendUserOperation({
 import { createExecution, getDeleGatorEnvironment, ExecutionMode } from "@metamask/delegation-toolkit"
 import { DelegationManager } from "@metamask/delegation-toolkit/contracts"
 import { zeroAddress } from "viem"
+import { callData } from "./config.ts"
 
 const delegations = [signedDelegation]
 
-const executions = createExecution({ target: zeroAddress })
+// USDC address on Ethereum Sepolia.
+const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+
+const executions = createExecution({ target: tokenAddress, callData })
 
 const redeemDelegationCalldata = DelegationManager.encode.redeemDelegations({
   delegations: [delegations],
@@ -230,6 +240,21 @@ const transactionHash = await delegateWalletClient.sendTransaction({
   to: getDeleGatorEnvironment(chain.id).DelegationManager,
   data: redeemDelegationCalldata,
   chain,
+})
+```
+
+</TabItem>
+
+<TabItem value="config.ts">
+
+```typescript
+import { encodeFunctionData, erc20Abi, parseUnits } from "viem"
+
+// calldata to transfer 1 USDC to delegate address.
+export const callData = encodeFunctionData({
+  abi: erc20Abi,
+  args: [ delegateSmartAccount.address, parseUnits("1", 6) ],
+  functionName: 'transfer',
 })
 ```
 

--- a/delegation-toolkit/guides/delegation/use-delegation-scopes/spending-limit.md
+++ b/delegation-toolkit/guides/delegation/use-delegation-scopes/spending-limit.md
@@ -29,14 +29,19 @@ Internally, this scope uses the [`erc20PeriodTransfer`](../../../reference/deleg
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseUnits } from "viem";
+
+// startDate should be in seconds.
+const startDate = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "erc20PeriodTransfer",
     tokenAddress: "0xb4aE654Aca577781Ca1c5DE8FbE60c2F423f37da",
-    periodAmount: 1000000000000000000n,
+    // USDC has 6 decimal places.
+    periodAmount: parseUnits("10", 6),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   to: delegateAccount,
   from: delegatorAccount,
@@ -57,15 +62,20 @@ Internally, this scope uses the [`erc20Streaming`](../../../reference/delegation
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseUnits } from "viem";
+
+// startTime should be in seconds.
+const startTime = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "erc20Streaming",
     tokenAddress: "0xc11F3a8E5C7D16b75c9E2F60d26f5321C6Af5E92",
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    // USDC has 6 decimal places.
+    amountPerSecond: parseUnits("0.1", 6),
+    initialAmount: parseUnits("10", 6),
+    maxAmount: parseUnits("100", 6),
+    startTime,
   },
   to: delegateAccount,
   from: delegatorAccount,
@@ -86,12 +96,14 @@ Internally, this scope uses the [`erc20TransferAmount`](../../../reference/deleg
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseUnits } from "viem";
 
 const delegation = createDelegation({
   scope: {
     type: "erc20TransferAmount",
     tokenAddress: "0xc11F3a8E5C7D16b75c9E2F60d26f5321C6Af5E92",
-    maxAmount: 10000n,
+    // USDC has 6 decimal places.
+    maxAmount: parseUnits("10", 6),
   },
   to: delegateAccount,
   from: delegatorAccount,
@@ -135,13 +147,17 @@ Internally, this scope uses the [`exactCalldata`](../../../reference/delegation/
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseEther } from "viem";
+
+// startDate should be in seconds.
+const startDate = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenPeriodTransfer",
-    periodAmount: 1000000000000000000n,
+    periodAmount: parseEther("0.01"),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   to: delegateAccount,
   from: delegatorAccount,
@@ -162,14 +178,18 @@ Internally, this scope uses the [`exactCalldata`](../../../reference/delegation/
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseEther } from "viem";
+
+// startTime should be in seconds.
+const startTime = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenStreaming",
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    amountPerSecond: parseEther("0.001"),
+    initialAmount: parseEther("0.01"),
+    maxAmount: parseEther("0.1"),
+    startTime,
   },
   to: delegateAccount,
   from: delegatorAccount,
@@ -190,12 +210,12 @@ Internally, this scope uses the [`exactCalldata`](../../../reference/delegation/
 
 ```typescript
 import { createDelegation } from "@metamask/delegation-toolkit";
+import { parseEther } from "viem";
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
-    // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
   to: delegateAccount,
   from: delegatorAccount,

--- a/delegation-toolkit/guides/erc7715/execute-on-metamask-users-behalf.md
+++ b/delegation-toolkit/guides/erc7715/execute-on-metamask-users-behalf.md
@@ -252,11 +252,11 @@ const transactionHash = await sessionAccountWalletClient.sendTransactionWithDele
 <TabItem value="config.ts">
 
 ```typescript
-import { encodeFunctionData, erc20Abi } from "viem";
+import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
 
 export const calldata = encodeFunctionData({
   abi: erc20Abi,
-  args: [ sessionAccount.address, 1000000n ],
+  args: [ sessionAccount.address, parseUnits("1", 6) ],
   functionName: 'transfer',
 });
 ```

--- a/delegation-toolkit/guides/smart-accounts/deploy-smart-account.md
+++ b/delegation-toolkit/guides/smart-accounts/deploy-smart-account.md
@@ -38,7 +38,7 @@ const userOperationHash = await bundlerClient.sendUserOperation({
   calls: [
     {
       to: "0x1234567890123456789012345678901234567890",
-      value: parseEther("1")
+      value: parseEther("0.001"),
     }
   ],
   maxFeePerGas,

--- a/delegation-toolkit/guides/smart-accounts/send-gasless-transaction.md
+++ b/delegation-toolkit/guides/smart-accounts/send-gasless-transaction.md
@@ -39,7 +39,7 @@ const userOperationHash = await bundlerClient.sendUserOperation({
   calls: [
     {
       to: "0x1234567890123456789012345678901234567890",
-      value: parseEther("1")
+      value: parseEther("0.001")
     }
   ],
   maxFeePerGas,

--- a/delegation-toolkit/guides/smart-accounts/send-user-operation.md
+++ b/delegation-toolkit/guides/smart-accounts/send-user-operation.md
@@ -52,7 +52,7 @@ const userOperationHash = await bundlerClient.sendUserOperation({
   calls: [
     {
       to: "0x1234567890123456789012345678901234567890",
-      value: parseEther("1")
+      value: parseEther("0.001")
     }
   ],
   maxFeePerGas,

--- a/delegation-toolkit/reference/delegation/caveat-enforcer-client.md
+++ b/delegation-toolkit/reference/delegation/caveat-enforcer-client.md
@@ -92,13 +92,16 @@ import { getDeleGatorEnvironment } from '@metamask/delegation-toolkit'
 
 const environment = getDeleGatorEnvironment(chain.id)
 
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startDate = Math.floor(Date.now() / 1000)
+
 export const delegation = createDelegation({
   scope: {
     type: 'erc20PeriodTransfer',
     tokenAddress: '0xb4aE654Aca577781Ca1c5DE8FbE60c2F423f37da',
-    periodAmount: 1000000000000000000n,
+    periodAmount: parseUnits('10', 6),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   to: 'DELEGATE_ADDRESS',
   from: 'DELEGATOR_ADDRESS',
@@ -140,17 +143,21 @@ const { availableAmount } = await caveatEnforcerClient.getErc20StreamingEnforcer
 import { createDelegation } from '@metamask/delegation-toolkit'
 import { sepolia as chain } from 'viem/chains'
 import { getDeleGatorEnvironment } from '@metamask/delegation-toolkit'
+import { parseUnits } from 'viem'
 
 const environment = getDeleGatorEnvironment(chain.id)
+
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startTime = Math.floor(Date.now() / 1000)
 
 export const delegation = createDelegation({
   scope: {
     type: 'erc20Streaming',
     tokenAddress: '0xc11F3a8E5C7D16b75c9E2F60d26f5321C6Af5E92',
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    amountPerSecond: parseUnits('0.1', 6),
+    initialAmount: parseUnits('1', 6),
+    maxAmount: parseUnits('10', 6),
+    startTime,
   },
   to: 'DELEGATE_ADDRESS',
   from: 'DELEGATOR_ADDRESS',
@@ -191,16 +198,20 @@ const { availableAmount } = await caveatEnforcerClient.getNativeTokenPeriodTrans
 ```typescript
 import { createDelegation } from '@metamask/delegation-toolkit'
 import { sepolia as chain } from 'viem/chains'
+import { parseEther } from 'viem'
 import { getDeleGatorEnvironment } from '@metamask/delegation-toolkit'
 
 const environment = getDeleGatorEnvironment(chain.id)
 
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startDate = Math.floor(Date.now() / 1000)
+
 export const delegation = createDelegation({
   scope: {
     type: 'nativeTokenPeriodTransfer',
-    periodAmount: 1000000000000000000n,
+    periodAmount: parseEther('0.01', 6),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   to: 'DELEGATE_ADDRESS',
   from: 'DELEGATOR_ADDRESS',
@@ -245,13 +256,16 @@ import { getDeleGatorEnvironment } from '@metamask/delegation-toolkit'
 
 const environment = getDeleGatorEnvironment(chain.id)
 
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startTime = Math.floor(Date.now() / 1000)
+
 export const delegation = createDelegation({
   scope: {
     type: "nativeTokenStreaming",
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    amountPerSecond: parseEther('0.001'),
+    initialAmount: parseEther('0.01'),
+    maxAmount: parseEther('0.1'),
+    startTime,
   },
   to: 'DELEGATE_ADDRESS',
   from: 'DELEGATOR_ADDRESS',
@@ -300,6 +314,7 @@ const { availableAmount } = await caveatEnforcerClient.getMultiTokenPeriodEnforc
 import { createDelegation, getDeleGatorEnvironment, ROOT_AUTHORITY } from '@metamask/delegation-toolkit'
 import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils'
 import { sepolia as chain } from 'viem/chains'
+import { parseUnits, parseEther } from 'viem'
 
 const environment = getDeleGatorEnvironment(chain.id)
 const caveatBuilder = createCaveatBuilder(environment)
@@ -311,8 +326,8 @@ const startDate = Math.floor(Date.now() / 1000);
 const tokenConfigs = [
   {
     token: "0xb4aE654Aca577781Ca1c5DE8FbE60c2F423f37da",
-    // 1 token with 18 decimals.
-    periodAmount: 1000000000000000000n,
+    // 1 token with 6 decimals.
+    periodAmount: parseUnits('1', 6),
      // 1 day in seconds.
     periodDuration: 86400,
     startDate
@@ -321,14 +336,14 @@ const tokenConfigs = [
     // For native token use zeroAddress
     token: zeroAddress,
     // 0.01 ETH in wei.
-    periodAmount: 10000000000000000n,
+    periodAmount: parseEther('0.01'),
     // 1 hour in seconds.
     periodDuration: 3600,
     startDate
   }
 ]
 
-const caveats = caveatBuilder.addCaveat('nativeTokenTransferAmount', 1000000n).addCaveat({
+const caveats = caveatBuilder.addCaveat({
   'multiTokenPeriod',
    tokenConfigs
 })

--- a/delegation-toolkit/reference/delegation/delegation-scopes.md
+++ b/delegation-toolkit/reference/delegation/delegation-scopes.md
@@ -31,14 +31,19 @@ At the start of each new period, the allowance resets.
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseUnits } from "viem";
+
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startDate = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "erc20PeriodTransfer",
     tokenAddress: "0xb4aE654Aca577781Ca1c5DE8FbE60c2F423f37da",
-    periodAmount: 1000000000000000000n,
+    // 10 ERC-20 token with 6 decimals
+    periodAmount: parseUnits("10", 6),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -70,15 +75,22 @@ At the start, a specified initial amount is released, after which tokens accrue 
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseUnits } from "viem";
+
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startTime = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "erc20Streaming",
     tokenAddress: "0xc11F3a8E5C7D16b75c9E2F60d26f5321C6Af5E92",
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    // 0.1 ERC-20 token with 6 decimals
+    amountPerSecond: parseUnits("0.1", 6),
+    // 1 ERC-20 token with 6 decimals
+    initialAmount: parseUnits("1", 6),
+    // 10 ERC-20 token with 6 decimals
+    maxAmount: parseUnits("10", 6),
+    startTime,
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -106,12 +118,14 @@ This scope is useful for setting simple, fixed transfer limits without any time-
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseUnits } from "viem";
 
 const delegation = createDelegation({
   scope: {
     type: "erc20TransferAmount",
     tokenAddress: "0xc11F3a8E5C7D16b75c9E2F60d26f5321C6Af5E92",
-    maxAmount: 10000n,
+    // 1 ERC-20 token with 6 decimals
+    maxAmount: parseUnits("1", 6),
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -174,13 +188,17 @@ At the start of each new period, the allowance resets.
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
+
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startDate = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenPeriodTransfer",
-    periodAmount: 1000000000000000000n,
+    periodAmount: parseEther("0.01"),
     periodDuration: 86400,
-    startDate: 1743763600,
+    startDate,
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -213,14 +231,18 @@ At the start, a specified initial amount is released, after which tokens accrue 
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
+
+// Since current time is in seconds, we need to convert milliseconds to seconds.
+const startTime = Math.floor(Date.now() / 1000);
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenStreaming",
-    amountPerSecond: 100n,
-    initialAmount: 1000000n,
-    maxAmount: 10000000n,
-    startTime: 1703980800,
+    amountPerSecond: parseEther("0.0001"),
+    initialAmount: parseEther("0.01"),
+    maxAmount: parseEther("0.1"),
+    startTime,
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -249,12 +271,13 @@ This scope is useful for setting simple, fixed transfer limits without any time 
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
 
 const delegation = createDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
     // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
   // Address that is granting the delegation
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",

--- a/delegation-toolkit/reference/delegation/index.md
+++ b/delegation-toolkit/reference/delegation/index.md
@@ -101,6 +101,7 @@ Creates a delegation with a specific delegate.
 ```typescript
 import { createDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
 
 const delegation = createDelegation({
   // Address that is granting the delegation
@@ -112,7 +113,7 @@ const delegation = createDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
     // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
 });
 ```
@@ -138,6 +139,7 @@ Creates an open delegation that can be redeemed by any delegate.
 ```typescript
 import { createOpenDelegation, getDelegatorEnvironment } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
 
 const delegation = createOpenDelegation({
   // Address that is granting the delegation
@@ -147,7 +149,7 @@ const delegation = createOpenDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
     // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
 });
 ```
@@ -168,13 +170,14 @@ Creates an `ExecutionStruct` instance.
 
 ```ts
 import { createExecution } from "@metamask/delegation-toolkit";
+import { parseEther } from "viem";
 
 // Creates an ExecutionStruct to transfer 0.01 ETH to
 // 0xe3C818389583fDD5cAC32f548140fE26BcEaE907 address.
 const execution = createExecution({
   target: "0xe3C818389583fDD5cAC32f548140fE26BcEaE907",
   // 0.01 ETH in wei
-  value: 10000000000000000n,
+  value: parseEther("0.01"),
   callData: "0x",
 });
 ```
@@ -295,6 +298,7 @@ const disableDelegationData = DelegationManager.encode.disableDelegation({
 ```ts
 import { createDelegation } from "@metamask/delegation-toolkit";
 import { sepolia } from "viem/chains";
+import { parseEther } from "viem";
 
 export const delegation = createDelegation({
   from: "0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1",
@@ -303,7 +307,7 @@ export const delegation = createDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
     // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
 });
 ```
@@ -448,7 +452,7 @@ import {
   getDeleGatorEnvironment,
   createDelegation,
 } from "@metamask/delegation-toolkit";
-import { createWalletClient } from "viem";
+import { createWalletClient, parseEther } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 
@@ -474,7 +478,7 @@ export const delegation = createDelegation({
   scope: {
     type: "nativeTokenTransferAmount",
     // 0.001 ETH in wei format.
-    maxAmount: 1000000000000000n,
+    maxAmount: parseEther("0.001"),
   },
 });
 ```


### PR DESCRIPTION
# Description

Improves the code snippets, avoids using the value, and uses viem utils to convert to desired format. Skips caveats, as part of another issue. 

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes docs examples by switching bigint literals to viem `parseUnits`/`parseEther`, computing start times at runtime, adding ERC-20 transfer calldata/targets for redemption, and reducing sample ETH values.
> 
> - **Guides**:
>   - Replace bigint literals with `parseUnits`/`parseEther` and compute `startDate`/`startTime` via `Math.floor(Date.now()/1000)` across `delegation` and ERC-7715 examples.
>   - Update redemption flows to use concrete ERC‑20 transfer calls:
>     - Set `createExecution` `target` to USDC `tokenAddress` and pass `callData` for `transfer` of 1 USDC via a new `config.ts`.
>     - Add explicit `tokenAddress` and `callData` in both smart account and EOA paths.
>   - Adjust sample ETH transfer values from `parseEther("1")` to `parseEther("0.001")` in smart account user operation examples.
> - **Reference**:
>   - Align API examples to viem helpers for amounts (`parseUnits`/`parseEther`) and dynamic timestamps; add necessary imports and comments about seconds.
>   - Update `createExecution` example `value` to `parseEther("0.01")`.
>   - Revise multi-token period enforcer example to use parsed amounts and remove hardcoded caveats values, keeping `multiTokenPeriod` config only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 115c8530df192707fbe22e1a130e6f6fb10f3955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->