### PR TITLE
fix: command to run python script

### DIFF
--- a/services/tutorials/ethereum/subscribe-to-pending-transactions.md
+++ b/services/tutorials/ethereum/subscribe-to-pending-transactions.md
@@ -144,8 +144,8 @@ if __name__ == "__main__":
 
 Execute the program using the following:
 
-```
-Python python3 subscribe.py
+```python
+python3 subscribe.py
 ```
 
 You should now see the terminal fill up with Ethereum transfers:


### PR DESCRIPTION
# Description

Fixed the command to run the script, which now works correctly

## Issue(s) fixed

Non-functional launch command/syntax error in code

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the execution command in `services/tutorials/ethereum/subscribe-to-pending-transactions.md` Step 6.
> 
> - Replaces malformed code block with a proper `python` fenced block and the correct command: `python3 subscribe.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebd9a71c169f09159926152afac26508a457f6bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->