### PR TITLE
fix(docs): resolve Ethers.js version inconsistency in embedded wallet examples

### DIFF
--- a/embedded-wallets/sdk/node/private-key.mdx
+++ b/embedded-wallets/sdk/node/private-key.mdx
@@ -40,6 +40,7 @@ console.log('Private Key Length:', privateKey.length) // Only log metadata
 ### Use with Ethers.js
 
 ```javascript
+// Example using ethers.js v6
 const { ethers } = require('ethers')
 
 // Get private key
@@ -59,7 +60,7 @@ console.log('Wallet Address:', address)
 // Sign a transaction
 const tx = {
   to: '0x742d35Cc6635C0532925a3b8138341B0F7E8a4e8',
-  value: ethers.parseEther('0.1'),
+  value: ethers.parseEther('0.1'), 
 }
 
 const signedTx = await connectedWallet.signTransaction(tx)


### PR DESCRIPTION
# Description
- Standardized on Ethers.js v6 API (`JsonRpcProvider`, `parseEther`)
- Added `// Example using ethers.js v6` comment for clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Improves security and updates examples in `private-key.mdx`.**
> 
> - Replace direct private key logs with `length`-only in EVM, Solana, and raw key examples
> - Standardize Ethers.js examples to v6 (`JsonRpcProvider`, `ethers.parseEther`) and add a v6 usage note
> - No SDK code changes; documentation updates only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c1b309610e852d7502d31d427225397d180eb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->