### PR TITLE
Add messaging for unsupported functions by external wallets

### DIFF
--- a/embedded-wallets/sdk/js/usage/enableMFA.mdx
+++ b/embedded-wallets/sdk/js/usage/enableMFA.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Function enableMFA | Embedded Wallets'
 
 Function to enable Multi-Factor Authentication (MFA) for users with Web3Auth.
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ```javascript
 try {
   await web3auth.enableMFA()

--- a/embedded-wallets/sdk/js/usage/getUserInfo.mdx
+++ b/embedded-wallets/sdk/js/usage/getUserInfo.mdx
@@ -15,6 +15,12 @@ This function will only return information based on the connected adapter. These
 
 :::
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Usage
 
 ```javascript

--- a/embedded-wallets/sdk/js/usage/manageMFA.mdx
+++ b/embedded-wallets/sdk/js/usage/manageMFA.mdx
@@ -11,6 +11,12 @@ import Tabs from '@theme/Tabs'
 
 You can redirect users to the Embedded Wallets account dashboard to manage their MFA settings by calling the `manageMFA()` function. This method ensures that identity details are injected into the dashboard internally for custom verifier-based dapps. In order to see what's present on the account dashboard, please refer to the [Account Dashboard](/embedded-wallets/features/user-account-dashboard).
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ```javascript
 await web3auth.manageMFA()
 ```

--- a/embedded-wallets/sdk/js/usage/showCheckout.mdx
+++ b/embedded-wallets/sdk/js/usage/showCheckout.mdx
@@ -12,6 +12,12 @@ This is a paid feature and the minimum [pricing plan](https://web3auth.io/pricin
 
 :::
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Usage
 
 ```ts

--- a/embedded-wallets/sdk/js/usage/showSwap.mdx
+++ b/embedded-wallets/sdk/js/usage/showSwap.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal showSwap Function | Embedded Wallets'
 
 Function to open the swap interface using the Wallet Services plugin.
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Usage
 
 ```ts

--- a/embedded-wallets/sdk/js/usage/showWalletConnectScanner.mdx
+++ b/embedded-wallets/sdk/js/usage/showWalletConnectScanner.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal showWalletConnectScanner | Embedded Wallets'
 
 Function to show the WalletConnect QR scanner using the Wallet Services plugin.
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Usage
 
 ```ts

--- a/embedded-wallets/sdk/js/usage/showWalletUI.mdx
+++ b/embedded-wallets/sdk/js/usage/showWalletUI.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal showWalletUI | Embedded Wallets'
 
 Function to show the templated wallet UI services modal using the Wallet Services plugin.
 
+:::info
+
+Please note that this function doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Usage
 
 ```javascript

--- a/embedded-wallets/sdk/react/hooks/useCheckout.mdx
+++ b/embedded-wallets/sdk/react/hooks/useCheckout.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useCheckout | Embedded Wallets'
 
 Hook to show the cryptocurrency checkout modal using Wallet Services plugin.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useEnableMFA.mdx
+++ b/embedded-wallets/sdk/react/hooks/useEnableMFA.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useEnableMFA | Embedded Wallets'
 
 Hook to enable Multi-Factor Authentication (MFA) using Web3Auth.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useManageMFA.mdx
+++ b/embedded-wallets/sdk/react/hooks/useManageMFA.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useManageMFA | Embedded Wallets'
 
 Hook to manage Multi-Factor Authentication (MFA) using Embedded Wallets. This hook provides a convenient way to trigger MFA management actions, such as updating or configuring MFA settings for the user.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useSwap.mdx
+++ b/embedded-wallets/sdk/react/hooks/useSwap.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useSwap | Embedded Wallets'
 
 Hook to open the Swap interface using the Wallet Services plugin.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useWalletConnectScanner.mdx
+++ b/embedded-wallets/sdk/react/hooks/useWalletConnectScanner.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useWalletConnectScanner | Embedded Wal
 
 Hook to show the WalletConnect QR scanner using the Wallet Services plugin.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useWalletServicesPlugin.mdx
+++ b/embedded-wallets/sdk/react/hooks/useWalletServicesPlugin.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useWalletServicesPlugin | Embedded Wal
 
 Hook to access the Wallet Services plugin context, enabling wallet-related features such as WalletConnect, checkout, swap, and wallet UI.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useWalletUI.mdx
+++ b/embedded-wallets/sdk/react/hooks/useWalletUI.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useWalletUI | Embedded Wallets'
 
 Hook to show the Wallet Services UI modal using the Wallet Services plugin.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/react/hooks/useWeb3AuthUser.mdx
+++ b/embedded-wallets/sdk/react/hooks/useWeb3AuthUser.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal React Hooks useWeb3AuthUser | Embedded Wallets'
 
 Hook to fetch and manage the current Embedded Wallets user information.
 
+:::info
+
+Please note that this hook doesn't work for external wallet logins. It only works for social login embedded wallets. It returns and empty object for external wallet logins.
+
+:::
+
 ### Import
 
 ```tsx

--- a/embedded-wallets/sdk/vue/composables/useCheckout.mdx
+++ b/embedded-wallets/sdk/vue/composables/useCheckout.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composable useCheckout | Embedded Wallets'
 
 Composable to show the cryptocurrency checkout modal using Wallet Services plugin.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useEnableMFA.mdx
+++ b/embedded-wallets/sdk/vue/composables/useEnableMFA.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composable useEnableMFA | Embedded Wallets'
 
 Composable to enable Multi-Factor Authentication (MFA) using Embedded Wallets in Vue.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useManageMFA.mdx
+++ b/embedded-wallets/sdk/vue/composables/useManageMFA.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composables useManageMFA | Embedded Wallets'
 
 Hook to manage Multi-Factor Authentication (MFA) using Embedded Wallets. This composable provides a convenient way to trigger MFA management actions, such as updating or configuring MFA settings for the user.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useSwap.mdx
+++ b/embedded-wallets/sdk/vue/composables/useSwap.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composables useSwap | Embedded Wallets'
 
 Hook to open the swap interface using the Wallet Services plugin.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useWalletConnectScanner.mdx
+++ b/embedded-wallets/sdk/vue/composables/useWalletConnectScanner.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composable useWalletConnectScanner | Embedded 
 
 Composable to show the WalletConnect QR scanner using the Wallet Services plugin in Vue.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useWalletServicesPlugin.mdx
+++ b/embedded-wallets/sdk/vue/composables/useWalletServicesPlugin.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composables useWalletServicesPlugin | Embedded
 
 Hook to access the Wallet Services Ppugin context, enabling wallet-related features such as WalletConnect, checkout, swap, and wallet UI.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useWalletUI.mdx
+++ b/embedded-wallets/sdk/vue/composables/useWalletUI.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal Vue Composables useWalletUI | Embedded Wallets'
 
 Hook to show the Wallet Services UI modal using the Wallet Services plugin.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts

--- a/embedded-wallets/sdk/vue/composables/useWeb3AuthUser.mdx
+++ b/embedded-wallets/sdk/vue/composables/useWeb3AuthUser.mdx
@@ -6,6 +6,12 @@ description: '@web3auth/modal/vue Composable useWeb3AuthUser | Embedded Wallets'
 
 Composable to fetch and manage the current Web3Auth user information in Vue.
 
+:::info
+
+Please note that this composable doesn't work for external wallet logins. It only works for social login embedded wallets.
+
+:::
+
 ### Import
 
 ```ts


### PR DESCRIPTION
Adds a quick messaging for edge case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add compatibility notes; low risk aside from potential wording/consistency issues affecting developer expectations.
> 
> **Overview**
> Adds consistent `:::info` callouts across JS usage docs and React/Vue hook/composable docs to clarify that MFA, user info, and Wallet Services modals (checkout/swap/wallet UI/WalletConnect scanner) **do not work with external wallet logins** and are intended for *social login embedded wallets* (with `useWeb3AuthUser` noting it returns an empty object for external wallets).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54fe4b8813fc85c8ad549fdfde69e2168ac36d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->