### PR TITLE
Correction of the name of the Polygon testnet network

### DIFF
--- a/services/tutorials/layer-2-networks/send-a-transaction.md
+++ b/services/tutorials/layer-2-networks/send-a-transaction.md
@@ -9,7 +9,7 @@ As with Ethereum, [transactions](https://ethereum.org/en/developers/docs/transac
 - Regular transactions from one account to another.
 - Contract deployment transactions, or calling a function in a smart contract.
 
-This tutorial uses the Ethereum Web3 JavaScript library to send a transaction between two accounts on the Polygon-Mumbai testnet.
+This tutorial uses the Ethereum Web3 JavaScript library to send a transaction between two accounts on the Polygon Amoy testnet.
 
 ## Prerequisites
 
@@ -27,11 +27,11 @@ You can use [MetaMask](https://metamask.io) or a similar Ethereum wallet to crea
 
 ### 1. Add Polygon network to MetaMask
 
-Refer to the Polygon instructions to [add the Polygon networks to MetaMask](https://polygon.technology/blog/getting-started-with-metamask-on-polygon). This tutorial uses the Polygon Mumbai network.
+Refer to the Polygon instructions to [add the Polygon networks to MetaMask](https://polygon.technology/blog/getting-started-with-metamask-on-polygon). This tutorial uses the Polygon Amoy network.
 
 ### 2. Fund your account
 
-[Use the Polygon faucet](https://faucet.polygon.technology) to load testnet MATIC on your account for the Mumbai network.
+[Use the Polygon faucet](https://faucet.polygon.technology) to load testnet MATIC on your account for the Amoy network.
 
 ### 3. Create a project directory
 
@@ -146,4 +146,4 @@ The command line will display the block number containing the transaction detail
 
 ### 8. View the transaction details
 
-Copy transaction hash and view the transaction in the [Polygon Mumbai block explorer](https://amoy.polygonscan.com/).
+Copy transaction hash and view the transaction in the [Polygon Amoy block explorer](https://amoy.polygonscan.com/).


### PR DESCRIPTION
# Description

Changed the name of the Polygon test network, as Mumbai is an outdated version and Amoy is the current one.
The changes only affected the names; the technical part is correct and corresponds to Amoy.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Polygon transaction tutorial to reflect the current Amoy testnet.
> 
> - Replaces all references to Mumbai with Amoy, including network selection, faucet instructions, and block explorer link
> - Intro line now specifies sending a transaction on Polygon Amoy testnet
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 380be05968c1ebd094931d1603c331ec7776d893. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->