### PR TITLE
Update basefeepercentile.md

### DIFF
--- a/services/reference/gas-api/api-reference/basefeepercentile.md
+++ b/services/reference/gas-api/api-reference/basefeepercentile.md
@@ -49,7 +49,7 @@ instead of using the curl authentication option (`-u`).
 ```bash
 curl -X "GET" \
   -u <YOUR-API-KEY>:<YOUR-API-KEY-SECRET> \
-  "https://gas.api.infura.io/networks/1/baseFeeHistory"
+  "https://gas.api.infura.io/networks/1/baseFeePercentile"
 ```
 
   </TabItem>
@@ -76,7 +76,7 @@ const chainId = 1;
         },
       }
     );
-    console.log("Base fee history:", data);
+    console.log("Base fee percentile:", data);
   } catch (error) {
     console.log("Server responded with:", error);
   }


### PR DESCRIPTION
# Description

There was a minor error in the logic of `baseFeePercentile`. The example stated:
```
curl -X “GET” \
  -u <YOUR-API-KEY>:<YOUR-API-KEY-SECRET> \
  “https://gas.api.infura.io/networks/1/baseFeeHistory // History?”
```
I corrected it to `Percentile` in accordance with the name.
I also corrected `console.log`.

How did I check it?
In the `services/reference/gas-api/api-reference` directory, I quickly checked two similar files ([FILE1](https://github.com/pineapplepeak/metamask-docs/blob/main/services/reference/gas-api/api-reference/basefeehistory.md), [FILE2](https://github.com/pineapplepeak/metamask-docs/blob/main/services/reference/gas-api/api-reference/busythreshold.md)) and made sure the logic was correct.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that correct example URLs/log output; no runtime or API behavior changes.
> 
> **Overview**
> Fixes the `baseFeePercentile` documentation examples to reference the correct endpoint, replacing an incorrect `baseFeeHistory` URL in the curl snippet.
> 
> Updates the JavaScript example output label from "Base fee history" to "Base fee percentile" to match the API being called.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 608c42d56a493d5848b3c54947974158eb85cb87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->