### PR TITLE
Fix missing await in gas estimation

### DIFF
--- a/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
+++ b/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
@@ -166,7 +166,7 @@ You can search for the transaction on a block explorer such as [Sepolia Ethersca
 To change default values, update the `signer.sendTransaction` method to include an `estimateGas` result:
 
 ```javascript title="eip1559_tx.js"
-const limit = provider.estimateGas({
+const limit = await provider.estimateGas({
   from: signer.address,
   to: "<to_address_goes_here>",
   value: ethers.utils.parseUnits("0.001", "ether"),


### PR DESCRIPTION
Fixes a bug where provider.estimateGas() was used without await, causing the transaction code to fail at runtime. The gas estimation now resolves correctly and works as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the ethers.js tutorial snippet to correctly await `provider.estimateGas` when deriving `gasLimit`, ensuring the example runs without runtime errors.
> 
> - Update in `send-a-transaction-ethers.md`: change `provider.estimateGas({...})` to `await provider.estimateGas({...})` in the optional fine-tuning example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d11460ffa83802d59bbf0b9db06c5407d450c71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->