### PR TITLE
fix(docs): corrected the example data

### DIFF
--- a/services/reference/zksync/json-rpc-methods/_eth_gettransactionreceipt-request.mdx
+++ b/services/reference/zksync/json-rpc-methods/_eth_gettransactionreceipt-request.mdx
@@ -15,7 +15,7 @@ curl https://zksync-mainnet.infura.io/v3/<YOUR-API-KEY> \
   <TabItem value="WSS">
 
 ```bash
-wscat -c wss://zksync-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_getTransactionCount", "params": ["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "0x5bad55"], "id": 1}'
+wscat -c wss://zksync-mainnet.infura.io/ws/v3/<YOUR-API-KEY> -x '{"jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0"], "id": 1}'
 ```
 
   </TabItem>


### PR DESCRIPTION
# Description
At the moment, you have a file named `_eth_gettransactionreceipt-request.mdx`, where the basis is `receipt`, which leads me to believe that inside the file I will see examples of obtaining `receipt`.
However, I saw two examples (curl + wss), where curl had an example of receiving a `receipt`, while in the wss example I saw an example of receiving a `count`, which confused me a little and led me to think that this was most likely a mistake and that there should be an example of receiving a `receipt` here. 

## Issue(s) fixed

Based on my thoughts above, I changed:
- the `eth_getTransactionCount` method to `eth_getTransactionReceipt`
- the parameters with the wallet address and block number (hex)
I assume that the original plan was to provide two examples of receiving `receipts` with different data transfer protocols (HTTP and WebSocket).
This idea is also confirmed by the file `_eth_gettransactioncount-request.mdx`, which contains two examples of obtaining `count`.

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects a JSON-RPC method name and parameters in an example snippet.
> 
> **Overview**
> Fixes the `eth_getTransactionReceipt` docs example so the WebSocket (`wscat`) request matches the HTTP example: it now calls `eth_getTransactionReceipt` with a transaction hash instead of incorrectly using `eth_getTransactionCount` with an address/block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7f781eec5b941af4477f533810f52c14996862b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->