### PR TITLE
Apply review feedback to user operation reverted troubleshooting page

### DIFF
--- a/smart-accounts-kit/troubleshooting/user-operation-reverted.md
+++ b/smart-accounts-kit/troubleshooting/user-operation-reverted.md
@@ -7,20 +7,20 @@ keywords: [user operation, reverted, reason 0x, empty revert, execution, trouble
 
 # User operation reverted
 
-A user operation reverts with reason `0x` when the validation phase passes
-but the execution phase fails silently. This is distinct from AA-coded `EntryPoint` contract errors such as `AA23`, `AA25`,
+A user operation reverts with reason `0x` when validation succeeds, but execution fails without a
+revert reason. This differs from AA-coded `EntryPoint` contract errors such as `AA23`, `AA25`,
 or `AA21`.
 
-When the `EntryPoint` contract calls the smart account's execution function, it uses a low-level
-`call` internally. If that inner call reverts with empty data, the bundler surfaces the error as
-reason `0x` with no additional information.
+When the `EntryPoint` contract calls the smart account's execution function, it performs a low-level
+`call` internally. If that inner call reverts with empty data, the bundler reports
+reason `0x` with no additional details.
 
-The following are common causes.
+The following sections describe common causes and how to troubleshoot them.
 
 ## Function doesn't exist
 
 The `callData` encodes a call from the smart account to a target contract, but the function
-selector doesn't match any function on that contract and no fallback function exists. The EVM
+selector doesn't match any function on that contract, and no fallback function exists. The EVM
 reverts with empty data.
 
 This commonly happens when:
@@ -30,7 +30,7 @@ This commonly happens when:
 
 ### Solution
 
-Decode your `callData` and verify the inner call. Check that the target address has deployed code
+Decode `callData` and verify the inner call. Confirm that the target address has deployed code
 and that the function selector matches the target's ABI.
 
 ```typescript
@@ -104,7 +104,7 @@ const allowance = await publicClient.readContract({
 If the cause isn't immediately clear, follow these steps:
 
 1. Decode the inner call: Extract the `(to, value, data)` tuple from your `callData` to
-   understand what the smart account executes.
+   confirm what the smart account executes.
 2. Use Tenderly: Simulate the user operation in [Tenderly](https://tenderly.co) to get a full
    execution trace. The trace view shows the exact line where the inner call reverts.
 2. Check the basics: Verify the target has deployed code, the smart account has enough


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

This PR applies review feedback from @bgravenorst on PR #2795 to the development version of the user operation reverted troubleshooting documentation.

All six suggested improvements have been implemented to enhance clarity, readability, and consistency:

1. **Clarified opening description** - Simplified the explanation of when user operations revert with reason `0x`
2. **Simplified technical explanation** - Made the EntryPoint behavior description more concise
3. **Improved transition sentence** - Better describes what the following sections cover
4. **Added missing comma** - Fixed grammar in the function selector explanation
5. **Simplified solution instructions** - Made the troubleshooting steps more direct
6. **Minor wording adjustment** - Changed "understand" to "confirm" for consistency

## Issue(s) fixed

Fixes #2796

## Preview

<!-- Preview link will be available after PR is created -->

## Checklist

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C09DWEKHW5N/p1774509029215099?thread_ts=1774509029.215099&cid=C09DWEKHW5N)

<div><a href="https://cursor.com/agents/bc-e2482af1-ffe2-5a39-af21-d5aa7fe76f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2482af1-ffe2-5a39-af21-d5aa7fe76f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

