### PR TITLE
Removal

### DIFF
--- a/services/reference/_partials/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/_partials/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/arbitrum/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/arbitrum/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://arbitrum-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://arbitrum-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://arbitrum-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/avalanche-c-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/avalanche-c-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://avalanche-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://avalanche-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://avalanche-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/base/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/base/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://base-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://base-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://base-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/blast/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/blast/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://blast-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://blast-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://blast-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/bnb-smart-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/bnb-smart-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://bsc-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://bsc-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://bsc-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/linea/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/linea/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://linea-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://linea-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params": [],"id":1}'
+wscat -c wss://linea-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc":"2.0","method":"eth_maxPriorityFeePerGas","params": [],"id":1}'
 ```
 
   </TabItem>

--- a/services/reference/mantle/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/mantle/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://mantle-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://mantle-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://mantle-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/opbnb/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/opbnb/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://opbnb-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://opbnb-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://opbnb-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/optimism/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/optimism/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://optimism-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://optimism-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://optimism-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/polygon-pos/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/polygon-pos/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://polygon-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://polygon-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://polygon-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>

--- a/services/reference/scroll/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
+++ b/services/reference/scroll/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx
@@ -15,7 +15,7 @@ curl https://scroll-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://scroll-mainnet.infura.io/ws/v3/d23391e03c6d40738530a1b4b679e66e -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
+wscat -c wss://scroll-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_maxPriorityFeePerGas", "params": [], "id": 1}'
 ```
 
   </TabItem>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces hardcoded API key with <YOUR-API-KEY> in WSS `wscat` examples for `eth_maxPriorityFeePerGas` across multiple network docs.
> 
> - **Docs**:
>   - **WSS examples**: Replace hardcoded API key with `<YOUR-API-KEY>` in `wscat` commands for `eth_maxPriorityFeePerGas`.
>     - Updated files:
>       - `services/reference/_partials/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/arbitrum/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/avalanche-c-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/base/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/blast/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/bnb-smart-chain/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/linea/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/mantle/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/opbnb/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/optimism/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/polygon-pos/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
>       - `services/reference/scroll/json-rpc-methods/_eth_maxpriorityfeepergas-request.mdx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37fa14fa9a470dc6cff934da0553d56a1922de4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->