### PR TITLE
Fix Ethereum API link in JSON-RPC methods documentation

### DIFF
--- a/wallet/reference/json-rpc-methods/index.md
+++ b/wallet/reference/json-rpc-methods/index.md
@@ -14,7 +14,7 @@ Each method may have one or more of the following labels:
 - **MetaMask** - The functionalities of these methods are specific to MetaMask, and may or may not be supported by other wallets.
 - **Restricted** - These methods are restricted and require requesting permission using [`wallet_requestPermissions`](/wallet/reference/json-rpc-methods/wallet_requestpermissions).
 - **Mobile** - These methods are only available on the MetaMask mobile app.
-- **Ethereum API** - These are standard Ethereum JSON-RPC API methods. See the [Ethereum wiki](https://ethereum.org/developers/docs/apis/json-rpc/) for more information about these methods.
+- **Ethereum API** - These are standard Ethereum JSON-RPC API methods. See the [Ethereum wiki](https://ethereum-json-rpc.com/) for more information about these methods.
 - **Multichain API** - These methods are compatible with the [Multichain API](../multichain-api.md).
 - **Experimental** - These methods are experimental and may be changed in the future.
 - **Deprecated** - These methods are deprecated and may be removed in the future.


### PR DESCRIPTION
Updated the link for Ethereum JSON-RPC API methods to the developers documentation.

# Description

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the `JSON-RPC API` docs to fix the **Ethereum API** reference link, pointing readers to `https://ethereum-json-rpc.com/` instead of the previous ethereum.org JSON-RPC page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe72d6aa861fad88f66e628bde209cfcfedc1c12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->