### PR TITLE
[Delegation Toolkit][ERC-7715] Hot Fixes

### DIFF
--- a/delegation-toolkit/guides/erc7715/execute-on-metamask-users-behalf.md
+++ b/delegation-toolkit/guides/erc7715/execute-on-metamask-users-behalf.md
@@ -56,8 +56,8 @@ const publicClient = createPublicClient({
 ### 3. Set up a session account
 
 Set up a session account which can either be a smart account or an externally owned account (EOA)
-to request ERC-7715 permissions. This account is responsible for executing transactions
-on behalf of the user. 
+to request ERC-7715 permissions. The requested permissions are granted to the session account, which
+is responsible for executing transactions on behalf of the user.
 
 <Tabs>
 <TabItem value="Smart account">
@@ -97,7 +97,7 @@ const sessionAccount = privateKeyToAccount("0x...");
 
 ### 4. Check the EOA account code
 
-Currently, ERC-7715 does not support automatically upgrading a user's account to a [MetaMask smart account](../../concepts/smart-accounts.md). Therefore, you must 
+Currently, ERC-7715 does not support automatically upgrading a MetaMask user's account to a [MetaMask smart account](../../concepts/smart-accounts.md). Therefore, you must 
 ensure that the user is upgraded to a smart account before requesting ERC-7715 permissions.
 
 If the user has not yet been upgraded, you can handle the upgrade [programmatically](/wallet/how-to/send-transactions/send-batch-transactions/#about-atomic-batch-transactions) or ask the 
@@ -162,6 +162,8 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
   signer: {
     type: "account",
     data: {
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccount.address,
     },
   },

--- a/delegation-toolkit/guides/erc7715/use-permissions/erc20-token.md
+++ b/delegation-toolkit/guides/erc7715/use-permissions/erc20-token.md
@@ -47,6 +47,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },
@@ -112,6 +115,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },

--- a/delegation-toolkit/guides/erc7715/use-permissions/native-token.md
+++ b/delegation-toolkit/guides/erc7715/use-permissions/native-token.md
@@ -44,6 +44,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },
@@ -106,6 +109,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },

--- a/delegation-toolkit/reference/erc7715/wallet-client.md
+++ b/delegation-toolkit/reference/erc7715/wallet-client.md
@@ -50,6 +50,7 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
   signer: {
     type: "account",
     data: {
+      // The requested permissions will granted to the address.
       address: "0x0955fFD7b83e5493a8c1FD5dC87e2CF37Eacc44a",
     },
   },

--- a/gator_versioned_docs/version-0.13.0/guides/erc7715/execute-on-metamask-users-behalf.md
+++ b/gator_versioned_docs/version-0.13.0/guides/erc7715/execute-on-metamask-users-behalf.md
@@ -56,8 +56,8 @@ const publicClient = createPublicClient({
 ### 3. Set up a session account
 
 Set up a session account which can either be a smart account or an externally owned account (EOA)
-to request ERC-7715 permissions. This account is responsible for executing transactions
-on behalf of the user. 
+to request ERC-7715 permissions. The requested permissions are granted to the session account, which
+is responsible for executing transactions on behalf of the user.
 
 <Tabs>
 <TabItem value="Smart account">
@@ -97,7 +97,7 @@ const sessionAccount = privateKeyToAccount("0x...");
 
 ### 4. Check the EOA account code
 
-Currently, ERC-7715 does not support automatically upgrading a user's account to a [MetaMask smart account](../../concepts/smart-accounts.md). Therefore, you must 
+Currently, ERC-7715 does not support automatically upgrading a MetaMask user's account to a [MetaMask smart account](../../concepts/smart-accounts.md). Therefore, you must 
 ensure that the user is upgraded to a smart account before requesting ERC-7715 permissions.
 
 If the user has not yet been upgraded, you can handle the upgrade [programmatically](/wallet/how-to/send-transactions/send-batch-transactions/#about-atomic-batch-transactions) or ask the 
@@ -162,6 +162,8 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
   signer: {
     type: "account",
     data: {
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccount.address,
     },
   },

--- a/gator_versioned_docs/version-0.13.0/guides/erc7715/use-permissions/erc20-token.md
+++ b/gator_versioned_docs/version-0.13.0/guides/erc7715/use-permissions/erc20-token.md
@@ -47,6 +47,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },
@@ -112,6 +115,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },

--- a/gator_versioned_docs/version-0.13.0/guides/erc7715/use-permissions/native-token.md
+++ b/gator_versioned_docs/version-0.13.0/guides/erc7715/use-permissions/native-token.md
@@ -44,6 +44,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },
@@ -106,6 +109,9 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
     type: "account",
     data: {
       // Session account created as a prerequisite.
+      //
+      // The requested permissions will granted to the
+      // session account.
       address: sessionAccountAddress,
     },
   },

--- a/gator_versioned_docs/version-0.13.0/reference/erc7715/wallet-client.md
+++ b/gator_versioned_docs/version-0.13.0/reference/erc7715/wallet-client.md
@@ -50,6 +50,7 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([{
   signer: {
     type: "account",
     data: {
+      // The requested permissions will granted to the address.
       address: "0x0955fFD7b83e5493a8c1FD5dC87e2CF37Eacc44a",
     },
   },


### PR DESCRIPTION
# Description

Hot Fixes for ERC-7715 to improve description, and code snippets based on the internal feedback. 

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies that ERC-7715 permissions are granted to the session account and updates all ERC-20/native token examples to include isAdjustmentAllowed, with minor wording and comment tweaks.
> 
> - **Guides (ERC-7715)**:
>   - Clarify that requested permissions are granted to the `session account`, which executes on the user’s behalf (`guides/erc7715/...`).
>   - Update examples to explicitly set `isAdjustmentAllowed: true` in permission requests for ERC-20 periodic/stream and native token periodic/stream.
>   - Minor copy edits (e.g., MetaMask user wording) and added inline comments indicating permissions apply to the session account.
> - **Reference**:
>   - Example in `reference/erc7715/wallet-client.md` adds a comment clarifying the address receiving permissions; examples also include `isAdjustmentAllowed: true`.
> - **Versioned docs (`gator_versioned_docs/version-0.13.0`)**:
>   - Mirror the same clarifications and example updates (session account notes, `isAdjustmentAllowed: true`, minor formatting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4aeb3906b875c463827376bbf630864bb4e497a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->