### PR TITLE
[Smart Accounts Kit] Add error codes

### DIFF
--- a/smart-accounts-kit/troubleshooting/error-codes.md
+++ b/smart-accounts-kit/troubleshooting/error-codes.md
@@ -18,7 +18,7 @@ Error codes from the [MetaMask Delegation Framework contracts](https://github.co
 | `0xb9f0f171` | `InvalidDelegator()` | The caller is not the delegator specificed in the delegation, or the delegator is not deployed. |
 | `0x05baa052` | `CannotUseADisabledDelegation()` | The delegation has been disabled by the delegator. |
 | `0xded4370e` | `InvalidAuthority()` | The delegation chain authority validation failed. The authority hash of a child delegation does not match the hash of its parent delegation. |
-| `0x1bcaf69f` | `BatchDataLengthMismatch()` | The array lengths do not match in a batch `redeemDelegations` call. |
+| `0x1bcaf69f` | `BatchDataLengthMismatch()` | The array lengths do not match in a batch `redeemDelegations` contract call. |
 | `0x005ecddb` | `AlreadyDisabled()` | The delegation has already been disabled. |
 | `0xf2a5f75a` | `AlreadyEnabled()` | The delegation is already enabled. |
 | `0xf645eedf` | `ECDSAInvalidSignature()` | Invalid ECDSA signature format. |


### PR DESCRIPTION
# Description

- Adds a new error codes page under troubleshooting section.

## Issue(s) fixed

Part of #2761 

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new documentation page only; no runtime or API behavior changes. Risk is limited to potential inaccuracies in listed error signatures/descriptions.
> 
> **Overview**
> Adds a new troubleshooting page, `smart-accounts-kit/troubleshooting/error-codes.md`, documenting **Delegation Framework revert/error identifiers**.
> 
> The page lists known error signatures for the Delegation Manager and smart accounts, plus caveat-enforcer error strings, to help users decode raw revert data during debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c2fdd0c3aaf035e31cf43fa8af62ab360059c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->