### PR TITLE
Change homepage card order

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,31 +22,10 @@ export default function Home(): JSX.Element {
         description="Build with the world's leading self-custodial crypto wallet."
       />
 
-      <SectionIntro description="Get started with the following resources:" />
-
-      <CardSection
-        colorPalette="purple"
-        cards={[
-          {
-            title: 'Quickstart',
-            description: 'Choose a quickstart guide that matches your project goals.',
-            href: '/quickstart',
-            buttonIcon: 'arrow-right',
-          },
-          {
-            title: 'Tutorials',
-            description:
-              'Explore use cases and follow the hands-on tutorials to build end-to-end dapps.',
-            href: '/tutorials/',
-            buttonIcon: 'arrow-right',
-          },
-        ]}
-      />
-
       <SectionIntro description="What do you want to do with MetaMask?" />
 
       <CardSection
-        colorPalette="blue"
+        colorPalette="purple"
         cards={[
           {
             title: 'Connect to MetaMask',
@@ -81,6 +60,27 @@ export default function Home(): JSX.Element {
             description:
               'Create a custom mini app that runs inside the MetaMask extension. Add support for custom networks, accounts types, and APIs.',
             href: '/snaps',
+            buttonIcon: 'arrow-right',
+          },
+        ]}
+      />
+
+      <SectionIntro description="Get started with the following resources:" />
+
+      <CardSection
+        colorPalette="blue"
+        cards={[
+          {
+            title: 'Quickstart',
+            description: 'Choose a quickstart guide that matches your project goals.',
+            href: '/quickstart',
+            buttonIcon: 'arrow-right',
+          },
+          {
+            title: 'Tutorials',
+            description:
+              'Explore use cases and follow the hands-on tutorials to build end-to-end dapps.',
+            href: '/tutorials/',
             buttonIcon: 'arrow-right',
           },
         ]}


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Change order of card sections on home page so product cards are more visible.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://metamask-docs-gehps5syk-consensys-ddffed67.vercel.app/

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders homepage card sections to show product cards first and swaps their color palettes (product to purple, resources to blue).
> 
> - **Homepage (`src/pages/index.tsx`)**:
>   - **Reorder sections**: Move `SectionIntro` and `CardSection` for "Get started" (Quickstart/Tutorials) below the product-focused "What do you want to do with MetaMask?" card section.
>   - **Color palettes**: Product cards `colorPalette` changed to `"purple"`; "Get started" cards set to `"blue"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 678ac93987353db190a26d0725a5b607df477c8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->