### PR TITLE
[Smart Accounts Kit] Update Tutorials

### DIFF
--- a/gator_versioned_docs/version-0.2.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-0.2.0/guides/delegation/check-delegation-state.md
@@ -69,7 +69,7 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 <TabItem value="example.ts">
 
 ```typescript
-import { delegation } './config.ts'
+import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
 const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({

--- a/gator_versioned_docs/version-0.2.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-0.2.0/guides/delegation/check-delegation-state.md
@@ -72,9 +72,10 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
-const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
-  delegation,
-})
+const { availableAmount } =
+  await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
+    delegation,
+  })
 ```
 
 </TabItem>

--- a/gator_versioned_docs/version-0.2.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-0.2.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -136,21 +136,21 @@ Before creating a delegation, ensure that the delegator account (in this example
 :::
 
 ```typescript
-import { createDelegation } from "@metamask/smart-accounts-kit"
-import { parseUnits } from "viem"
+import { createDelegation } from '@metamask/smart-accounts-kit'
+import { parseUnits } from 'viem'
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
   environment: delegatorSmartAccount.environment,
   scope: {
-    type: "erc20TransferAmount",
+    type: 'erc20TransferAmount',
     tokenAddress,
     // 10 USDC
-    maxAmount: parseUnits("10", 6),
+    maxAmount: parseUnits('10', 6),
   },
 })
 ```

--- a/gator_versioned_docs/version-0.2.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-0.2.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -145,7 +145,7 @@ const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
-  environment: delegatorSmartAccount.environment
+  environment: delegatorSmartAccount.environment,
   scope: {
     type: "erc20TransferAmount",
     tokenAddress,

--- a/gator_versioned_docs/version-0.3.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-0.3.0/guides/delegation/check-delegation-state.md
@@ -69,7 +69,7 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 <TabItem value="example.ts">
 
 ```typescript
-import { delegation } './config.ts'
+import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
 const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({

--- a/gator_versioned_docs/version-0.3.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-0.3.0/guides/delegation/check-delegation-state.md
@@ -72,9 +72,10 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
-const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
-  delegation,
-})
+const { availableAmount } =
+  await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
+    delegation,
+  })
 ```
 
 </TabItem>

--- a/gator_versioned_docs/version-0.3.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-0.3.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -136,21 +136,21 @@ Before creating a delegation, ensure that the delegator account (in this example
 :::
 
 ```typescript
-import { createDelegation } from "@metamask/smart-accounts-kit"
-import { parseUnits } from "viem"
+import { createDelegation } from '@metamask/smart-accounts-kit'
+import { parseUnits } from 'viem'
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
   environment: delegatorSmartAccount.environment,
   scope: {
-    type: "erc20TransferAmount",
+    type: 'erc20TransferAmount',
     tokenAddress,
     // 10 USDC
-    maxAmount: parseUnits("10", 6),
+    maxAmount: parseUnits('10', 6),
   },
 })
 ```

--- a/gator_versioned_docs/version-0.3.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-0.3.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -145,7 +145,7 @@ const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
-  environment: delegatorSmartAccount.environment
+  environment: delegatorSmartAccount.environment,
   scope: {
     type: "erc20TransferAmount",
     tokenAddress,

--- a/gator_versioned_docs/version-1.0.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-1.0.0/guides/delegation/check-delegation-state.md
@@ -69,7 +69,7 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 <TabItem value="example.ts">
 
 ```typescript
-import { delegation } './config.ts'
+import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
 const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({

--- a/gator_versioned_docs/version-1.0.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-1.0.0/guides/delegation/check-delegation-state.md
@@ -72,9 +72,10 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
-const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
-  delegation,
-})
+const { availableAmount } =
+  await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
+    delegation,
+  })
 ```
 
 </TabItem>

--- a/gator_versioned_docs/version-1.0.0/guides/delegation/create-redelegation.md
+++ b/gator_versioned_docs/version-1.0.0/guides/delegation/create-redelegation.md
@@ -162,8 +162,8 @@ const caveatBuilder = createCaveatBuilder(bobSmartAccount.environment)
 const caveats = caveatBuilder.addCaveat(CaveatType.LimitedCalls, { limit: 1 })
 
 const redelegation: Delegation = {
-  delegate: bobSmartAccount.address,
-  delegator: carolSmartAccount.address,
+  delegate: carolSmartAccount.address,
+  delegator: bobSmartAccount.address,
   authority: hashDelegation(rootDelegation),
   caveats: caveats.build(),
   salt: '0x',

--- a/gator_versioned_docs/version-1.0.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-1.0.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -145,7 +145,7 @@ const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
-  environment: delegatorSmartAccount.environment
+  environment: delegatorSmartAccount.environment,
   scope: {
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,

--- a/gator_versioned_docs/version-1.0.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-1.0.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -136,11 +136,11 @@ Before creating a delegation, ensure that the delegator account (in this example
 :::
 
 ```typescript
-import { createDelegation, ScopeType } from "@metamask/smart-accounts-kit"
-import { parseUnits } from "viem"
+import { createDelegation, ScopeType } from '@metamask/smart-accounts-kit'
+import { parseUnits } from 'viem'
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
@@ -150,7 +150,7 @@ const delegation = createDelegation({
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,
     // 10 USDC
-    maxAmount: parseUnits("10", 6),
+    maxAmount: parseUnits('10', 6),
   },
 })
 ```

--- a/gator_versioned_docs/version-1.1.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-1.1.0/guides/delegation/check-delegation-state.md
@@ -69,7 +69,7 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 <TabItem value="example.ts">
 
 ```typescript
-import { delegation } './config.ts'
+import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
 const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({

--- a/gator_versioned_docs/version-1.1.0/guides/delegation/check-delegation-state.md
+++ b/gator_versioned_docs/version-1.1.0/guides/delegation/check-delegation-state.md
@@ -72,9 +72,10 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
-const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
-  delegation,
-})
+const { availableAmount } =
+  await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
+    delegation,
+  })
 ```
 
 </TabItem>

--- a/gator_versioned_docs/version-1.1.0/guides/delegation/create-redelegation.md
+++ b/gator_versioned_docs/version-1.1.0/guides/delegation/create-redelegation.md
@@ -162,8 +162,8 @@ const caveatBuilder = createCaveatBuilder(bobSmartAccount.environment)
 const caveats = caveatBuilder.addCaveat(CaveatType.LimitedCalls, { limit: 1 })
 
 const redelegation: Delegation = {
-  delegate: bobSmartAccount.address,
-  delegator: carolSmartAccount.address,
+  delegate: carolSmartAccount.address,
+  delegator: bobSmartAccount.address,
   authority: hashDelegation(rootDelegation),
   caveats: caveats.build(),
   salt: '0x',

--- a/gator_versioned_docs/version-1.1.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-1.1.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -145,7 +145,7 @@ const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
-  environment: delegatorSmartAccount.environment
+  environment: delegatorSmartAccount.environment,
   scope: {
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,

--- a/gator_versioned_docs/version-1.1.0/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/gator_versioned_docs/version-1.1.0/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -136,11 +136,11 @@ Before creating a delegation, ensure that the delegator account (in this example
 :::
 
 ```typescript
-import { createDelegation, ScopeType } from "@metamask/smart-accounts-kit"
-import { parseUnits } from "viem"
+import { createDelegation, ScopeType } from '@metamask/smart-accounts-kit'
+import { parseUnits } from 'viem'
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
@@ -150,7 +150,7 @@ const delegation = createDelegation({
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,
     // 10 USDC
-    maxAmount: parseUnits("10", 6),
+    maxAmount: parseUnits('10', 6),
   },
 })
 ```

--- a/smart-accounts-kit/guides/delegation/check-delegation-state.md
+++ b/smart-accounts-kit/guides/delegation/check-delegation-state.md
@@ -70,7 +70,7 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 <TabItem value="example.ts">
 
 ```typescript
-import { delegation } './config.ts'
+import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
 const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({

--- a/smart-accounts-kit/guides/delegation/check-delegation-state.md
+++ b/smart-accounts-kit/guides/delegation/check-delegation-state.md
@@ -73,9 +73,10 @@ This example uses the [`getErc20PeriodTransferEnforcerAvailableAmount`](../../re
 import { delegation } from './config.ts'
 
 // Returns the available amount for current period.
-const { availableAmount } = await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
-  delegation,
-})
+const { availableAmount } =
+  await caveatEnforcerClient.getErc20PeriodTransferEnforcerAvailableAmount({
+    delegation,
+  })
 ```
 
 </TabItem>

--- a/smart-accounts-kit/guides/delegation/create-redelegation.md
+++ b/smart-accounts-kit/guides/delegation/create-redelegation.md
@@ -163,8 +163,8 @@ const caveatBuilder = createCaveatBuilder(bobSmartAccount.environment)
 const caveats = caveatBuilder.addCaveat(CaveatType.LimitedCalls, { limit: 1 })
 
 const redelegation: Delegation = {
-  delegate: bobSmartAccount.address,
-  delegator: carolSmartAccount.address,
+  delegate: carolSmartAccount.address,
+  delegator: bobSmartAccount.address,
   authority: hashDelegation(rootDelegation),
   caveats: caveats.build(),
   salt: '0x',

--- a/smart-accounts-kit/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/smart-accounts-kit/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -137,11 +137,11 @@ Before creating a delegation, ensure that the delegator account (in this example
 :::
 
 ```typescript
-import { createDelegation, ScopeType } from "@metamask/smart-accounts-kit"
-import { parseUnits } from "viem"
+import { createDelegation, ScopeType } from '@metamask/smart-accounts-kit'
+import { parseUnits } from 'viem'
 
 // USDC address on Ethereum Sepolia.
-const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+const tokenAddress = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'
 
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
@@ -151,7 +151,7 @@ const delegation = createDelegation({
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,
     // 10 USDC
-    maxAmount: parseUnits("10", 6),
+    maxAmount: parseUnits('10', 6),
   },
 })
 ```

--- a/smart-accounts-kit/guides/delegation/execute-on-smart-accounts-behalf.md
+++ b/smart-accounts-kit/guides/delegation/execute-on-smart-accounts-behalf.md
@@ -146,7 +146,7 @@ const tokenAddress = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 const delegation = createDelegation({
   to: delegateSmartAccount.address, // This example uses a delegate smart account
   from: delegatorSmartAccount.address,
-  environment: delegatorSmartAccount.environment
+  environment: delegatorSmartAccount.environment,
   scope: {
     type: ScopeType.Erc20TransferAmount,
     tokenAddress,

--- a/src/pages/tutorials/create-custom-caveat-enforcer.md
+++ b/src/pages/tutorials/create-custom-caveat-enforcer.md
@@ -136,7 +136,7 @@ const currentTime = Math.floor(Date.now() / 1000)
 // Add an hour to the currentTime
 const validTimestamp = currentTime + 3600
 
-const caveats = caveatBuilder.addCaveat('nativeTokenTransferAmount', parseEther('0.01')).addCaveat({
+const caveats = caveatBuilder.addCaveat('nativeTokenTransferAmount', { maxAmount: parseEther('0.01') }).addCaveat({
   enforcer: afterTimestampEnforcer,
   terms: toHex(validTimestamp),
 })
@@ -156,6 +156,7 @@ const delegation: Delegation = {
 
 ```typescript
 import { createPublicClient, http } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { sepolia as chain } from 'viem/chains'
 import { Implementation, toMetaMaskSmartAccount } from '@metamask/smart-accounts-kit'
 

--- a/src/pages/tutorials/create-custom-caveat-enforcer.md
+++ b/src/pages/tutorials/create-custom-caveat-enforcer.md
@@ -136,10 +136,12 @@ const currentTime = Math.floor(Date.now() / 1000)
 // Add an hour to the currentTime
 const validTimestamp = currentTime + 3600
 
-const caveats = caveatBuilder.addCaveat('nativeTokenTransferAmount', { maxAmount: parseEther('0.01') }).addCaveat({
-  enforcer: afterTimestampEnforcer,
-  terms: toHex(validTimestamp),
-})
+const caveats = caveatBuilder
+  .addCaveat('nativeTokenTransferAmount', { maxAmount: parseEther('0.01') })
+  .addCaveat({
+    enforcer: afterTimestampEnforcer,
+    terms: toHex(validTimestamp),
+  })
 
 const delegation: Delegation = {
   delegate: 'DELEGATE_ADDRESS',

--- a/src/pages/tutorials/create-invite-link.md
+++ b/src/pages/tutorials/create-invite-link.md
@@ -191,7 +191,7 @@ A root delegation is the first delegation in a chain of delegations, and an open
 In this example, the inviter creates an invitation that can be redeemed by any invitee, allowing the invitee to spend up to 0.001 ETH.
 
 ```ts
-import { createOpenDelegation } from '@metamask/smart-accounts-kit';
+import { createOpenDelegation } from '@metamask/smart-accounts-kit'
 
 const delegation = createOpenDelegation({
   from: smartAccount.address,
@@ -201,7 +201,7 @@ const delegation = createOpenDelegation({
     // 0.001 ETH in wei format.
     maxAmount: 1000000000000000n,
   },
-});
+})
 ```
 
 #### 4.4. Sign the delegation

--- a/src/pages/tutorials/create-invite-link.md
+++ b/src/pages/tutorials/create-invite-link.md
@@ -140,9 +140,9 @@ This example uses a [Hybrid smart account](/smart-accounts-kit/guides/smart-acco
 
 ```tsx
 import { Implementation, toMetaMaskSmartAccount } from '@metamask/smart-accounts-kit'
-import { useAccount, usePublicClient, useWalletClient } from 'wagmi'
+import { useConnection, usePublicClient, useWalletClient } from 'wagmi'
 
-const { address } = useAccount()
+const { address } = useConnection()
 const publicClient = usePublicClient()
 const { data: walletClient } = useWalletClient()
 
@@ -195,7 +195,7 @@ import { createOpenDelegation } from '@metamask/smart-accounts-kit';
 
 const delegation = createOpenDelegation({
   from: smartAccount.address,
-  environment: smartAccount.environment;
+  environment: smartAccount.environment,
   scope: {
     type: 'nativeTokenTransferAmount',
     // 0.001 ETH in wei format.
@@ -278,7 +278,7 @@ import { DelegationManager } from '@metamask/smart-accounts-kit/contracts'
 
 const delegations = [decodedDelegation]
 
-const executions = [createExecution(smartAccount.address, 1000000000000000n)]
+const executions = [createExecution({ target: smartAccount.address, value: 1000000000000000n })]
 
 const redeemDelegationCalldata = DelegationManager.encode.redeemDelegations({
   delegations: [delegations],

--- a/src/pages/tutorials/use-erc20-paymaster.md
+++ b/src/pages/tutorials/use-erc20-paymaster.md
@@ -134,6 +134,8 @@ Batch the approve call with other onchain actions you want to perform using the 
 Pass the `paymasterClient` from [Step 3](#3-set-up-a-paymaster-client) to the `paymaster` property.
 
 ```typescript
+import { parseAbi, parseEther } from 'viem'
+
 // Appropriate fee per gas must be determined for the bundler being used.
 const maxFeePerGas = 1n;
 const maxPriorityFeePerGas = 1n;
@@ -150,10 +152,10 @@ const userOperationHash = await bundlerClient.sendUserOperation({
     {
       // USDC token address
       to: token,
-      abi: parseAbi(["function approve(address,uint)"]),
+      abi: parseAbi(['function approve(address,uint)']),
       functionName: "approve",
       args: [pimlicoPaymasterAddress, approvalAmount],
-    }
+    },
     // Batch the approve call with other onchain actions.
     {
       to: "0x1234567890123456789012345678901234567890",

--- a/src/pages/tutorials/use-erc20-paymaster.md
+++ b/src/pages/tutorials/use-erc20-paymaster.md
@@ -137,13 +137,13 @@ Pass the `paymasterClient` from [Step 3](#3-set-up-a-paymaster-client) to the `p
 import { parseAbi, parseEther } from 'viem'
 
 // Appropriate fee per gas must be determined for the bundler being used.
-const maxFeePerGas = 1n;
-const maxPriorityFeePerGas = 1n;
+const maxFeePerGas = 1n
+const maxPriorityFeePerGas = 1n
 
-const pimlicoPaymasterAddress = "0x777777777777AeC03fd955926DbF81597e66834C";
+const pimlicoPaymasterAddress = '0x777777777777AeC03fd955926DbF81597e66834C'
 
 // 10 USDC in wei format. Since USDC has 6 decimals, the wei value is 10 * 10^6.
-const approvalAmount = 10000000n;
+const approvalAmount = 10000000n
 
 const userOperationHash = await bundlerClient.sendUserOperation({
   account: smartAccount,
@@ -153,19 +153,19 @@ const userOperationHash = await bundlerClient.sendUserOperation({
       // USDC token address
       to: token,
       abi: parseAbi(['function approve(address,uint)']),
-      functionName: "approve",
+      functionName: 'approve',
       args: [pimlicoPaymasterAddress, approvalAmount],
     },
     // Batch the approve call with other onchain actions.
     {
-      to: "0x1234567890123456789012345678901234567890",
-      value: parseEther("1"),
+      to: '0x1234567890123456789012345678901234567890',
+      value: parseEther('1'),
     },
   ],
   maxFeePerGas,
   maxPriorityFeePerGas,
   paymaster: paymasterClient,
-});
+})
 ```
 
 ## Next steps


### PR DESCRIPTION
# Description

- Update tutorials to v1.0.0 breaking changes, along with Wagmi v3.
- Fix code snippets in guides

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docs-only changes, but they update code snippets for delegation creation/redeeming and redelegation roles; incorrect examples could mislead integrators and break implementations.
> 
> **Overview**
> Updates Smart Accounts Kit delegation guides/tutorials across multiple versioned docs to match newer SDK usage and formatting (fixes broken imports, scope/type literals, and updates `createExecution`/`createCaveatBuilder.addCaveat` call signatures).
> 
> Corrects the redelegation example to swap `delegate`/`delegator` addresses, and updates tutorials for Wagmi v3 usage (switches `useAccount` to `useConnection` and related snippet adjustments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc4fc7b6ced90adf3f451b3cf2a3c5da3115b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->