### PR TITLE
Add DIN support.

### DIFF
--- a/services/reference/celo/index.md
+++ b/services/reference/celo/index.md
@@ -6,6 +6,13 @@ import CardList from '@site/src/components/CardList'
 
 # Celo
 
+:::note Decentralized Infrastructure Network (DIN)
+
+Celo is supported through the [DIN](https://www.din.build/) service,
+meaning calls to the network are routed to [partner infrastructure providers](#partners-and-privacy-policies).
+
+:::
+
 Celo is an Ethereum layer-2 network designed for fast, low-cost payments. It offers low fees and fast finality while letting you reuse familiar Ethereum tools and contracts with little or no change.
 
 :::info See also
@@ -35,3 +42,15 @@ Select an option below to get started with the Celo network.
     }
   ]}
 />
+
+## Partners and privacy policies
+
+No personal information is sent as part of partner requests, only information necessary to fulfill your API
+request. This means that Infura's partner service provider can service your request, but not store the
+content of your request.
+
+The following partners provide access to the BSC network:
+<!-- markdown-link-check-disable -->
+- BlockPI ([Terms of Use](https://blockpi.io/terms-of-use), [Privacy Policy](https://blockpi.io/privacy-policy))
+- 0xFury ([Privacy policy](https://0xfury.com/privacy))
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
# Description

Celo is supported via DIN.

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DIN note and a partners/privacy section to the Celo docs, including partner list and data-handling details.
> 
> - **Docs (Celo)**
>   - Add DIN note explaining requests are routed via partner infrastructure providers in `services/reference/celo/index.md`.
>   - Introduce **Partners and privacy policies** section:
>     - Clarifies no personal information is sent; partners cannot store request content.
>     - Lists partner providers with policy links: `BlockPI`, `0xFury`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eadf5d8ebdc7bba9645c2b2d5a5e406c8940ed50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->