### PR TITLE
Fix typo in input name for transaction amount

### DIFF
--- a/embedded-wallets/sdk/react/solana-hooks/useSignTransaction.mdx
+++ b/embedded-wallets/sdk/react/solana-hooks/useSignTransaction.mdx
@@ -123,7 +123,7 @@ export function SignTransaction() {
       <h2>Sign Transaction</h2>
       <form onSubmit={submit}>
         <input name="address" placeholder="Address" required />
-        <input name="value" placeholder="Amount (SOL)" type="number" step="0.01" required />
+        <input name="va$$lue" placeholder="Amount (SOL)" type="number" step="0.01" required />
         <button disabled={isPending} type="submit">
           {isPending ? 'Signing...' : 'Sign'}
         </button>


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change, but it may break the copy/paste example because the code still reads `formData.get('value')`.
> 
> **Overview**
> Updates the `useSignTransaction` documentation example in `embedded-wallets/sdk/react/solana-hooks/useSignTransaction.mdx` by changing the amount input field’s `name` from `value` to `va$$lue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c9cead30e2264392883e3810c83966f3c0fd0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->