### PR TITLE
move osano script to headTags

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,6 +35,12 @@ const config = {
 
   headTags: [
     {
+      tagName: 'script',
+      attributes: {
+        src: 'https://cmp.osano.com/AzZMxHTbQDOQD8c1J/84e64bce-4a70-4dcc-85cb-7958f22b2371/osano.js',
+      },
+    },
+    {
       tagName: 'link',
       attributes: {
         rel: 'icon',
@@ -129,9 +135,6 @@ const config = {
       src: baseUrl + 'js/code-focus.js',
       async: false,
       defer: true,
-    },
-    {
-      src: 'https://cmp.osano.com/AzZMxHTbQDOQD8c1J/84e64bce-4a70-4dcc-85cb-7958f22b2371/osano.js',
     },
   ],
 


### PR DESCRIPTION
# Description

Place osano.js first in the `<head>` tag - https://docs.osano.com/hc/en-us/articles/22472073125652-Osano-and-Google-Tag-Manager#direct-install
