### PR TITLE
Incorrect link Ethereum Sepolia

### DIFF
--- a/services/how-to/get-testnet-tokens.md
+++ b/services/how-to/get-testnet-tokens.md
@@ -23,7 +23,7 @@ Use [testnet endpoints](../get-started/endpoints.md) during development and init
 | [Blast Sepolia](https://docs.blast.io/using-blast)| [Blast Sepolia faucet](https://faucet.quicknode.com/blast/sepolia)|     |
 | [Binance Smart Chain (BSC) Sepolia](https://academy.binance.com/en/articles/connecting-metamask-to-binance-smart-chain)| [BSC Sepolia faucet](https://www.bnbchain.org/en/testnet-faucet)| [BSC bridge](https://www.bnbchain.org/en/bnb-chain-bridge)|
 | [Celo Alfajores](https://docs.celo.org/getting-started/alfajores-testnet)| [Celo Alfajores faucet](https://faucet.celo.org/alfajores)| [Celo bridge](https://docs.celo.org/protocol/bridge#token-bridges)|
-| [Ethereum Sepolia](https://docs.blast.io/building/bridges/testnet)| [Ethereum Sepolia faucet](https://faucet.quicknode.com/ethereum/sepolia)| [Sepolia bridge](https://docs.blast.io/building/bridges/testnet)|
+| [Ethereum Sepolia](https://ethereum.org/developers/docs/networks/)| [Ethereum Sepolia faucet](https://faucet.quicknode.com/ethereum/sepolia)| [Sepolia bridge](https://docs.blast.io/building/bridges/testnet)|
 | [Linea Sepolia](https://support.linea.build/getting-started/how-to-get-linea-goerli-testnet-eth)| [Linea Sepolia faucet](https://docs.metamask.io/developer-tools/faucet)| [Linea bridge](https://bridge.linea.build)|
 | [Mantle Sepolia](https://docs.mantle.xyz/network/for-uers/how-to-guides/connecting-wallet-to-mantle-network)| [Mantle Sepolia faucet](https://faucet.sepolia.mantle.xyz) |[Mantle bridge](https://app.mantle.xyz/bridge?network=sepolia)| 
 | [Optimism Sepolia](https://docs.optimism.io/builders/tools/build/faucets)| [Optimism Sepolia faucet](https://faucet.quicknode.com/optimism/sepolia)| [Optimism bridge](https://app.optimism.io/bridge)| 


### PR DESCRIPTION
# Description

Ethereum Sepolia had a link to Blast documentation. I corrected it to Ethereum documentation, test networks section, where there is information about test networks, and also separately about Sepolia.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single hyperlink with no impact on runtime behavior.
> 
> **Overview**
> Updates `services/how-to/get-testnet-tokens.md` to correct the `Ethereum Sepolia` reference link, replacing an incorrect Blast documentation URL with the official Ethereum networks documentation URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a21f1f8c4f95cf2ba43fa6ffd19c65336431773b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->