### PR TITLE
Fix undefined `provider`

### DIFF
--- a/wallet/how-to/send-transactions/index.md
+++ b/wallet/how-to/send-transactions/index.md
@@ -22,6 +22,8 @@ select each button:
 const ethereumButton = document.querySelector(".enableEthereumButton");
 const sendEthButton = document.querySelector(".sendEthButton");
 
+const provider = window.ethereum; // Or use your EIP-6963 provider
+
 let accounts = [];
 
 sendEthButton.addEventListener("click", () => {


### PR DESCRIPTION
# Description

The JavaScript example uses a `provider` variable that is never defined within the snippet.

This leads to a `ReferenceError` when copying and running the code as-is. Although comments mention `window.ethereum` or EIP-6963 providers, no actual assignment is shown.

Change

Added an explicit provider initialization at the beginning of the example:

`const provider = window.ethereum; // Or use your EIP-6963 provider`

This ensures the example works out of the box and avoids confusion for developers following the guide.

Alternatively, users can replace this with their own provider implementation (e.g., from EIP-6963).

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes a broken JavaScript example by initializing `provider`, with no behavioral impact on the product.
> 
> **Overview**
> Fixes the `Send transactions` guide example (`wallet/how-to/send-transactions/index.md`) by adding an explicit `const provider = window.ethereum` initialization so the snippet no longer references an undefined `provider` when copied and run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b1acc9fa13e7820c611e59c616a5fe9d6bb137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->