### PR TITLE
Exclude Services .mdx files from llms.txt generator

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -379,7 +379,7 @@ const config = {
           },
           {
             filename: 'llms-sdk.txt',
-            includePatterns: ['sdk/**/*.md'],
+            includePatterns: ['sdk/**/*.{md,mdx}'],
             fullContent: false,
             title: 'MetaMask SDK documentation',
             description: 'Documentation links for MetaMask SDK',
@@ -463,7 +463,7 @@ const config = {
           },
           {
             filename: 'llms-services.txt',
-            includePatterns: ['services/**/*.{md,mdx}'],
+            includePatterns: ['services/**/*.md'],
             fullContent: false,
             title: 'Services documentation',
             description: 'Documentation links for MetaMask services',


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

The llms.txt generator cannot parse imported `_partials` files used throughout the Services API reference (exclusively on Services `.mdx` pages). This adds to the length of each PR build, and raises errors in the build logs (without failing the build) which can be confusing if you're trying to identify other errors.

This PR excludes `.mdx` files within the services llms config to ensure cleaner logs. We can update the configuration again if we remove the use of `_partials` imports.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts Services LLMs generation to `.md` files by excluding `.mdx` in `docusaurus.config.js`.
> 
> - **LLMs config (in `docusaurus.config.js`)**:
>   - Update `customLLMFiles` for Services to include only `services/**/*.md` in both `llms-services.txt` and `llms-services-full.txt`, excluding `.mdx` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644fe3160f4baca817f260cb0cedfe7378caf4c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->