### PR TITLE
adds cost of erroneous call

### DIFF
--- a/services/get-started/pricing/credit-cost.mdx
+++ b/services/get-started/pricing/credit-cost.mdx
@@ -30,12 +30,14 @@ The process used to determine the credit cost for each request is as follows:
 
 ## Error code costs
 
-When making requests that return status code errors, some errors count towards your credit usage.
+When making requests that return HTTP status code errors, some errors count towards your credit usage:
 
 - **`429` errors**: These are not charged and can occur if you've exceeded your allowed throughput limit (requests per second).
 - **`402` errors**: These are not charged and can occur if you've exceeded your allowed daily credit usage.
 - **`4xx` errors**: These are errors caused by human input, and consume 5 credits.
 - **`5xx` errors**: These are server errors, and do not consume any credit charges.
+
+Making requests to a non-existent JSON-RPC method costs 160 credits.
 
 ## Ethereum
 


### PR DESCRIPTION
# Description

Clarifies that Calling a non existent method costs 160 credits.
Clarifies that the bullet point list is for HTTP errors.

## Issue(s) fixed

Fixes #2471 


## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies HTTP error code billing and adds a 160-credit cost for calls to non-existent JSON-RPC methods in the credit cost docs.
> 
> - **Docs (pricing/credit-cost)**:
>   - Clarify that the listed error codes refer to HTTP status codes.
>   - Add explicit cost for requests to non-existent JSON-RPC methods: `160` credits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebcf1d160a4d5fa7a052a2a3a50d04682cb71e78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->