### PR TITLE
remove FIN AI

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@docusaurus/remark-plugin-npm2yarn": "3.9.2",
     "@docusaurus/theme-common": "3.9.2",
     "@docusaurus/theme-mermaid": "3.9.2",
-    "@intercom/messenger-js-sdk": "^0.0.14",
     "@lottiefiles/react-lottie-player": "^3.6.0",
     "@mdx-js/react": "^3.1.0",
     "@mermaid-js/layout-elk": "^0.1.9",

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import Footer from '@theme-original/Footer'
-import { Intercom } from '@intercom/messenger-js-sdk'
-import useIsBrowser from '@docusaurus/useIsBrowser'
 
 export default function FooterWrapper(props) {
   const [canShowFooter, setCanShowFooter] = useState(true)
@@ -21,21 +19,12 @@ export default function FooterWrapper(props) {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      // check if footer can be shown
       const path = window.location.pathname
       if (path.includes('quickstart')) {
         setCanShowFooter(false)
       }
     }
   }, [])
-
-  const isBrowser = useIsBrowser()
-  const isProd = process.env.NODE_ENV === 'production'
-  if (isBrowser && isProd) {
-    Intercom({
-      app_id: 'txttgas6',
-    })
-  }
 
   if (!canShowFooter) return null
 


### PR DESCRIPTION
# Description

Removes the Intercom Fin AI chat widget, which is trained on support content and not relevant to the developer documentation site. Its answers are more likely to confuse users.

<!-- Complete the following checklist before merging your PR. -->

- [x] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [x] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a third-party chat widget and its dependency, with minimal impact beyond eliminating the production-only client-side initialization.
> 
> **Overview**
> Removes the Intercom (Fin AI) chat widget from the docs site by deleting the `@intercom/messenger-js-sdk` dependency and stripping the production/browser-only `Intercom({ app_id: ... })` initialization from `src/theme/Footer/index.js`.
> 
> Footer behavior otherwise remains the same (including the cookie-management handler and quickstart footer hiding), just without loading the Intercom script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d33fb369c2499f3ed0c8bda3a578450a3553d84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->