### PR TITLE
MM Connect style fixes

### DIFF
--- a/.cursor/rules/product-metamask-connect.mdc
+++ b/.cursor/rules/product-metamask-connect.mdc
@@ -32,6 +32,13 @@ consistently:
 - **Account IDs** (CAIP-10): chain-qualified account identifiers such as `eip155:1:0xabc...`.
 - **Sessions** (CAIP-25): an authorized connection grouping approved scopes and accounts.
 
+## Method references in prose
+
+When referring to a method or function in prose text, markdown tables, or headings, omit the
+trailing `()`. Write `connect`, not `connect()`. This keeps references concise and distinguishes
+prose names from actual invocations in code blocks. If the reference shows parameters to illustrate
+usage (for example, `connect(scopes, caipAccountIds)`), keep the parentheses and parameters.
+
 ## EVM conventions
 
 - Reference the `window.ethereum` provider when discussing the injected provider.

--- a/metamask-connect/evm/guides/manage-user-accounts.md
+++ b/metamask-connect/evm/guides/manage-user-accounts.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Manage user accounts
 
-Use MetaMask Connect EVM to connect wallets, retrieve user accounts, and handle session lifecycle in Vanilla JavaScript or Wagmi dapps. MetaMask Connect EVM provides `connect()` for wallet access, `connectAndSign()` for single-step authentication, and the `accountsChanged` event for tracking when users switch accounts.
+Use MetaMask Connect EVM to connect wallets, retrieve user accounts, and handle session lifecycle in Vanilla JavaScript or Wagmi dapps. MetaMask Connect EVM provides `connect` for wallet access, `connectAndSign` for single-step authentication, and the `accountsChanged` event for tracking when users switch accounts.
 
 With MetaMask Connect EVM, you can:
 

--- a/metamask-connect/evm/guides/metamask-exclusive/display-tokens.md
+++ b/metamask-connect/evm/guides/metamask-exclusive/display-tokens.md
@@ -173,8 +173,8 @@ try {
 
 ### Display multiple NFTs
 
-To prompt users to add multiple NFTs, use `sendAsync()` instead of
-`request()` to call `wallet_watchAsset`.
+To prompt users to add multiple NFTs, use `sendAsync` instead of
+`request` to call `wallet_watchAsset`.
 For example:
 
 ```javascript

--- a/metamask-connect/evm/guides/metamask-exclusive/use-deeplinks.md
+++ b/metamask-connect/evm/guides/metamask-exclusive/use-deeplinks.md
@@ -30,7 +30,8 @@ Convert deeplinks to QR codes so users can scan them with a mobile device.
 If a user doesn't have the mobile app installed, deeplinks route the user to a landing page where they can download the app.
 
 :::tip
-The [**Open a dapp in the in-app browser**](#open-a-dapp-inside-the-metamask-in-app-browser) deeplink works for any dapp regardless of ecosystem (EVM, Solana, or multichain) — it simply opens a URL inside the MetaMask mobile app's built-in browser.
+The [**Open a dapp in the in-app browser**](#open-a-dapp-inside-the-metamask-in-app-browser) deeplink works for any dapp regardless of ecosystem (EVM, Solana, or multichain).
+It opens a URL inside the MetaMask mobile app's built-in browser.
 The remaining deeplinks on this page (send, buy, sell) are EVM-specific.
 :::
 

--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -40,7 +40,7 @@ Replace `@metamask/sdk` and `@metamask/sdk-react` imports with the new `@metamas
 
 :::note
 `@metamask/sdk-react` has no direct replacement. If you were using `MetaMaskProvider` and
-`useSDK()`, migrate to [wagmi hooks](../quickstart/wagmi.md) or manage the client instance in your
+`useSDK`, migrate to [wagmi hooks](../quickstart/wagmi.md) or manage the client instance in your
 own React context (see [React context pattern](#react-context-pattern-replacing-usesdk) below).
 :::
 
@@ -63,7 +63,7 @@ own React context (see [React context pattern](#react-context-pattern-replacing-
 
 ### 3. Update initialization
 
-Replace the `MetaMaskSDK` constructor and `init()` call with `createEVMClient()`, which handles
+Replace the `MetaMaskSDK` constructor and `init` call with `createEVMClient`, which handles
 initialization in a single async step.
 
 :::caution
@@ -142,7 +142,7 @@ options that MetaMask Connect EVM no longer exposes.
 
 ### 4. Update connection flow
 
-In MetaMask Connect EVM, you request chain permissions during `connect()` and receive the connected accounts
+In MetaMask Connect EVM, you request chain permissions during `connect` and receive the connected accounts
 and selected chain ID in a single response. This replaces the previous flow where you connected first
 and then made a separate JSON-RPC request for `eth_chainId`.
 
@@ -165,12 +165,12 @@ and then made a separate JSON-RPC request for `eth_chainId`.
 // add-end
 ```
 
-`connect()` now returns an object with both `accounts` and `chainId` in a single call.
+`connect` now returns an object with both `accounts` and `chainId` in a single call.
 The `chainIds` parameter specifies which chains to request permission for.
 Ethereum Mainnet (`0x1`) is always included regardless of what you pass.
 
 :::note
-Chain IDs must be hex strings — use `'0x1'`, not `1` or `'1'`, in `chainIds` and
+Chain IDs must be hex strings. Use `'0x1'`, not `1` or `'1'`, in `chainIds` and
 `supportedNetworks` keys.
 :::
 
@@ -207,8 +207,8 @@ app and encounter errors referencing `Buffer`, `crypto`, `stream`, or `Event is 
 
 ### 5. Update provider access
 
-In MetaMask Connect EVM, `client.getProvider()` returns an EIP-1193 provider. You no longer use the
-`SDKProvider` returned by `sdk.getProvider()`.
+In MetaMask Connect EVM, `client.getProvider` returns an EIP-1193 provider. You no longer use the
+`SDKProvider` returned by `sdk.getProvider`.
 
 **Old:**
 
@@ -231,10 +231,10 @@ In MetaMask Connect EVM, `client.getProvider()` returns an EIP-1193 provider. Yo
 Key differences:
 
 - The provider is a standard EIP-1193 provider, not the custom `SDKProvider`.
-- The provider is available immediately after `createEVMClient` resolves, even before `connect()`.
+- The provider is available immediately after `createEVMClient` resolves, even before `connect`.
 - Read-only calls (like `eth_blockNumber`) work immediately against `supportedNetworks` RPCs.
-  Account-dependent calls require `connect()` first.
-- `client.getProvider()` never returns `undefined`.
+  Account-dependent calls require `connect` first.
+- `client.getProvider` never returns `undefined`.
 
 ### 6. Update event handling
 
@@ -341,10 +341,10 @@ See the [multichain quickstart](../../multichain/quickstart/javascript.md) for a
 | Old (`@metamask/sdk`)    | New (`@metamask/connect-evm`)                      | Status                                |
 | ------------------------ | -------------------------------------------------- | ------------------------------------- |
 | `new MetaMaskSDK(opts)`  | `await createEVMClient(opts)`                      | Renamed, async                        |
-| `sdk.init()`             | Not needed                                         | Init happens in `createEVMClient`     |
-| `sdk.connect()`          | `client.connect({ chainIds })`                     | Returns `{ accounts, chainId }`       |
-| `sdk.getProvider()`      | `client.getProvider()`                             | Returns EIP-1193 provider             |
-| `sdk.disconnect()`       | `client.disconnect()`                              | Same, plus partial disconnect support |
+| `sdk.init`               | Not needed                                         | Init happens in `createEVMClient`     |
+| `sdk.connect`            | `client.connect({ chainIds })`                     | Returns `{ accounts, chainId }`       |
+| `sdk.getProvider`        | `client.getProvider`                               | Returns EIP-1193 provider             |
+| `sdk.disconnect`         | `client.disconnect`                                | Same, plus partial disconnect support |
 | `dappMetadata`           | `dapp`                                             | Renamed                               |
 | `infuraAPIKey`           | [`getInfuraRpcUrls({ infuraApiKey })`](../reference/methods.md#getinfurarpcurls) in `api.supportedNetworks` | Helper function                       |
 | `readonlyRPCMap`         | `api.supportedNetworks`                            | Merged with Infura URLs               |

--- a/metamask-connect/evm/index.md
+++ b/metamask-connect/evm/index.md
@@ -79,17 +79,17 @@ description: 'Set up MetaMask Connect EVM in a React Native or Expo dapp.',
 
 The EVM client works seamlessly with popular Ethereum libraries:
 
-| Library                               | Compatibility                                     |
-| ------------------------------------- | ------------------------------------------------- |
-| [viem](https://viem.sh/)              | Use with `custom()` transport                     |
-| [ethers.js](https://docs.ethers.org/) | Pass `client.getProvider()` to `BrowserProvider`  |
-| [web3.js](https://web3js.org/)        | Pass `client.getProvider()` to `Web3` constructor |
+| Library                               | Compatibility                                   |
+| ------------------------------------- | ----------------------------------------------- |
+| [viem](https://viem.sh/)              | Use with `custom` transport                     |
+| [ethers.js](https://docs.ethers.org/) | Pass `client.getProvider` to `BrowserProvider`  |
+| [web3.js](https://web3js.org/)        | Pass `client.getProvider` to `Web3` constructor |
 
 ## Frequently asked questions
 
 ### What libraries does MetaMask Connect EVM work with?
 
-MetaMask Connect EVM provides an EIP-1193 compatible provider that works with viem (via `custom()` transport), ethers.js (via `BrowserProvider`), web3.js (via `Web3` constructor), and Wagmi (via the `metamask()` connector). It also supports wallet connector libraries like RainbowKit, ConnectKit, Dynamic, Privy, Web3Auth, and more.
+MetaMask Connect EVM provides an EIP-1193 compatible provider that works with viem (via `custom` transport), ethers.js (via `BrowserProvider`), web3.js (via `Web3` constructor), and Wagmi (via the `metamask` connector). It also supports wallet connector libraries like RainbowKit, ConnectKit, Dynamic, Privy, Web3Auth, and more.
 
 ### Do I need an Infura API key for MetaMask Connect EVM?
 

--- a/metamask-connect/evm/quickstart/connectkit.md
+++ b/metamask-connect/evm/quickstart/connectkit.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, JavaScript, ConnectKit, SDK, dapp, Wallet SDK, con
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/evm/quickstart/dynamic.md
+++ b/metamask-connect/evm/quickstart/dynamic.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, Dynamic, SDK, dapp, Wallet SDK, dynamic xyz, embed
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/evm/quickstart/javascript.md
+++ b/metamask-connect/evm/quickstart/javascript.md
@@ -146,7 +146,7 @@ These examples configure MetaMask Connect EVM with the following options:
 
 :::info Asynchronous client
 `createEVMClient` returns a promise. Always `await` it before using the client.
-The client is a **singleton** — calling `createEVMClient` again returns the same instance.
+The client is a **singleton**; calling `createEVMClient` again returns the same instance.
 :::
 
 ### 3. Connect and use provider
@@ -179,19 +179,19 @@ const balance = await provider.request({
 console.log('Balance:', balance)
 ```
 
-[`evmClient.connect()`](../reference/methods.md#connect) handles cross-platform connection (desktop and mobile), including deeplinking.
+[`evmClient.connect`](../reference/methods.md#connect) handles cross-platform connection (desktop and mobile), including deeplinking.
 Pass `chainIds` to request permission for specific chains (hex strings). Ethereum Mainnet (`0x1`)
 is always included regardless of what you pass.
 
-Use [`provider.request()`](../reference/provider-api.md#request) for arbitrary [JSON-RPC requests](../reference/json-rpc-api/index.md) like `eth_chainId` or `eth_getBalance`, or for [batching requests](../guides/metamask-exclusive/batch-requests.md) via `metamask_batch`.
+Use [`provider.request`](../reference/provider-api.md#request) for arbitrary [JSON-RPC requests](../reference/json-rpc-api/index.md) like `eth_chainId` or `eth_getBalance`, or for [batching requests](../guides/metamask-exclusive/batch-requests.md) via `metamask_batch`.
 
 ## Common MetaMask Connect EVM methods at a glance
 
 | Method                                                                         | Description                                              |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------- |
-| [`connect()`](../reference/methods.md#connect)                                 | Triggers wallet connection flow                          |
+| [`connect`](../reference/methods.md#connect)                                   | Triggers wallet connection flow                          |
 | [`connectAndSign({ message: "..." })`](../reference/methods.md#connectandsign) | Connects and prompts the user to sign a message          |
-| [`getProvider()`](../reference/methods.md#getprovider)                         | Returns the provider object for RPC requests             |
+| [`getProvider`](../reference/methods.md#getprovider)                           | Returns the provider object for RPC requests             |
 | [`provider.request({ method, params })`](../reference/provider-api.md#request) | Calls any Ethereum JSON‑RPC method                       |
 | [Batched RPC](../guides/metamask-exclusive/batch-requests.md)                  | Use `metamask_batch` to group multiple JSON-RPC requests |
 

--- a/metamask-connect/evm/quickstart/nodejs.md
+++ b/metamask-connect/evm/quickstart/nodejs.md
@@ -72,8 +72,8 @@ const evmClient = await createEVMClient({
 
 ### 3. Connect to MetaMask
 
-Call [`connect()`](../reference/methods.md#connect) to start the connection flow.
-A QR code appears in the terminal — scan it with the MetaMask mobile app:
+Call [`connect`](../reference/methods.md#connect) to start the connection flow.
+A QR code appears in the terminal. Scan it with the MetaMask mobile app:
 
 ```javascript
 try {

--- a/metamask-connect/evm/quickstart/rainbowkit.md
+++ b/metamask-connect/evm/quickstart/rainbowkit.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, JavaScript, RainbowKit, SDK, dapp, Wallet SDK, rai
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/evm/quickstart/react-native.md
+++ b/metamask-connect/evm/quickstart/react-native.md
@@ -218,7 +218,7 @@ you will get `crypto.getRandomValues is not a function`.
 ### 6. Use MetaMask Connect EVM
 
 Initialize the EVM client and use it to connect, sign, and send transactions.
-`mobile.preferredOpenLink` is **required** — it tells MetaMask Connect how to open deeplinks to the MetaMask
+`mobile.preferredOpenLink` is **required**; it tells MetaMask Connect how to open deeplinks to the MetaMask
 Mobile app:
 
 ```tsx

--- a/metamask-connect/evm/quickstart/wagmi.md
+++ b/metamask-connect/evm/quickstart/wagmi.md
@@ -327,11 +327,11 @@ If you previously used `@metamask/sdk` with Wagmi, the MetaMask connector now us
 
    | Old (wagmi v2)                      | New (wagmi v3)                         | Notes                                       |
    | ----------------------------------- | -------------------------------------- | ------------------------------------------- |
-   | `useAccount()`                      | `useConnection()`                      | Returns `address`, `isConnected`, `chainId` |
-   | `useConnect()` returns `connectors` | `useConnectors()` hook                 | Connectors are a separate hook              |
+   | `useAccount`                        | `useConnection`                        | Returns `address`, `isConnected`, `chainId` |
+   | `useConnect` returns `connectors`   | `useConnectors` hook                   | Connectors are a separate hook              |
    | `connect({ connector })`            | `connect.mutate({ connector })`        | Hooks return mutation objects               |
-   | `signMessage({ message })`          | `signMessage.mutateAsync({ message })` | Use `.mutateAsync()` for async results      |
-   | `sendTransaction({...})`            | `sendTx.mutateAsync({...})`            | Use `.mutateAsync()` for async results      |
+   | `signMessage({ message })`          | `signMessage.mutateAsync({ message })` | Use `.mutateAsync` for async results        |
+   | `sendTransaction({...})`            | `sendTx.mutateAsync({...})`            | Use `.mutateAsync` for async results        |
    | `switchChain({ chainId })`          | `switchChain.mutate({ chainId })`      | Mutation pattern                            |
 
 3. Update connector options:

--- a/metamask-connect/evm/quickstart/web3auth.md
+++ b/metamask-connect/evm/quickstart/web3auth.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, Embedded Wallets, SDK, dapp, Wallet SDK, web3auth,
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/evm/reference/methods.md
+++ b/metamask-connect/evm/reference/methods.md
@@ -21,7 +21,13 @@ toc_max_heading_level: 2
 
 # MetaMask Connect EVM methods
 
-MetaMask Connect EVM (`@metamask/connect-evm`) exposes five primary methods: `connect()` to establish a wallet session, `connectAndSign()` to connect and sign a message in one step, `connectWith()` to connect and execute an RPC call atomically, `getProvider()` to obtain the EIP-1193 provider for arbitrary JSON-RPC requests, and `disconnect()` to end the session.
+MetaMask Connect EVM (`@metamask/connect-evm`) exposes five primary methods:
+
+- `connect` to establish a wallet session.
+- `connectAndSign` to connect and sign a message in one step.
+- `connectWith` to connect and execute an RPC call atomically.
+- `getProvider` to obtain the EIP-1193 provider for arbitrary JSON-RPC requests.
+- `disconnect` to end the session.
 
 ## `connect`
 
@@ -170,8 +176,8 @@ await evmClient.switchChain({
 ## `getProvider`
 
 Returns the active EIP-1193 Ethereum provider object.
-The provider is available immediately after `createEVMClient` resolves, even before calling `connect()`.
-Read-only RPC calls work immediately; account-dependent calls require `connect()` first.
+The provider is available immediately after `createEVMClient` resolves, even before calling `connect`.
+Read-only RPC calls work immediately; account-dependent calls require `connect` first.
 
 ### Returns
 
@@ -222,7 +228,7 @@ This only revokes the EVM-specific scopes currently held in the session; it does
 
 :::tip Multichain partial disconnect
 If your dapp also uses Solana via the [multichain client](../../multichain/index.md), calling
-`disconnect()` on the EVM client only revokes EVM (`eip155`) scopes.
+`disconnect` on the EVM client only revokes EVM (`eip155`) scopes.
 Non-EVM scopes remain active, so the user stays connected to Solana.
 :::
 

--- a/metamask-connect/evm/reference/provider-api.md
+++ b/metamask-connect/evm/reference/provider-api.md
@@ -1,7 +1,7 @@
 ---
 title: 'Ethereum Provider API - MetaMask Connect EVM'
 sidebar_label: Ethereum Provider API
-description: Reference for the MetaMask Ethereum provider API (EIP-1193), covering properties, the request() method, and events like accountsChanged and chainChanged.
+description: Reference for the MetaMask Ethereum provider API (EIP-1193), covering properties, the request method, and events like accountsChanged and chainChanged.
 keywords:
   [
     ethereum provider,
@@ -19,7 +19,7 @@ keywords:
 
 # Ethereum provider API
 
-The MetaMask Ethereum provider API follows the EIP-1193 standard and exposes a `request()` method for JSON-RPC calls, properties like `chainId` and `selectedAddress`, and events including `accountsChanged`, `chainChanged`, `connect`, and `disconnect`. MetaMask injects this provider as `window.ethereum`, and MetaMask Connect EVM returns the same interface via `getProvider()`.
+The MetaMask Ethereum provider API follows the EIP-1193 standard and exposes a `request` method for JSON-RPC calls, properties like `chainId` and `selectedAddress`, and events including `accountsChanged`, `chainChanged`, `connect`, and `disconnect`. MetaMask injects this provider as `window.ethereum`, and MetaMask Connect EVM returns the same interface via `getProvider`.
 
 Use the provider [properties](#properties), [methods](#methods), and [events](#events) in your dapp.
 
@@ -33,7 +33,7 @@ We recommend using this mechanism to connect to MetaMask.
 Access the provider API using the selected EIP-6963 provider object.
 Throughout this documentation, we refer to the selected provider using `provider`.
 
-When using MetaMask Connect EVM, you get the same EIP-1193 provider via `client.getProvider()`.
+When using MetaMask Connect EVM, you get the same EIP-1193 provider via `client.getProvider`.
 The provider returned by MetaMask Connect EVM is available immediately after `createEVMClient` resolves
 and supports the same methods, properties, and events documented below.
 :::
@@ -57,7 +57,7 @@ provider.isMetaMask // Or window.ethereum.isMetaMask if you don't support EIP-69
 
 ## Methods
 
-### `isConnected()`
+### `isConnected`
 
 Indicates whether the provider is connected to the current chain.
 If the provider isn't connected, reload the page to re-establish the connection.
@@ -83,7 +83,7 @@ None.
 provider.isConnected() // Or window.ethereum.isConnected() if you don't support EIP-6963.
 ```
 
-### `request()`
+### `request`
 
 This method is used to submit [JSON-RPC API requests](json-rpc-api/index.md) to Ethereum using MetaMask.
 
@@ -102,7 +102,7 @@ If the request fails, the promise rejects with an [error](#errors).
 
 #### Example
 
-The following is an example of using `request()` to call
+The following is an example of using `request` to call
 [`eth_sendTransaction`](json-rpc-api/index.md):
 
 ```javascript
@@ -129,7 +129,7 @@ provider // Or window.ethereum if you don't support EIP-6963.
   })
 ```
 
-### `_metamask.isUnlocked()`
+### `_metamask.isUnlocked`
 
 :::caution
 This method is experimental.
@@ -220,7 +220,7 @@ provider // Or window.ethereum if you don't support EIP-6963.
 The provider emits this event when it's first able to submit RPC requests to a chain.
 When using MetaMask Connect EVM, the `connect` event also includes the `accounts` array.
 We recommend listening to this event and using the
-[`isConnected()`](#isconnected) provider method to determine when
+[`isConnected`](#isconnected) provider method to determine when
 the provider is connected.
 
 ### `disconnect`
@@ -235,7 +235,7 @@ In general, this only happens due to network connectivity issues or some unfores
 
 When the provider emits this event, it doesn't accept new requests until the connection to the chain
 is re-established, which requires reloading the page.
-You can also use the [`isConnected()`](#isconnected) provider method
+You can also use the [`isConnected`](#isconnected) provider method
 to determine if the provider is disconnected.
 
 ### `message`
@@ -324,7 +324,7 @@ interface ProviderRpcError extends Error {
 }
 ```
 
-The [`request()`](#request) provider method throws errors eagerly.
+The [`request`](#request) provider method throws errors eagerly.
 You can use the error `code` property to determine why the request failed.
 Common codes and their meaning include:
 

--- a/metamask-connect/integration-options.md
+++ b/metamask-connect/integration-options.md
@@ -62,7 +62,7 @@ support both ecosystems while keeping familiar provider interfaces for each.
 |                    | Multichain                                           | Single-ecosystem                                                                       | Multi-ecosystem                         |
 | ------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
 | **Package**        | [`connect-multichain`](multichain/index.md) | [`connect-evm`](evm/index.md) or [`connect-solana`](solana/index.md) | Both `connect-evm` and `connect-solana` |
-| **Effort**         | Medium — scope-based API                             | Low — drop-in provider                                                                 | Low — two providers                     |
+| **Effort**         | Medium (scope-based API)                             | Low (drop-in provider)                                                                 | Low (two providers)                     |
 | **EVM support**    | Via `wallet_invokeMethod`                            | EIP-1193 provider                                                                      | EIP-1193 provider                       |
 | **Solana support** | Via `wallet_invokeMethod`                            | Wallet Standard                                                                        | Wallet Standard                         |
 | **Cross-chain UX** | Single prompt for all ecosystems                     | Single ecosystem                                                                       | Separate connect per ecosystem          |
@@ -99,5 +99,5 @@ The migration involves updating your client initialization code and adopting sco
 
 ### Does MetaMask Connect work with wagmi, ethers.js, and viem?
 
-Yes. The EVM client (`@metamask/connect-evm`) provides an EIP-1193 compatible provider that works directly with viem's `custom()` transport, ethers.js `BrowserProvider`, and web3.js `Web3` constructor.
+Yes. The EVM client (`@metamask/connect-evm`) provides an EIP-1193 compatible provider that works directly with viem's `custom` transport, ethers.js `BrowserProvider`, and web3.js `Web3` constructor.
 The Solana client provides a Wallet Standard compatible wallet that works with the Solana Wallet Adapter ecosystem.

--- a/metamask-connect/multichain/guides/send-transactions.md
+++ b/metamask-connect/multichain/guides/send-transactions.md
@@ -7,7 +7,8 @@ keywords: [multichain, evm, solana, transaction, send, invokeMethod, signAndSend
 
 # Send EVM and Solana transactions
 
-This guide shows you how to send transactions on both EVM networks and Solana from a single multichain session — no network switching required.
+This guide shows you how to send transactions on both EVM networks and Solana from a single multichain session.
+No network switching is required.
 
 ## Prerequisites
 
@@ -52,7 +53,7 @@ The multichain client routes EVM methods based on type:
 | **RPC node** | `eth_call`, `eth_getBalance`, `eth_blockNumber`, `eth_getTransactionReceipt`, `eth_estimateGas`, `eth_getCode`, `eth_getLogs` | Infura / custom RPC URL from `supportedNetworks` |
 | **Wallet**   | `eth_sendTransaction`, `personal_sign`, `eth_signTypedData_v4`, `wallet_switchEthereumChain`, `wallet_addEthereumChain`       | MetaMask (extension or mobile)                   |
 
-All Solana methods route through the MetaMask wallet — there is no RPC node fallback for Solana.
+All Solana methods route through the MetaMask wallet. There is no RPC node fallback for Solana.
 
 ## Send an EVM transaction
 
@@ -76,7 +77,7 @@ const txHash = await client.invokeMethod({
 console.log('ETH tx hash:', txHash)
 ```
 
-Target a different chain by changing the `scope` — for example, `eip155:137` for Polygon:
+Target a different chain by changing the `scope`; for example, `eip155:137` for Polygon:
 
 ```javascript
 const txHash = await client.invokeMethod({

--- a/metamask-connect/multichain/guides/sign-transactions.md
+++ b/metamask-connect/multichain/guides/sign-transactions.md
@@ -7,7 +7,8 @@ keywords: [multichain, evm, solana, sign, personal_sign, signTypedData, signMess
 
 # Sign messages on EVM and Solana
 
-This guide shows you how to sign messages and typed data on both EVM networks and Solana from a single multichain session — no network switching required.
+This guide shows you how to sign messages and typed data on both EVM networks and Solana from a single multichain session.
+No network switching is required.
 
 All signing methods route to the MetaMask wallet and require user approval.
 
@@ -63,12 +64,12 @@ const signature = await client.invokeMethod({
 console.log('Signature:', signature)
 ```
 
-Target a different chain by changing the `scope` — for example, `eip155:137` for Polygon.
+Target a different chain by changing the `scope`; for example, `eip155:137` for Polygon.
 
 ## Sign EVM typed data (`eth_signTypedData_v4`)
 
 Use [`eth_signTypedData_v4`](../../evm/reference/json-rpc-api/eth_signTypedData_v4.mdx) to sign [EIP-712](https://eips.ethereum.org/EIPS/eip-712) structured data.
-The params order is `[account, typedDataJSON]` — the typed data must be passed as a JSON string, not an object:
+The params order is `[account, typedDataJSON]`. The typed data must be passed as a JSON string, not an object:
 
 ```javascript
 const typedData = {

--- a/metamask-connect/multichain/index.md
+++ b/metamask-connect/multichain/index.md
@@ -43,7 +43,7 @@ Instead of connecting to one chain at a time, the Multichain API lets you:
 - **Send requests to any chain in the session**: For example, send a Solana transaction and an EVM transaction through the same connection.
 - **Manage the full session lifecycle**: Connect, retrieve session data, invoke methods on any chain, and disconnect using [SDK methods](reference/methods.md) that wrap the underlying [Multichain API](reference/api.md).
 
-For dapps that support both EVM and Solana, this means one session covers both — and users see a single approval prompt.
+For dapps that support both EVM and Solana, this means one session covers both, and users see a single approval prompt.
 
 <p align="center">
     <img height="500" src={require("./_assets/metamask-connect-modal.png").default} alt="MetaMask Connect Multichain Connect Modal" />
@@ -54,10 +54,10 @@ For dapps that support both EVM and Solana, this means one session covers both �
 The multichain client is a good fit when you're:
 
 - **Building a new dapp** designed from the ground up for multiple ecosystems.
-- **Looking for the best cross-chain UX** — one connection prompt for all chains.
+- **Looking for the best cross-chain UX**: one connection prompt for all chains.
 - **Needing full control** over the session lifecycle.
 
-If you're adding MetaMask Connect Multichain to an existing dapp and want minimal code changes, the [ecosystem-specific clients](../integration-options.md) ([`@metamask/connect-evm`](../evm/index.md) or [`@metamask/connect-solana`](../solana/index.md)) are a simpler starting point — you can always migrate later.
+If you're adding MetaMask Connect Multichain to an existing dapp and want minimal code changes, the [ecosystem-specific clients](../integration-options.md) ([`@metamask/connect-evm`](../evm/index.md) or [`@metamask/connect-solana`](../solana/index.md)) are a simpler starting point. You can always migrate later.
 
 ## Get started
 

--- a/metamask-connect/multichain/quickstart/javascript.md
+++ b/metamask-connect/multichain/quickstart/javascript.md
@@ -157,16 +157,16 @@ if (ethAccounts.length > 0) {
 ```
 
 The user sees a single approval prompt for all requested chains.
-Use [`invokeMethod()`](../reference/methods.md#invokemethod) to call RPC methods on any chain in the session by specifying a [scope](../concepts/scopes.md).
+Use [`invokeMethod`](../reference/methods.md#invokemethod) to call RPC methods on any chain in the session by specifying a [scope](../concepts/scopes.md).
 
 ## Multichain client methods at a glance
 
 | Method                                                                     | Description                                                                                  |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [`connect(scopes, caipAccountIds)`](../reference/methods.md#connect)       | Connects to MetaMask with multichain [scopes](../concepts/scopes.md)                         |
-| [`getSession()`](../reference/methods.md#getsession)                       | Returns the current [session](../concepts/sessions.md) with approved accounts |
+| [`getSession`](../reference/methods.md#getsession)                         | Returns the current [session](../concepts/sessions.md) with approved accounts |
 | [`invokeMethod({ scope, request })`](../reference/methods.md#invokemethod) | Calls an RPC method on a specific chain using a [scope](../concepts/scopes.md)               |
-| [`disconnect()`](../reference/methods.md#disconnect)                       | Disconnects all [scopes](../concepts/scopes.md) and ends the session                         |
+| [`disconnect`](../reference/methods.md#disconnect)                         | Disconnects all [scopes](../concepts/scopes.md) and ends the session                         |
 | [`disconnect(scopes)`](../reference/methods.md#disconnect)                 | Disconnects specific [scopes](../concepts/scopes.md) without ending the session              |
 | [`on(event, handler)`](../reference/methods.md#on)                         | Registers an event handler                                                                   |
 | [`off(event, handler)`](../reference/methods.md#off)                       | Removes an event handler                                                                     |

--- a/metamask-connect/multichain/quickstart/nodejs.md
+++ b/metamask-connect/multichain/quickstart/nodejs.md
@@ -69,13 +69,13 @@ const client = await createMultichainClient({
 
 :::info Asynchronous client
 `createMultichainClient` returns a promise. Always `await` it before using the client.
-The client is a **singleton** — calling it again returns the same instance with merged options.
+The client is a **singleton**; calling it again returns the same instance with merged options.
 :::
 
 ### 3. Connect to MetaMask
 
 Register a [`wallet_sessionChanged`](../reference/api.md#wallet_sessionchanged) listener using the [`on`](../reference/methods.md#on) method to capture session data, then connect with both EVM and Solana scopes in a single call.
-A QR code appears in the terminal — scan it with the MetaMask mobile app:
+A QR code appears in the terminal. Scan it with the MetaMask mobile app:
 
 ```javascript
 let session
@@ -179,9 +179,9 @@ client.on('wallet_sessionChanged', session => {
 | Method                                                                           | Description                                                                                   |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | [`connect(scopes, caipAccountIds)`](../reference/methods.md#connect)             | Connects to MetaMask with multichain [scopes](../concepts/scopes.md).                         |
-| [`getSession()`](../reference/methods.md#getsession)                             | Returns the current [session](../concepts/sessions.md) with approved accounts. |
+| [`getSession`](../reference/methods.md#getsession)                               | Returns the current [session](../concepts/sessions.md) with approved accounts. |
 | [`invokeMethod({ scope, request })`](../reference/methods.md#invokemethod)       | Calls an RPC method on a specific chain using a [scope](../concepts/scopes.md).               |
-| [`disconnect()`](../reference/methods.md#disconnect)                             | Disconnects all [scopes](../concepts/scopes.md) and ends the session.                         |
+| [`disconnect`](../reference/methods.md#disconnect)                               | Disconnects all [scopes](../concepts/scopes.md) and ends the session.                         |
 | [`disconnect(scopes)`](../reference/methods.md#disconnect)                       | Disconnects specific [scopes](../concepts/scopes.md) without ending the session.              |
 | [`on(event, handler)`](../reference/methods.md#on)                               | Registers an event handler.                                                                   |
 | [`getInfuraRpcUrls({ infuraApiKey })`](../reference/methods.md#getinfurarpcurls) | Generates Infura RPC URLs keyed by CAIP-2 chain ID.                                           |

--- a/metamask-connect/multichain/quickstart/react-native.md
+++ b/metamask-connect/multichain/quickstart/react-native.md
@@ -222,7 +222,7 @@ you will get `crypto.getRandomValues is not a function`.
 ### 6. Use MetaMask Connect Multichain
 
 Initialize the multichain client and use it to connect to both EVM and Solana networks in a single session.
-`mobile.preferredOpenLink` is **required** — it tells MetaMask Connect how to open deeplinks to the MetaMask
+`mobile.preferredOpenLink` is **required**; it tells MetaMask Connect how to open deeplinks to the MetaMask
 Mobile app:
 
 ```tsx
@@ -452,9 +452,9 @@ npx expo run:ios
 | Method                                                                  | Description                                            |
 | ----------------------------------------------------------------------- | ------------------------------------------------------ |
 | [`connect(scopes, caipAccountIds)`](../reference/methods.md#connect)    | Connects to MetaMask with multichain [scopes](../concepts/scopes.md). |
-| [`getSession()`](../reference/methods.md#getsession)                    | Returns the current session with approved accounts.     |
+| [`getSession`](../reference/methods.md#getsession)                      | Returns the current session with approved accounts.     |
 | [`invokeMethod({ scope, request })`](../reference/methods.md#invokemethod) | Calls an RPC method on a specific chain.             |
-| [`disconnect()`](../reference/methods.md#disconnect)                    | Disconnects all scopes and ends the session.            |
+| [`disconnect`](../reference/methods.md#disconnect)                      | Disconnects all scopes and ends the session.            |
 | [`disconnect(scopes)`](../reference/methods.md#disconnect)              | Disconnects specific scopes without ending the session. |
 | [`on(event, handler)`](../reference/methods.md#on)                     | Registers an event handler.                             |
 

--- a/metamask-connect/multichain/reference/methods.md
+++ b/metamask-connect/multichain/reference/methods.md
@@ -67,7 +67,7 @@ Call this after [`connect`](#connect) to retrieve the accounts the user authoriz
 
 ### Returns
 
-A promise that resolves to the current `Session` object containing `sessionScopes` — a map of CAIP-2 scope IDs to their approved accounts.
+A promise that resolves to the current `Session` object containing `sessionScopes`, a map of CAIP-2 scope IDs to their approved accounts.
 
 ### Example
 
@@ -114,8 +114,8 @@ console.log('ETH balance:', balance)
 Disconnects from MetaMask.
 The behavior depends on whether `scopes` are provided:
 
-- **No arguments** — revokes all scopes and fully tears down the session.
-- **With `scopes`** — revokes only the specified scopes. If other scopes remain, the session stays alive.
+- **No arguments**: revokes all scopes and fully tears down the session.
+- **With `scopes`**: revokes only the specified scopes. If other scopes remain, the session stays alive.
 
 ### Parameters
 

--- a/metamask-connect/multichain/tutorials/create-multichain-dapp.md
+++ b/metamask-connect/multichain/tutorials/create-multichain-dapp.md
@@ -102,16 +102,16 @@ export async function getClient() {
 
 `createMultichainClient` takes two configuration objects:
 
-- **`dapp`** — Your dapp's identity.
+- **`dapp`**: Your dapp's identity.
   MetaMask shows the `name` and `url` during the connection prompt so users know who is requesting
   access.
-- **`api.supportedNetworks`** — A map of [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
+- **`api.supportedNetworks`**: A map of [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
   scope IDs to RPC endpoint URLs.
   Each entry tells the client which chains your dapp supports and where to send RPC requests.
 
 ### 3. Connect (sign-in)
 
-Call `connect()` with the scopes you want.
+Call `connect` with the scopes you want.
 The user sees a single approval prompt for all four chains:
 
 ```typescript
@@ -192,7 +192,7 @@ const lineaBalance = await getEvmBalance(SCOPES.LINEA, lineaAccounts)
 const baseBalance = await getEvmBalance(SCOPES.BASE, baseAccounts)
 ```
 
-The same function works for all three EVM chains — only the `scope` changes.
+The same function works for all three EVM chains; only the `scope` changes.
 
 #### Solana balance
 
@@ -288,7 +288,7 @@ const txHash = await client.invokeMethod({
 console.log('EVM tx hash:', txHash)
 ```
 
-To send on a different chain, change the `scope` — for example, `SCOPES.LINEA` or `SCOPES.BASE`.
+To send on a different chain, change the `scope`; for example, `SCOPES.LINEA` or `SCOPES.BASE`.
 The same address format and RPC method works across all EVM chains.
 
 #### Solana transaction
@@ -580,7 +580,7 @@ export default function App() {
 
 - **Leverage session persistence.**
   Sessions survive page reloads and new tabs.
-  Check for an existing session on startup with `getSession()` before prompting the user to connect
+  Check for an existing session on startup with `getSession` before prompting the user to connect
   again.
 
 - **Show chain context clearly.**

--- a/metamask-connect/solana/guides/send-legacy-transaction.md
+++ b/metamask-connect/solana/guides/send-legacy-transaction.md
@@ -86,7 +86,7 @@ for (const transaction of transactions) {
 
 ## Sign a transaction without sending
 
-Use `solana:signTransaction` when you need a signed transaction but want to submit it yourself — for
+Use `solana:signTransaction` when you need a signed transaction but want to submit it yourself; for
 example, for offline signing or multi-sig workflows.
 
 ```javascript

--- a/metamask-connect/solana/guides/send-versioned-transaction.md
+++ b/metamask-connect/solana/guides/send-versioned-transaction.md
@@ -7,7 +7,7 @@ keywords: [solana, versioned transaction, v0 transaction, address lookup table, 
 
 # Send a versioned transaction
 
-Solana [versioned transactions](https://solana.com/developers/guides/advanced/versions) (`v0`) support [Address Lookup Tables](https://solana.com/developers/guides/advanced/lookup-tables), which let you reference up to 256 addresses in a single transaction — useful for complex operations that would exceed the limits of legacy transactions.
+Solana [versioned transactions](https://solana.com/developers/guides/advanced/versions) (`v0`) support [Address Lookup Tables](https://solana.com/developers/guides/advanced/lookup-tables), which let you reference up to 256 addresses in a single transaction. This is useful for complex operations that would exceed the limits of legacy transactions.
 
 This guide shows you how to create, sign, and send versioned transactions through MetaMask.
 

--- a/metamask-connect/solana/guides/sign-data/sign-message.md
+++ b/metamask-connect/solana/guides/sign-data/sign-message.md
@@ -7,7 +7,7 @@ keywords: [solana sign message, signMessage, wallet-standard, offchain signature
 
 # Sign messages
 
-Your dapp can ask users to sign a message with their Solana account — for example, to verify ownership or authorize an action.
+Your dapp can ask users to sign a message with their Solana account; for example, to verify ownership or authorize an action.
 
 ## Use `signMessage`
 

--- a/metamask-connect/solana/guides/use-wallet-adapter.md
+++ b/metamask-connect/solana/guides/use-wallet-adapter.md
@@ -82,7 +82,8 @@ export const SolanaProvider: FC<SolanaProviderProps> = ({ children }) => {
 };
 ```
 
-Calling [`createSolanaClient()`](../reference/methods.md#createsolanaclient) registers MetaMask with the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) registry, so MetaMask appears as a connection option in the wallet modal — even if the user doesn't have MetaMask installed.
+Calling [`createSolanaClient`](../reference/methods.md#createsolanaclient) registers MetaMask with the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) registry.
+This displays MetaMask as a connection option in the wallet modal, even if the user doesn't have MetaMask installed.
 
 ### 3. Add the provider to your root layout
 

--- a/metamask-connect/solana/quickstart/dynamic.md
+++ b/metamask-connect/solana/quickstart/dynamic.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, Dynamic, SDK, dapp, Wallet SDK, dynamic xyz, solan
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/solana/quickstart/javascript.md
+++ b/metamask-connect/solana/quickstart/javascript.md
@@ -158,9 +158,9 @@ The client handles cross-platform connection (desktop and mobile), including dee
 
 | Method                                                       | Description                                                                                                |
 | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| [`getWallet()`](../reference/methods.md#getwallet)           | Returns a [Wallet Standard](https://github.com/wallet-standard/wallet-standard) compatible wallet instance |
-| [`registerWallet()`](../reference/methods.md#registerwallet) | Registers MetaMask with the Wallet Standard registry (no-op if auto-registered)                            |
-| [`disconnect()`](../reference/methods.md#disconnect)         | Disconnects Solana scopes without terminating the broader multichain session                               |
+| [`getWallet`](../reference/methods.md#getwallet)           | Returns a [Wallet Standard](https://github.com/wallet-standard/wallet-standard) compatible wallet instance |
+| [`registerWallet`](../reference/methods.md#registerwallet) | Registers MetaMask with the Wallet Standard registry (no-op if auto-registered)                            |
+| [`disconnect`](../reference/methods.md#disconnect)         | Disconnects Solana scopes without terminating the broader multichain session                               |
 
 ## Usage example
 

--- a/metamask-connect/solana/quickstart/nodejs.md
+++ b/metamask-connect/solana/quickstart/nodejs.md
@@ -25,10 +25,10 @@ Get started with MetaMask Connect Solana in a Node.js application.
 The SDK displays a QR code in the terminal that you scan with the MetaMask mobile app to establish a connection.
 
 :::info Wallet Standard is browser-only
-[Wallet Standard](https://github.com/wallet-standard/wallet-standard) features (`getWallet()`,
+[Wallet Standard](https://github.com/wallet-standard/wallet-standard) features (`getWallet`,
 `wallet.features[...]`) are designed for browser environments.
-In Node.js, use the multichain core directly via `client.core.connect()` and
-`client.core.invokeMethod()` to interact with Solana.
+In Node.js, use the multichain core directly via `client.core.connect` and
+`client.core.invokeMethod` to interact with Solana.
 :::
 
 ## Prerequisites
@@ -73,14 +73,14 @@ const solanaClient = await createSolanaClient({
 
 :::info Asynchronous client
 [`createSolanaClient`](../reference/methods.md#createsolanaclient) returns a promise. Always `await` it before using the client.
-The client uses a singleton multichain core under the hood — calling it multiple times
+The client uses a singleton multichain core under the hood; calling it multiple times
 returns the same underlying session.
 :::
 
 ### 3. Connect to MetaMask
 
 Register a [`wallet_sessionChanged`](../../multichain/reference/api.md#wallet_sessionchanged) listener to capture session data, then connect with a Solana scope.
-A QR code appears in the terminal — scan it with the MetaMask mobile app:
+A QR code appears in the terminal. Scan it with the MetaMask mobile app:
 
 ```javascript
 let session

--- a/metamask-connect/solana/quickstart/react-native.md
+++ b/metamask-connect/solana/quickstart/react-native.md
@@ -221,7 +221,7 @@ you will get `crypto.getRandomValues is not a function`.
 ### 6. Use MetaMask Connect with Solana
 
 Initialize the multichain client and use `invokeMethod` to interact with Solana.
-`mobile.preferredOpenLink` is **required** — it tells MetaMask Connect how to open deeplinks to the MetaMask
+`mobile.preferredOpenLink` is **required**; it tells MetaMask Connect how to open deeplinks to the MetaMask
 mobile app:
 
 ```tsx

--- a/metamask-connect/solana/quickstart/web3auth.md
+++ b/metamask-connect/solana/quickstart/web3auth.md
@@ -7,9 +7,9 @@ keywords: [connect, MetaMask, Embedded Wallets, SDK, dapp, Wallet SDK, web3auth 
 ---
 
 :::info Heads up
-Looks like you've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
-The MetaMask Connect integration for this library is on its way — once ready, it will be linked
-from the sidebar navigation. In the meantime, this guide is still perfectly valid if you're using
+You've landed on a guide that still uses the MetaMask legacy SDK (`@metamask/sdk`).
+The MetaMask Connect integration for this library is coming soon. Once ready, it will be linked
+from the sidebar navigation. In the meantime, this guide is still valid if you're using
 MetaMask SDK.
 :::
 

--- a/metamask-connect/solana/reference/methods.md
+++ b/metamask-connect/solana/reference/methods.md
@@ -20,7 +20,7 @@ toc_max_heading_level: 2
 
 # MetaMask Connect Solana methods
 
-MetaMask Connect Solana (`@metamask/connect-solana`) provides `createSolanaClient()` to initialize the client, `getInfuraRpcUrls()` to generate Infura RPC endpoints for Solana networks, `getWallet()` to access Wallet Standard features (`signTransaction`, `signAndSendTransaction`, `signMessage`), and automatic Wallet Standard registration for compatibility with the Solana Wallet Adapter ecosystem. The client wraps `@metamask/connect-multichain` and handles wallet discovery and session management automatically.
+MetaMask Connect Solana (`@metamask/connect-solana`) provides `createSolanaClient` to initialize the client, `getInfuraRpcUrls` to generate Infura RPC endpoints for Solana networks, `getWallet` to access Wallet Standard features (`signTransaction`, `signAndSendTransaction`, `signMessage`), and automatic Wallet Standard registration for compatibility with the Solana Wallet Adapter ecosystem. The client wraps `@metamask/connect-multichain` and handles wallet discovery and session management automatically.
 
 ## `createSolanaClient`
 
@@ -44,7 +44,7 @@ Calling `createSolanaClient` multiple times returns the same underlying multicha
 
 :::note
 `createSolanaClient` does not accept `eventHandlers`.
-To listen for lower-level multichain events (such as session changes), use `client.core.on()` after
+To listen for lower-level multichain events (such as session changes), use `client.core.on` after
 creating the client. See the [multichain event methods](/metamask-connect/multichain/reference/methods#on).
 :::
 
@@ -91,7 +91,7 @@ Each chain must be activated in your [Infura dashboard](https://developer.metama
 
 ### Returns
 
-[`SolanaSupportedNetworks`](#solanasupportednetworks) — a map of network names to Infura RPC URLs.
+[`SolanaSupportedNetworks`](#solanasupportednetworks), a map of network names to Infura RPC URLs.
 
 ### Example
 
@@ -198,7 +198,7 @@ console.log('Solana accounts:', solAccounts)
 
 ## Supported Wallet Standard features
 
-The wallet returned by [`getWallet()`](#getwallet) implements the following
+The wallet returned by [`getWallet`](#getwallet) implements the following
 [Wallet Standard](https://github.com/wallet-standard/wallet-standard) features.
 Access them via `wallet.features['<feature>']`.
 
@@ -263,9 +263,9 @@ The object returned by [`createSolanaClient`](#createsolanaclient).
 | Property / Method  | Type                  | Description                                                    |
 | ------------------ | --------------------- | -------------------------------------------------------------- |
 | `core`             | `MultichainCore`      | The underlying MultichainCore instance.                        |
-| `getWallet()`      | `() => Wallet`        | Returns a Wallet Standard compatible MetaMask wallet instance. |
-| `registerWallet()` | `() => Promise<void>` | Registers MetaMask with the Wallet Standard registry.          |
-| `disconnect()`     | `() => Promise<void>` | Disconnects all Solana scopes from MetaMask.                   |
+| `getWallet`        | `() => Wallet`        | Returns a Wallet Standard compatible MetaMask wallet instance. |
+| `registerWallet`   | `() => Promise<void>` | Registers MetaMask with the Wallet Standard registry.          |
+| `disconnect`       | `() => Promise<void>` | Disconnects all Solana scopes from MetaMask.                   |
 
 ## Next steps
 

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/connect-and-sign.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/connect-and-sign.mdx
@@ -1,3 +1,3 @@
 ### Connect and sign (Optional)
 
-Use `client.connectAndSign()` to connect and sign a `personal_sign` message in a single user approval. It returns the signature as a hex string.
+Use `client.connectAndSign` to connect and sign a `personal_sign` message in a single user approval. It returns the signature as a hex string.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/connect-with.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/connect-with.mdx
@@ -1,3 +1,3 @@
 ### Connect and execute an RPC method (Optional)
 
-Use `client.connectWith()` to connect and execute any JSON-RPC method in a single user approval. Pass `params` as a function that receives the connected account, so you can use it as the `from` field.
+Use `client.connectWith` to connect and execute any JSON-RPC method in a single user approval. Pass `params` as a function that receives the connected account, so you can use it as the `from` field.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/disconnect.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/disconnect.mdx
@@ -1,3 +1,3 @@
 ### Disconnect from MetaMask
 
-Use the `client.disconnect()` method to disconnect from MetaMask.
+Use the `client.disconnect` method to disconnect from MetaMask.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/initialization.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/initialization.mdx
@@ -3,6 +3,6 @@
 Initialize MetaMask Connect EVM using `createEVMClient` with these options:
 
 - `dapp` - Displays your dapp's name, URL, and icon URL during connection.
-- `api.supportedNetworks` - Maps chain IDs to RPC URLs. Use `getInfuraRpcUrls()` to generate URLs for all Infura-supported chains.
+- `api.supportedNetworks` - Maps chain IDs to RPC URLs. Use `getInfuraRpcUrls` to generate URLs for all Infura-supported chains.
 
-`createEVMClient` is async and returns a singleton — calling it again returns the same instance.
+`createEVMClient` is async and returns a singleton; calling it again returns the same instance.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/provider.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/provider.mdx
@@ -1,7 +1,7 @@
 ### Use the provider
 
-Use `client.getProvider()` to get the provider object for RPC requests.
+Use `client.getProvider` to get the provider object for RPC requests.
 
-Use `provider.request()` for arbitrary [JSON-RPC requests](/metamask-connect/evm/reference/json-rpc-api) like
+Use `provider.request` for arbitrary [JSON-RPC requests](/metamask-connect/evm/reference/json-rpc-api) like
 `eth_chainId` or `eth_getBalance`, or for [batching requests](/metamask-connect/evm/guides/metamask-exclusive/batch-requests) via
 `metamask_batch`.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/reactQuickStart.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/reactQuickStart.mdx
@@ -1,9 +1,9 @@
 ### MetaMask Connect - React quickstart
 
 This quickstart shows you how to connect a React application to the MetaMask wallet using
-MetaMask Connect package.
+the MetaMask Connect EVM package.
 
-Clone the React quickstart application.
+Clone the React quickstart application to follow along with a complete example:
 
 ```shell
 npx degit MetaMask/metamask-connect-examples/quickstarts/evm/react mm-react-quickstart

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/send-transaction.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/send-transaction.mdx
@@ -1,3 +1,3 @@
 ### Send a transaction
 
-Use `provider.request()` with [`eth_sendTransaction`](/metamask-connect/evm/reference/json-rpc-api/eth_sendTransaction) to send a transaction. The provider prompts MetaMask for user approval and returns the transaction hash.
+Use `provider.request` with [`eth_sendTransaction`](/metamask-connect/evm/reference/json-rpc-api/eth_sendTransaction) to send a transaction. The provider prompts MetaMask for user approval and returns the transaction hash.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/sign-message.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/sign-message.mdx
@@ -1,3 +1,3 @@
 ### Sign a message
 
-Use `provider.request()` with [`personal_sign`](/metamask-connect/evm/guides/sign-data) to request a cryptographic signature from the user. MetaMask displays the message for user approval and returns the signature.
+Use `provider.request` with [`personal_sign`](/metamask-connect/evm/guides/sign-data) to request a cryptographic signature from the user. MetaMask displays the message for user approval and returns the signature.

--- a/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/switch-chain.mdx
+++ b/src/pages/quickstart/builder/metamask-connect/evm-react/stepContent/switch-chain.mdx
@@ -1,3 +1,3 @@
 ### Switch chain
 
-Use `client.switchChain()` to switch the active chain. If the chain is not already added to MetaMask, pass `chainConfiguration` to trigger a `wallet_addEthereumChain` fallback.
+Use `client.switchChain` to switch the active chain. If the chain is not already added to MetaMask, pass `chainConfiguration` to trigger a `wallet_addEthereumChain` fallback.


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Apply minor fixes across the MM Connect docs for consistency:

- Omit `()` when referring to methods for simplicity. This follows Google developer docs style. Update Cursor rules accordingly.
- Avoid using em or en dashes in prose. Rephrase sentences if needed.

Also minor update to quickstart intro.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://metamask-docs-r6ed800lc-consensys-ddffed67.vercel.app/metamask-connect

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that standardize method naming and punctuation; main risk is minor confusion if any reference now reads differently than expected.
> 
> **Overview**
> **Docs style cleanup across MetaMask Connect (EVM, Multichain, Solana).** Updates prose and tables to omit trailing `()` when referring to methods (while keeping parentheses when showing parameters), and adds a corresponding rule to `.cursor/rules/product-metamask-connect.mdc`.
> 
> Also rephrases various sentences to avoid em/en dashes and improve readability, plus a small tweak to the React quickstart intro wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1333f7397e034e505f918906356e944ab2088b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->