### PR TITLE
Fixed the eth_signTypedData_v4 example - correct use of `from` and im…

### DIFF
--- a/wallet/how-to/sign-data/index.md
+++ b/wallet/how-to/sign-data/index.md
@@ -62,6 +62,9 @@ Ensure your contract is as readable as possible to the user.
 The following is an example of using `eth_signTypedData_v4` with MetaMask:
 
 ```javascript title="index.js"
+import * as sigUtil from "@metamask/eth-sig-util"
+import * as ethUtil from "ethereumjs-util"
+
 signTypedDataV4Button.addEventListener("click", async function (event) {
   event.preventDefault()
 
@@ -131,9 +134,10 @@ signTypedDataV4Button.addEventListener("click", async function (event) {
     },
   })
 
-  var from = await web3.eth.getAccounts()
+  var accounts = await web3.eth.getAccounts()
+  var from = accounts[0]
 
-  var params = [from[0], msgParams]
+  var params = [from, msgParams]
   var method = "eth_signTypedData_v4"
 
   provider // Or window.ethereum if you don't support EIP-6963.
@@ -141,7 +145,7 @@ signTypedDataV4Button.addEventListener("click", async function (event) {
       {
         method,
         params,
-        from: from[0],
+        from: from,
       },
       function (err, result) {
         if (err) return console.dir(err)
@@ -163,7 +167,7 @@ signTypedDataV4Button.addEventListener("click", async function (event) {
           alert("Successfully recovered signer as " + from)
         } else {
           alert(
-            "Failed to verify signer when comparing " + result + " to " + from
+            "Failed to verify signer when comparing " + result.result + " to " + from
           )
         }
       }


### PR DESCRIPTION
# Description

The example using `eth_signTypedData_v4` contained errors:

`from` was returned as an array (`web3.eth.getAccounts()`), but was used as an address string.

The `sigUtil` and `ethUtil` imports were missing, which caused calls to `recoverTypedSignature_v4` and `toChecksumAddress` to fail.

The alert messages and signature verification used an array instead of a single address.

What has been fixed:

The correct imports have been added: `import * as sigUtil from “@metamask/eth-sig-util”` and `import * as ethUtil from “ethereumjs-util”`.

`from = accounts[0]` is used to pass a single address to RPC and for signature verification.

The check `ethUtil.toChecksumAddress(recovered) === ethUtil.toChecksumAddress(from)` is now correct.

`Alert` messages display a single address instead of an array.

After these changes, the example is fully functional and complies with the recommended use of EIP-712 signatures with MetaMask.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects sample code imports and address handling; no production logic affected.
> 
> **Overview**
> Updates the `eth_signTypedData_v4` guide example to be runnable by adding missing `@metamask/eth-sig-util` and `ethereumjs-util` imports.
> 
> Fixes account handling by selecting `from = accounts[0]` (instead of treating the full accounts array as an address) and uses that single address consistently for RPC params, checksum comparison, and error messaging during signature recovery/verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 704a5571c214157714c020a9419c5d03fca314a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->