### PR TITLE
[Smart Accounts Kit] Fix typos

### DIFF
--- a/gator_versioned_docs/version-0.1.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
+++ b/gator_versioned_docs/version-0.1.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
@@ -1,5 +1,5 @@
 ---
-description: Use Advanced Permissions (ERC-7115) to perform executions on a MetaMask user's behalf.
+description: Use Advanced Permissions (ERC-7715) to perform executions on a MetaMask user's behalf.
 sidebar_label: Execute on a MetaMask user's behalf
 keywords: [execution, smart account, create, redeem, delegation, erc 7715, 7715, session account, advanced permissions]
 ---
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Perform executions on a MetaMask user's behalf
 
-[Advanced Permissions (ERC-7115)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
+[Advanced Permissions (ERC-7715)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
 behalf. For example, a user can grant your dapp permission to spend 10 USDC per day to buy ETH over the course 
 of a month. Once the permission is granted, your dapp can use the allocated 10 USDC each day to 
 purchase ETH directly from the MetaMask user's account.
@@ -104,7 +104,7 @@ If the user has not yet been upgraded, you can handle the upgrade [programmatica
 user to [switch to a smart account manually](https://support.metamask.io/configure/accounts/switch-to-or-revert-from-a-smart-account/#how-to-switch-to-a-metamask-smart-account).
 
 :::info Why is a Smart Account upgrade is required?
-MetaMask's Advanced Permissions (ERC-7115) implementation requires the user to be upgraded to a MetaMask 
+MetaMask's Advanced Permissions (ERC-7715) implementation requires the user to be upgraded to a MetaMask 
 Smart Account because, under the hood, you're requesting a signature for an [ERC-7710 delegation](../../concepts/delegation/index.md).
 ERC-7710 delegation is one of the core features supported only by MetaMask Smart Accounts.
 :::

--- a/gator_versioned_docs/version-0.1.0/guides/advanced-permissions/use-permissions/native-token.md
+++ b/gator_versioned_docs/version-0.1.0/guides/advanced-permissions/use-permissions/native-token.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use the native token permissions with Advanced Permissions (ERC-7115).
+description: Learn how to use the native token permissions with Advanced Permissions (ERC-7715).
 keywords: [permissions, spending limit, restrict, 7715, erc-7715, native-token-permissions, advanced permissions]
 ---
 
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Use native token permissions
  
-[Advanced Permissions (ERC-7115)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
+[Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
 permissions for native token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites

--- a/gator_versioned_docs/version-0.2.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
+++ b/gator_versioned_docs/version-0.2.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
@@ -1,5 +1,5 @@
 ---
-description: Use Advanced Permissions (ERC-7115) to perform executions on a MetaMask user's behalf.
+description: Use Advanced Permissions (ERC-7715) to perform executions on a MetaMask user's behalf.
 sidebar_label: Execute on a MetaMask user's behalf
 keywords: [execution, smart account, create, redeem, delegation, erc 7715, 7715, session account, advanced permissions]
 ---
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Perform executions on a MetaMask user's behalf
 
-[Advanced Permissions (ERC-7115)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
+[Advanced Permissions (ERC-7715)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
 behalf. For example, a user can grant your dapp permission to spend 10 USDC per day to buy ETH over the course 
 of a month. Once the permission is granted, your dapp can use the allocated 10 USDC each day to 
 purchase ETH directly from the MetaMask user's account.
@@ -106,7 +106,7 @@ If the user has not yet been upgraded, you can handle the upgrade [programmatica
 user to [switch to a smart account manually](https://support.metamask.io/configure/accounts/switch-to-or-revert-from-a-smart-account/#how-to-switch-to-a-metamask-smart-account).
 
 :::info Why is a Smart Account upgrade is required?
-MetaMask's Advanced Permissions (ERC-7115) implementation requires the user to be upgraded to a MetaMask 
+MetaMask's Advanced Permissions (ERC-7715) implementation requires the user to be upgraded to a MetaMask 
 Smart Account because, under the hood, you're requesting a signature for an [ERC-7710 delegation](../../concepts/delegation/index.md).
 ERC-7710 delegation is one of the core features supported only by MetaMask Smart Accounts.
 :::

--- a/gator_versioned_docs/version-0.2.0/guides/advanced-permissions/use-permissions/native-token.md
+++ b/gator_versioned_docs/version-0.2.0/guides/advanced-permissions/use-permissions/native-token.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use the native token permissions with Advanced Permissions (ERC-7115).
+description: Learn how to use the native token permissions with Advanced Permissions (ERC-7715).
 keywords: [permissions, spending limit, restrict, 7715, erc-7715, native-token-permissions, advanced permissions]
 ---
 
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Use native token permissions
  
-[Advanced Permissions (ERC-7115)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
+[Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
 permissions for native token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites

--- a/gator_versioned_docs/version-0.3.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
+++ b/gator_versioned_docs/version-0.3.0/guides/advanced-permissions/execute-on-metamask-users-behalf.md
@@ -1,5 +1,5 @@
 ---
-description: Use Advanced Permissions (ERC-7115) to perform executions on a MetaMask user's behalf.
+description: Use Advanced Permissions (ERC-7715) to perform executions on a MetaMask user's behalf.
 sidebar_label: Execute on a MetaMask user's behalf
 keywords: [execution, smart account, create, redeem, delegation, erc 7715, 7715, session account, advanced permissions]
 ---
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Perform executions on a MetaMask user's behalf
 
-[Advanced Permissions (ERC-7115)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
+[Advanced Permissions (ERC-7715)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
 behalf. For example, a user can grant your dapp permission to spend 10 USDC per day to buy ETH over the course 
 of a month. Once the permission is granted, your dapp can use the allocated 10 USDC each day to 
 purchase ETH directly from the MetaMask user's account.
@@ -106,7 +106,7 @@ If the user has not yet been upgraded, you can handle the upgrade [programmatica
 user to [switch to a smart account manually](https://support.metamask.io/configure/accounts/switch-to-or-revert-from-a-smart-account/#how-to-switch-to-a-metamask-smart-account).
 
 :::info Why is a Smart Account upgrade is required?
-MetaMask's Advanced Permissions (ERC-7115) implementation requires the user to be upgraded to a MetaMask 
+MetaMask's Advanced Permissions (ERC-7715) implementation requires the user to be upgraded to a MetaMask 
 Smart Account because, under the hood, you're requesting a signature for an [ERC-7710 delegation](../../concepts/delegation/index.md).
 ERC-7710 delegation is one of the core features supported only by MetaMask Smart Accounts.
 :::

--- a/gator_versioned_docs/version-0.3.0/guides/advanced-permissions/use-permissions/native-token.md
+++ b/gator_versioned_docs/version-0.3.0/guides/advanced-permissions/use-permissions/native-token.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use the native token permissions with Advanced Permissions (ERC-7115).
+description: Learn how to use the native token permissions with Advanced Permissions (ERC-7715).
 keywords: [permissions, spending limit, restrict, 7715, erc-7715, native-token-permissions, advanced permissions]
 ---
 
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Use native token permissions
  
-[Advanced Permissions (ERC-7115)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
+[Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
 permissions for native token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites

--- a/smart-accounts-kit/guides/advanced-permissions/execute-on-metamask-users-behalf.md
+++ b/smart-accounts-kit/guides/advanced-permissions/execute-on-metamask-users-behalf.md
@@ -1,5 +1,5 @@
 ---
-description: Use Advanced Permissions (ERC-7115) to perform executions on a MetaMask user's behalf.
+description: Use Advanced Permissions (ERC-7715) to perform executions on a MetaMask user's behalf.
 sidebar_label: Execute on a MetaMask user's behalf
 keywords: [execution, smart account, create, redeem, delegation, erc 7715, 7715, session account, advanced permissions]
 ---
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Perform executions on a MetaMask user's behalf
 
-[Advanced Permissions (ERC-7115)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
+[Advanced Permissions (ERC-7715)](../../concepts/advanced-permissions.md) are fine-grained permissions that your dapp can request from a MetaMask user to execute transactions on their 
 behalf. For example, a user can grant your dapp permission to spend 10 USDC per day to buy ETH over the course 
 of a month. Once the permission is granted, your dapp can use the allocated 10 USDC each day to 
 purchase ETH directly from the MetaMask user's account.
@@ -106,7 +106,7 @@ If the user has not yet been upgraded, you can handle the upgrade [programmatica
 user to [switch to a smart account manually](https://support.metamask.io/configure/accounts/switch-to-or-revert-from-a-smart-account/#how-to-switch-to-a-metamask-smart-account).
 
 :::info Why is a Smart Account upgrade is required?
-MetaMask's Advanced Permissions (ERC-7115) implementation requires the user to be upgraded to a MetaMask 
+MetaMask's Advanced Permissions (ERC-7715) implementation requires the user to be upgraded to a MetaMask 
 Smart Account because, under the hood, you're requesting a signature for an [ERC-7710 delegation](../../concepts/delegation/index.md).
 ERC-7710 delegation is one of the core features supported only by MetaMask Smart Accounts.
 :::

--- a/smart-accounts-kit/guides/advanced-permissions/get-granted-advanced-permissions.md
+++ b/smart-accounts-kit/guides/advanced-permissions/get-granted-advanced-permissions.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to get the granted Advanced Permissions for a wallet.
-sidebar_label: Get granted permisisons
+sidebar_label: Get granted permissions
 keywords: [advanced permissions, granted execution permissions, erc-7715, 7715]
 ---
 

--- a/smart-accounts-kit/guides/advanced-permissions/get-supported-permissions.md
+++ b/smart-accounts-kit/guides/advanced-permissions/get-supported-permissions.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to get supported Advanced Permissions for a wallet.
-sidebar_label: Get supported permisisons
+sidebar_label: Get supported permissions
 keywords: [advanced permissions, supported execution permissions, erc-7715, 7715]
 ---
 

--- a/smart-accounts-kit/guides/advanced-permissions/use-permissions/native-token.md
+++ b/smart-accounts-kit/guides/advanced-permissions/use-permissions/native-token.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use the native token permissions with Advanced Permissions (ERC-7115).
+description: Learn how to use the native token permissions with Advanced Permissions (ERC-7715).
 keywords: [permissions, spending limit, restrict, 7715, erc-7715, native-token-permissions, advanced permissions]
 ---
 
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Use native token permissions
  
-[Advanced Permissions (ERC-7115)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
+[Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports native token permission types that allow you to request fine-grained
 permissions for native token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites


### PR DESCRIPTION
# Description

Fix typos for Advanced Permissions

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that correct ERC numbering and sidebar label typos; no code or API behavior changes.
> 
> **Overview**
> Updates Advanced Permissions docs across versioned guides and `smart-accounts-kit` to consistently reference **ERC-7715** (replacing incorrect `ERC-7115`) in descriptions and intro text.
> 
> Fixes minor documentation typos in sidebar labels (`permisisons` → `permissions`) for the “get granted/supported permissions” guides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b24254cb553dbc11339e451f0297e5ab125bb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->