### PR TITLE
Guard Osano script injection to production builds

### DIFF
--- a/src/plugins/osano.ts
+++ b/src/plugins/osano.ts
@@ -2,6 +2,11 @@ const OsanoPlugin = () => {
   return {
     name: 'docusaurus-plugin-osano',
     injectHtmlTags() {
+      // Prevent Osano from running in Vercel preview/dev builds where it can block React hydration.
+      if (process.env.VERCEL_ENV !== 'production') {
+        return {}
+      }
+
       return {
         headTags: [
           {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Restricts the Osano CMP script injection to production Vercel builds only, so preview and development deployments do not load the synchronous Osano script that can block React hydration.

## Issue(s) fixed

Fixes #2850

## Preview

N/A (configuration/plugin change)

## Checklist

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-468d2a02-66e1-52a2-9c75-d8c84b818cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-468d2a02-66e1-52a2-9c75-d8c84b818cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

