### PR TITLE
fix(CopyPageButton): prevent position flash on page reload

### DIFF
--- a/src/components/CopyPageButton/CopyPageButton.jsx
+++ b/src/components/CopyPageButton/CopyPageButton.jsx
@@ -261,7 +261,7 @@ export default function CopyPageButton({ standalone = false }) {
   };  
 
   return (
-    <div className={styles.container} ref={containerRef} data-copy-button>
+    <div className={`${styles.container} ${standalone ? styles.standalone : ''}`} ref={containerRef} data-copy-button>
       <button
         className={styles.mainButton}
         onClick={() => setIsOpen(!isOpen)}

--- a/src/components/CopyPageButton/CopyPageButton.module.css
+++ b/src/components/CopyPageButton/CopyPageButton.module.css
@@ -25,6 +25,10 @@
   visibility: visible;
 }
 
+.standalone {
+  visibility: visible;
+}
+
 .mainButton {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Description
Fix `CopyPageButton` flashing at the wrong position (top-left) for a split second 
on page reload before moving to its correct position (top-right of H1).

The button was briefly visible in its default DOM position before `useEffect` could 
move it into the `.h1Wrapper`. Fixed by hiding the button with `visibility:hidden` by 
default, and only showing it via `visibility:visible` when it's inside `.h1Wrapper` 
— ensuring it's never visible until it's already in the correct position.

## Issue(s) fixed
Fixes #2811

## Preview
https://github.com/user-attachments/assets/74c45f41-a142-40a5-884d-f68a778be71c



## Checklist
- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist
- [x] I've read the contribution guidelines.
- [x] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

@alexandratran please review the PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS/markup tweak that only affects `CopyPageButton` visibility and positioning; potential risk is the button staying hidden if wrapper/standalone styling isn’t applied as expected.
> 
> **Overview**
> Prevents `CopyPageButton` from briefly rendering in the wrong (default) position on page reload by making the container `visibility: hidden` by default.
> 
> The button is now only made visible when rendered inside `.h1Wrapper`, or when the `standalone` prop is set (via an added conditional `styles.standalone` class).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42c67c877e2d4ab74eb0ab4d66c155b7befdee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->