### PR TITLE
Celo updates.

### DIFF
--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -57,6 +57,14 @@ Ensure that you replace `<YOUR-API-KEY>` with an API key from your [MetaMask Dev
 
 ## Celo
 
+:::info Celo Alfajores Deprecation Notice
+
+As communicated by the
+[Celo Foundation](https://forum.celo.org/t/introducing-celo-sepolia-celo-s-new-ethereum-l2-testnet/12155)
+and Ethereum Foundation, the Holesky testnet has reached end of life as of September 30th, 2025. Celo Alfajores builds upon Holesky, which means it has also reached its end of life.
+
+:::
+
 | Network             | Description             | URL                                                   |
 |---------------------|-------------------------|-------------------------------------------------------|
 | Mainnet             | JSON-RPC over HTTPS     | `https://celo-mainnet.infura.io/v3/<YOUR-API-KEY>`    |

--- a/services/reference/celo/index.md
+++ b/services/reference/celo/index.md
@@ -6,16 +6,11 @@ import CardList from '@site/src/components/CardList'
 
 # Celo
 
-Celo is a fully EVM-compatible, Proof of Stake (PoS), layer-1 protocol that features a mobile-first platform, built-in
-stablecoins, collateralized by crypto and natural assets.
-
-Celo is a platform that acts as a global payment infrastructure for cryptocurrencies targeting mobile users. Celo operates
-native, ERC20-like stable tokens like [cUSD, cEUR, and cREAL](https://celoreserve.org/).
+Celo is an Ethereum layer-2 network designed for fast, low-cost payments. It offers low fees and fast finality while letting you reuse familiar Ethereum tools and contracts with little or no change.
 
 :::info See also
 
 - The [official Celo documentation](https://docs.celo.org/) for more information.
-- The [key differences between building on Celo and Ethereum](https://docs.celo.org/developer/migrate/from-ethereum).
 
 :::
 

--- a/services/reference/celo/json-rpc-methods/index.md
+++ b/services/reference/celo/json-rpc-methods/index.md
@@ -22,6 +22,3 @@ The following methods are supported by Celo, but not supported by Infura using a
 - `eth_newFilter`
 - `eth_newBlockFilter`
 - `eth_uninstallFilter`
-
-Infura is also compatible with the [Celo ContractKit](https://docs.celo.org/developer/contractkit), a library of tools
-designed to integrate applications with Celo.


### PR DESCRIPTION
# Description

Celo is now an L2. Also the testnet is being deprecated.

## Checklist



- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Celo docs to L2 positioning, adds Alfajores deprecation notice in endpoints, and removes ContractKit mention from JSON-RPC methods.
> 
> - **Celo documentation updates**:
>   - **L2 positioning**: Revise overview in `services/reference/celo/index.md` to describe Celo as an Ethereum L2 and streamline "See also" links.
>   - **Testnet deprecation**: Add Alfajores deprecation notice in `services/get-started/endpoints.md` under the Celo section.
>   - **JSON-RPC cleanup**: In `services/reference/celo/json-rpc-methods/index.md`, keep unsupported methods list and remove the ContractKit compatibility note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e64f6520019d4e0a8f7446db9f82e7db659d00f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->