### PR TITLE
Remove limited availability for Solana.

### DIFF
--- a/services/reference/solana/index.md
+++ b/services/reference/solana/index.md
@@ -10,9 +10,6 @@ import CardList from '@site/src/components/CardList'
 
 Solana is supported through the [DIN](https://www.infura.io/solutions/decentralized-infrastructure-service) service, meaning calls to the network are routed to [partner infrastructure providers](#partners-and-privacy-policies).
 
-Solana access is currently limited to select customers. [Contact us](https://www.infura.io/contact)
-if you're interested in accessing these methods.
-
 :::
 
 Solana provides a high-performance network that is utilized for a range of use cases, including finance, NFTs, payments, and gaming.

--- a/services/reference/solana/json-rpc-methods/index.md
+++ b/services/reference/solana/json-rpc-methods/index.md
@@ -10,8 +10,6 @@ sidebar_key: solana-json-rpc-api
 Solana is supported through the [DIN](https://www.infura.io/solutions/decentralized-infrastructure-service) service,
 meaning calls to the network are routed to [partner infrastructure providers](../../solana/index.md#partners-and-privacy-policies).
 
-Solana access is currently limited to select customers. [Contact us](https://www.infura.io/contact)
-if you're interested in accessing these methods.
 :::
 
 Infura supports the standard Solana API methods and the

--- a/services/reference/solana/quickstart.md
+++ b/services/reference/solana/quickstart.md
@@ -9,11 +9,6 @@ import Banner from '@site/src/components/Banner'
 
 This quickstart guide will help you set up and make calls on the Solana network using the Infura endpoints.
 
-:::note limited access
-Solana access is currently limited to select customers. [Contact us](https://www.infura.io/contact)
-if you're interested in accessing these methods.
-:::
-
 ## Prerequisites
 
 Ensure you have an [API key](/developer-tools/dashboard/get-started/create-api) with the Solana network enabled.


### PR DESCRIPTION
# Description

Solana is no longer under limited availability.

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change removing the “limited access” messaging; low risk aside from potentially miscommunicating product availability if rolled out prematurely.
> 
> **Overview**
> Updates Solana documentation to reflect general availability by removing the **“limited access / contact us”** notices from the main Solana landing page, the JSON-RPC API page, and the Solana quickstart.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d38d986eebcc05464b7c0a8db4a85fe8c6228bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->