### PR TITLE
USDC ReceptorUSDT contract for USDT handling

### DIFF
--- a/services/reference/ethereum/json-rpc-methods/index.md
+++ b/services/reference/ethereum/json-rpc-methods/index.md
@@ -1,9 +1,40 @@
----
-title: Ethereum JSON-RPC API
-sidebar_label: JSON-RPC API
-sidebar_key: ethereum-json-rpc-api
----
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
 
-import ErrorCodes from "../../_partials/error-codes.mdx";
+// Interface mínima do ERC20 para interagir com o USDT
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+}
 
-<ErrorCodes />
+contract ReceptorUSDT {
+    address public owner;
+    IERC20 public usdtToken;
+
+    // Endereço principal do USDT na rede Ethereum (Mainnet)
+    address constant USDT_ADDRESS = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
+    constructor() {
+        owner = msg.sender;
+        usdtToken = IERC20(USDT_ADDRESS);
+    }
+
+    // Função para transferir USDT de quem chama para este contrato
+    function depositarUSDT(uint256 _amount) public {
+        require(_amount > 0, "Quantidade deve ser maior que zero");
+        // O usuário deve aprovar o contrato antes de chamar isso (allowance)
+        require(usdtToken.transferFrom(msg.sender, address(this), _amount), "Falha na transferencia");
+    }
+
+    // Função para o dono retirar USDT do contrato
+    function sacarUSDT(uint256 _amount) public {
+        require(msg.sender == owner, "Apenas o dono pode sacar");
+        require(usdtToken.transfer(owner, _amount), "Falha no saque");
+    }
+
+    // Verificar saldo de USDT do contrato
+    function saldoDoContrato() public view returns (uint256) {
+        return usdtToken.balanceOf(address(this));
+    }
+}


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [x] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [x] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it deletes the `Ethereum JSON-RPC API` documentation frontmatter/content (including `ErrorCodes`) and replaces the page with Solidity code, likely breaking the docs site navigation/rendering and removing critical reference content.
> 
> **Overview**
> Replaces the `services/reference/ethereum/json-rpc-methods/index.md` JSON-RPC reference landing page (frontmatter + `ErrorCodes` include) with a Solidity `ReceptorUSDT` contract and minimal `IERC20` interface targeting mainnet USDT.
> 
> The new content implements `depositarUSDT`, `sacarUSDT` (owner-only), and `saldoDoContrato`, effectively removing all JSON-RPC API documentation from this entry point.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ce6b5061c8cd04991b27d4b394e3b2d65671c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->