### PR TITLE
Revert "Fix incorrect selector in ERC-20 example"

### DIFF
--- a/services/how-to/interact-with-erc-20-tokens.md
+++ b/services/how-to/interact-with-erc-20-tokens.md
@@ -52,7 +52,7 @@ web3.sha3("Transfer(address, address, uint256)")[0..4]
   <TabItem value="Result" label="Result" >
 
 ```javascript
-0xa9059cbb
+0x70a08231
 ```
 
   </TabItem>


### PR DESCRIPTION
Reverts MetaMask/metamask-docs#2652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts a prior change in the ERC-20 docs.
> 
> - In `services/how-to/interact-with-erc-20-tokens.md`, updates the example "Result" for `web3.sha3("Transfer(address, address, uint256)")[0..4]` from `0xa9059cbb` to `0x70a08231`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2cc42f9c2f65e85382bc132756ea944a7b3b96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->