### PR TITLE
Fix ethers v5/v6 inconsistency

### DIFF
--- a/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
+++ b/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
@@ -168,19 +168,21 @@ You can search for the transaction on a block explorer such as [Sepolia Ethersca
 To change default values, update the `signer.sendTransaction` method to include an `estimateGas` result:
 
 ```javascript title="eip1559_tx.js"
+const { ethers, parseUnits } = require("ethers");
+
 const limit = await provider.estimateGas({
   from: signer.address,
   to: "<to_address_goes_here>",
-  value: ethers.utils.parseUnits("0.001", "ether"),
+  value: parseUnits("0.001", "ether"),
 });
 
 // Creating and sending the transaction object
 const tx = await signer.sendTransaction({
   to: "<to_address_goes_here>",
-  value: ethers.utils.parseUnits("0.001", "ether"),
+  value: parseUnits("0.001", "ether"),
   gasLimit: limit,
   nonce: await signer.getTransactionCount(),
-  maxPriorityFeePerGas: ethers.utils.parseUnits("2", "gwei"),
-  chainId: 11155111,
+  maxPriorityFeePerGas: parseUnits("2", "gwei"),
+  chainId: 11155111, // Sepolia
 });
 ```


### PR DESCRIPTION
# Description

This PR fixes an inconsistency between `ethers.js` versions in the tutorial.

- Updated the optional transaction example to use `ethers.js v6` syntax (removed `ethers.utils` usage)
- Ensured `parseUnits` is used consistently across the file
- Added clarity by aligning all examples with `ethers v6`

These changes prevent copy-paste errors and ensure the code works correctly with `ethers v6`.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a code snippet to consistent `ethers` v6 syntax, reducing copy/paste errors.
> 
> **Overview**
> Updates the “Fine tune the transaction details” snippet in `send-a-transaction-ethers.md` to consistently use `ethers` v6-style `parseUnits` (removing `ethers.utils.parseUnits`) and adds a brief `chainId` comment for Sepolia.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b93f92fbc32c8ba055d213ce789e9ddc14045bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->