### PR TITLE
Update Web3 libraries list to include Viem

### DIFF
--- a/services/concepts/web3-libraries.md
+++ b/services/concepts/web3-libraries.md
@@ -35,6 +35,7 @@ Some popular Ethereum-compatible Web3 libraries include (but are not limited to)
 | PHP        | [Web3.php](https://github.com/web3p/web3.php)                                                       |
 | Java       | [Web3j](https://docs.web3j.io/)                                                                     |
 | Ruby       | [Ethereum Ruby library](https://github.com/EthWorks/ethereum.rb)                                    |
+| Viem       | [Viem](https://viem.sh/)                                                                            |
 
 :::info How to access the blockchain
 


### PR DESCRIPTION
# Description
Viem has been added to the list of Web3 libraries in `services/concepts/web3-libraries.md`.

# Why

Viem is a modern, actively maintained Ethereum Web3 library with TypeScript-first support.

It is already used in other parts of the documentation (e.g., `send-a-transaction-viem.md`), so adding it to this list ensures consistency across the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to include `Viem` in the list of Ethereum Web3 libraries.
> 
> - Adds a new `Viem` entry with link in the libraries table of `web3-libraries.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77aeb21930180fca6872ada06883e0e970cb0d77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->