### PR TITLE
Fix incorrect JS slice and selector in ERC-20 transfer example

### DIFF
--- a/services/how-to/interact-with-erc-20-tokens.md
+++ b/services/how-to/interact-with-erc-20-tokens.md
@@ -45,7 +45,7 @@ The JSON-RPC format expects `eth_sendRawTransaction` to have a specific data fie
   <TabItem value="JavaScript" label="JavaScript" default>
 
 ```javascript
-web3.sha3("Transfer(address, address, uint256)")[0..4]
+web3.sha3("Transfer(address, address, uint256)").slice(0, 10)
 ```
 
   </TabItem>


### PR DESCRIPTION
Fixed the example of generating a function selector for ERC-20 transfer in the documentation

Replaced the incorrect syntax `[0..4]` with the correct `.slice(0, 10)`.

These changes make the example work and eliminate misleading errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the ERC-20 docs to correct the JavaScript example for deriving the function selector.
> 
> - Replaces incorrect `web3.sha3("Transfer(address, address, uint256)")[0..4]` with `web3.sha3("Transfer(address, address, uint256)").slice(0, 10)` in `services/how-to/interact-with-erc-20-tokens.md` to properly produce the 4-byte selector for `eth_sendRawTransaction` data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c777afd1c7208571c6353ce1a987ae69f0b84b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->