### PR TITLE
Remove testnet.

### DIFF
--- a/services/get-started/endpoints.md
+++ b/services/get-started/endpoints.md
@@ -57,20 +57,15 @@ Ensure that you replace `<YOUR-API-KEY>` with an API key from your [MetaMask Dev
 
 ## Celo
 
-:::info Celo Alfajores Deprecation Notice
-
-As communicated by the
-[Celo Foundation](https://forum.celo.org/t/introducing-celo-sepolia-celo-s-new-ethereum-l2-testnet/12155)
-and Ethereum Foundation, the Holesky testnet has reached end of life as of September 30th, 2025. Celo Alfajores builds upon Holesky, which means it has also reached its end of life.
-
+:::info Mainnet only
+Infura provides access to Celo mainnet only.
 :::
 
 | Network             | Description             | URL                                                   |
 |---------------------|-------------------------|-------------------------------------------------------|
 | Mainnet             | JSON-RPC over HTTPS     | `https://celo-mainnet.infura.io/v3/<YOUR-API-KEY>`    |
 | Mainnet             | JSON-RPC over WebSocket | `wss://celo-mainnet.infura.io/ws/v3/<YOUR-API-KEY>`   |
-| Testnet (Alfajores) | JSON-RPC over HTTPS     | `https://celo-alfajores.infura.io/v3/<YOUR-API-KEY>`  |
-| Testnet (Alfajores) | JSON-RPC over WebSocket | `wss://celo-alfajores.infura.io/ws/v3/<YOUR-API-KEY>` |
+
 
 ## Ethereum
 


### PR DESCRIPTION
# Description

Remove Celo testnet. Testnet access will be removed from the Developer dashboard.

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Celo Alfajores testnet endpoints and replaces the deprecation notice with a "Mainnet only" info banner.
> 
> - **Docs** (`services/get-started/endpoints.md`):
>   - **Celo**:
>     - Remove `Testnet (Alfajores)` HTTPS and WebSocket endpoint rows.
>     - Replace Alfajores deprecation notice with `Mainnet only` info banner stating Infura supports Celo mainnet only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f733a10ba52da3ec0ccfcdf8821cb8a2b1394f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->