### PR TITLE
Fix mobile tooltips

### DIFF
--- a/smart-accounts-kit/reference/glossary.mdx
+++ b/smart-accounts-kit/reference/glossary.mdx
@@ -19,7 +19,7 @@ Fine-grained, wallet execution permissions that dapps can request from MetaMask 
 
 ### Bundler
 
-An ERC-4337 component that manages the alternate mempool: it collects user operations from smart accounts, bundles them into transactions, and submits them to the network.
+An ERC-4337 component that manages the alternate mempool: it collects user operations from smart accounts, packages them, and submits them to the network.
 
 ### Caveat
 

--- a/src/theme/GlossaryTerm/index.js
+++ b/src/theme/GlossaryTerm/index.js
@@ -149,11 +149,6 @@ export default function GlossaryTerm({
           }
         >
           <strong>{term}</strong> {effectiveDefinition}
-          {isTouch && (
-            <a href={glossaryHref} className={styles.tooltipLink}>
-              View in glossary →
-            </a>
-          )}
         </span>
       )}
     </span>

--- a/src/theme/GlossaryTerm/index.js
+++ b/src/theme/GlossaryTerm/index.js
@@ -4,6 +4,17 @@ import GithubSlugger from 'github-slugger';
 import glossaryData from '@site/src/lib/glossary.json';
 import styles from './styles.module.css';
 
+function useIsTouchDevice() {
+  const [isTouch, setIsTouch] = useState(false);
+  useEffect(() => {
+    setIsTouch(
+      'ontouchstart' in window ||
+      window.matchMedia('(pointer: coarse)').matches
+    );
+  }, []);
+  return isTouch;
+}
+
 export default function GlossaryTerm({
   term,
   definition,
@@ -14,6 +25,7 @@ export default function GlossaryTerm({
   const [tooltipStyle, setTooltipStyle] = useState(null);
   const wrapperRef = useRef(null);
   const tooltipRef = useRef(null);
+  const isTouch = useIsTouchDevice();
 
   const updatePosition = useCallback(() => {
     if (!wrapperRef.current || !tooltipRef.current) return;
@@ -25,7 +37,6 @@ export default function GlossaryTerm({
 
     const preferredGap = 8; // px
 
-    // Decide top vs bottom based on available space
     const hasSpaceAbove = wrapperRect.top >= tooltipRect.height + preferredGap;
     const hasSpaceBelow = viewportHeight - wrapperRect.bottom >= tooltipRect.height + preferredGap;
     const placeAbove = hasSpaceAbove || !hasSpaceBelow;
@@ -37,7 +48,6 @@ export default function GlossaryTerm({
       top = wrapperRect.bottom + preferredGap;
     }
 
-    // Center horizontally on the wrapper, then clamp within viewport with margin
     const horizontalMargin = 8;
     let left = wrapperRect.left + wrapperRect.width / 2 - tooltipRect.width / 2;
     left = Math.max(
@@ -51,8 +61,6 @@ export default function GlossaryTerm({
   useEffect(() => {
     if (!showTooltip) return;
 
-    // Use double requestAnimationFrame to ensure DOM is fully rendered and layout is complete
-    // This ensures tooltipRef.current is available and has proper dimensions
     let rafId2;
     const rafId1 = requestAnimationFrame(() => {
       rafId2 = requestAnimationFrame(() => {
@@ -72,7 +80,18 @@ export default function GlossaryTerm({
     };
   }, [showTooltip, updatePosition]);
 
-  // Pull definition from local glossary data if not provided
+  // Close tooltip when tapping outside on touch devices
+  useEffect(() => {
+    if (!isTouch || !showTooltip) return;
+    const handleTouchOutside = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setShowTooltip(false);
+      }
+    };
+    document.addEventListener('touchstart', handleTouchOutside);
+    return () => document.removeEventListener('touchstart', handleTouchOutside);
+  }, [isTouch, showTooltip]);
+
   const effectiveDefinition = useMemo(() => {
     if (definition && typeof definition === 'string' && definition.length > 0) {
       return definition;
@@ -95,15 +114,24 @@ export default function GlossaryTerm({
     return slugger.slug(String(term || ''));
   }, [term]);
 
+  const glossaryHref = `${effectiveRoutePath}#${termId}`;
+
+  const handleClick = (e) => {
+    if (!isTouch) return;
+    e.preventDefault();
+    setShowTooltip((prev) => !prev);
+  };
+
   return (
     <span ref={wrapperRef} className={styles.glossaryTermWrapper}>
       <a
-        href={`${effectiveRoutePath}#${termId}`}
+        href={glossaryHref}
         className={styles.glossaryTerm}
-        onMouseEnter={() => setShowTooltip(true)}
-        onMouseLeave={() => setShowTooltip(false)}
-        onFocus={() => setShowTooltip(true)}
-        onBlur={() => setShowTooltip(false)}
+        onClick={handleClick}
+        onMouseEnter={isTouch ? undefined : () => setShowTooltip(true)}
+        onMouseLeave={isTouch ? undefined : () => setShowTooltip(false)}
+        onFocus={isTouch ? undefined : () => setShowTooltip(true)}
+        onBlur={isTouch ? undefined : () => setShowTooltip(false)}
         aria-describedby={`tooltip-${termId}`}
       >
         {displayText}
@@ -121,6 +149,11 @@ export default function GlossaryTerm({
           }
         >
           <strong>{term}</strong> {effectiveDefinition}
+          {isTouch && (
+            <a href={glossaryHref} className={styles.tooltipLink}>
+              View in glossary →
+            </a>
+          )}
         </span>
       )}
     </span>

--- a/src/theme/GlossaryTerm/index.js
+++ b/src/theme/GlossaryTerm/index.js
@@ -86,6 +86,7 @@ export default function GlossaryTerm({
     const handleTouchOutside = (e) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
         setShowTooltip(false);
+        setTooltipStyle(null);
       }
     };
     document.addEventListener('touchstart', handleTouchOutside);
@@ -119,8 +120,13 @@ export default function GlossaryTerm({
   const handleClick = (e) => {
     if (!isTouch) return;
     e.preventDefault();
-    setShowTooltip((prev) => !prev);
+    setShowTooltip((prev) => {
+      if (prev) setTooltipStyle(null);
+      return !prev;
+    });
   };
+
+  const tooltipPositioned = showTooltip && tooltipStyle != null;
 
   return (
     <span ref={wrapperRef} className={styles.glossaryTermWrapper}>
@@ -129,9 +135,9 @@ export default function GlossaryTerm({
         className={styles.glossaryTerm}
         onClick={handleClick}
         onMouseEnter={isTouch ? undefined : () => setShowTooltip(true)}
-        onMouseLeave={isTouch ? undefined : () => setShowTooltip(false)}
+        onMouseLeave={isTouch ? undefined : () => { setShowTooltip(false); setTooltipStyle(null); }}
         onFocus={isTouch ? undefined : () => setShowTooltip(true)}
-        onBlur={isTouch ? undefined : () => setShowTooltip(false)}
+        onBlur={isTouch ? undefined : () => { setShowTooltip(false); setTooltipStyle(null); }}
         aria-describedby={`tooltip-${termId}`}
       >
         {displayText}
@@ -140,10 +146,10 @@ export default function GlossaryTerm({
         <span
           ref={tooltipRef}
           id={`tooltip-${termId}`}
-          className={`${styles.tooltip} ${showTooltip ? styles.tooltipVisible : ''} ${styles.tooltipFloating}`}
+          className={`${styles.tooltip} ${tooltipPositioned ? styles.tooltipVisible : ''} ${styles.tooltipFloating}`}
           role="tooltip"
           style={
-            showTooltip && tooltipStyle
+            tooltipPositioned
               ? { top: `${tooltipStyle.top}px`, left: `${tooltipStyle.left}px` }
               : undefined
           }

--- a/src/theme/GlossaryTerm/index.js
+++ b/src/theme/GlossaryTerm/index.js
@@ -8,7 +8,7 @@ function useIsTouchDevice() {
   const [isTouch, setIsTouch] = useState(false);
   useEffect(() => {
     setIsTouch(
-      'ontouchstart' in window ||
+      'ontouchstart' in window &&
       window.matchMedia('(pointer: coarse)').matches
     );
   }, []);

--- a/src/theme/GlossaryTerm/styles.module.css
+++ b/src/theme/GlossaryTerm/styles.module.css
@@ -67,18 +67,6 @@
   border-color: var(--ifm-color-emphasis-400);
 }
 
-.tooltipLink {
-  display: block;
-  margin-top: 0.5rem;
-  font-size: 0.85em;
-  color: var(--ifm-color-primary);
-  text-decoration: none;
-}
-
-.tooltipLink:hover {
-  text-decoration: underline;
-}
-
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .tooltip {

--- a/src/theme/GlossaryTerm/styles.module.css
+++ b/src/theme/GlossaryTerm/styles.module.css
@@ -67,6 +67,18 @@
   border-color: var(--ifm-color-emphasis-400);
 }
 
+.tooltipLink {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85em;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.tooltipLink:hover {
+  text-decoration: underline;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .tooltip {


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Mobile tooltips had buggy behavior. Edit tooltip component to behave like a popover on mobile touchscreens.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://metamask-docs-obf0gmjb3-consensys-ddffed67.vercel.app/smart-accounts-kit/development/get-started/install/

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change confined to the `GlossaryTerm` tooltip interaction/positioning and a minor glossary wording tweak.
> 
> **Overview**
> Improves `GlossaryTerm` tooltip behavior on touch devices by switching from hover/focus-triggered tooltips to a tap-to-toggle popover that **prevents navigation**, closes on outside tap, and avoids showing the tooltip until it has a computed fixed position.
> 
> Also makes a small docs wording update in the Smart Accounts glossary (Bundler definition: “bundles” → “packages”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66aa1914fd6d0fad2a2567cf6776304bfc2bafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->