### PR TITLE
fix: wrong token in native-token.md

### DIFF
--- a/smart-accounts-kit/guides/advanced-permissions/use-permissions/native-token.md
+++ b/smart-accounts-kit/guides/advanced-permissions/use-permissions/native-token.md
@@ -22,7 +22,7 @@ permissions for native token transfers with time-based (periodic) or streaming c
 This permission type ensures a per-period limit for native token transfers. At the start of each new period, the allowance resets.
 
 For example, a user signs an ERC-7715 permission that lets a dapp spend up to 0.001 ETH on their behalf each day. The dapp can transfer a total of
-0.001 USDC per day; the limit resets at the beginning of the next day.
+0.001 ETH per day; the limit resets at the beginning of the next day.
 
 See the [native token periodic permission API reference](../../../reference/advanced-permissions/permissions.md#native-token-periodic-permission) for more information.
 


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects documentation in the native token permissions guide for clarity and proper rendering.
> 
> - Updates example text to use `0.001 ETH` per day (replacing incorrect `USDC`/negative value)
> - Restores closing `</Tabs>` tag to ensure tabs render correctly in `native-token.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f710f94a46f26b39354f792db15b1a4f1429aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->