### PR TITLE
Docs: add headless mode and Solana batch guides

### DIFF
--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -267,7 +267,11 @@ provider.on('disconnect', () => {
 })
 ```
 
-MetaMask Connect EVM also supports SDK-level event handlers that you register during initialization:
+MetaMask Connect EVM also supports SDK-level event handlers that you register during initialization.
+The `connect` handler receives both `chainId` and `accounts` (a MetaMask Connect extension of the
+standard EIP-1193 `connect` event, which only includes `chainId`).
+See the [Ethereum provider API events](../reference/provider-api.md#events) for the full event
+reference.
 
 ```typescript
 const client = await createEVMClient({
@@ -291,7 +295,13 @@ const client = await createEVMClient({
 })
 ```
 
-You can also listen for the `display_uri` event on the **provider** for custom QR code UI:
+You can also listen for the `display_uri` event on the **provider** for custom QR code UI.
+
+:::note Event naming
+The `eventHandlers` option uses camelCase (`displayUri`), while the provider event uses snake_case
+(`display_uri`).
+Both deliver the same URI string for QR code rendering.
+:::
 
 ```typescript
 const provider = client.getProvider()

--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -92,7 +92,7 @@ recreate it on every render.
 // remove-start
 - const sdk = new MetaMaskSDK({
 -  dappMetadata: {
--    name: 'My DApp',
+-    name: 'My Dapp',
 -    url: window.location.href,
 -  },
 -   infuraAPIKey: 'YOUR_INFURA_KEY',
@@ -113,7 +113,7 @@ recreate it on every render.
 // add-start
 + const client = await createEVMClient({
 +  dapp: {
-+    name: 'My DApp',
++    name: 'My Dapp',
 +    url: window.location.href,
 +  },
 +  api: {
@@ -195,7 +195,7 @@ The method returns the signature directly:
 
 ```typescript
 const signature = await client.connectAndSign({
-  message: 'Sign in to My DApp',
+  message: 'Sign in to My Dapp',
   chainIds: ['0x1'],
 })
 ```
@@ -275,7 +275,7 @@ reference.
 
 ```typescript
 const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
+  dapp: { name: 'My Dapp' },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_KEY',
@@ -335,7 +335,7 @@ straightforward:
 import { createMultichainClient } from '@metamask/connect-multichain'
 
 const multichainClient = await createMultichainClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       'eip155:1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -402,7 +402,7 @@ export function EVMProvider({ children }: { children: React.ReactNode }) {
     if (initialized.current) return
     initialized.current = true
     createEVMClient({
-      dapp: { name: 'My DApp', url: window.location.href },
+      dapp: { name: 'My Dapp', url: window.location.href },
       api: { supportedNetworks: getInfuraRpcUrls({ infuraApiKey: 'YOUR_INFURA_API_KEY' }) },
     }).then(setClient)
   }, [])

--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -298,7 +298,7 @@ const client = await createEVMClient({
 You can also listen for the `display_uri` event on the **provider** for custom QR code UI.
 
 :::note Event naming
-The `eventHandlers` option uses camelCase (`displayUri`), while the provider event uses snake_case
+The `eventHandlers` option uses camel case (`displayUri`), while the provider event uses snake case
 (`display_uri`).
 Both deliver the same URI string for QR code rendering.
 :::

--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -318,7 +318,7 @@ MetaMask Connect EVM introduces features that are not available in `@metamask/sd
 | ---------------------- | ---------------------------------------------------------------------------------------------------------- |
 | **Multichain client**  | `createMultichainClient` from `@metamask/connect-multichain` supports CAIP-25 scopes across EVM and Solana |
 | **`invokeMethod`**     | Call RPC methods on specific CAIP-2 scopes without switching chains                                        |
-| **Solana support**     | `createSolanaClient` from `@metamask/connect-solana` with wallet-standard adapter                          |
+| **Solana support**     | `createSolanaClient` from `@metamask/connect-solana` with Wallet Standard adapter                          |
 | **`connectAndSign`**   | Connect and sign a message in a single user approval                                                       |
 | **`connectWith`**      | Connect and execute any RPC method in a single user approval                                               |
 | **Partial disconnect** | `disconnect(scopes)` revokes specific CAIP scopes while keeping others active                              |

--- a/metamask-connect/evm/guides/sign-data/index.md
+++ b/metamask-connect/evm/guides/sign-data/index.md
@@ -195,7 +195,7 @@ import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -284,7 +284,7 @@ import { ethers } from 'ethers'
 import { BrowserProvider, parseUnits } from 'ethers'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -377,7 +377,7 @@ import { createEVMClient } from '@metamask/connect-evm'
 import { Web3 } from 'web3'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -545,7 +545,7 @@ import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -574,7 +574,7 @@ import { createEVMClient } from '@metamask/connect-evm'
 import { ethers } from 'ethers'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
@@ -599,7 +599,7 @@ import { createEVMClient } from '@metamask/connect-evm'
 import { Web3 } from 'web3'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       '0x1': 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',

--- a/metamask-connect/evm/quickstart/javascript.md
+++ b/metamask-connect/evm/quickstart/javascript.md
@@ -154,6 +154,8 @@ const evmClient = await createEVMClient({
 These examples configure MetaMask Connect EVM with the following options:
 
 - `dapp` - Ensures trust by showing your dapp's `name`, `url`, and `iconUrl` during connection.
+  Use `base64Icon` instead of `iconUrl` when a hosted URL is unavailable (for example, in React
+  Native).
 - `api.supportedNetworks` - A map of hex chain IDs to RPC URLs for all networks supported by the app.
   Use the [`getInfuraRpcUrls`](../reference/methods.md#getinfurarpcurls) helper to generate URLs for all Infura-supported chains, or specify your own.
 

--- a/metamask-connect/evm/quickstart/react-native.md
+++ b/metamask-connect/evm/quickstart/react-native.md
@@ -256,7 +256,7 @@ function getClient() {
   if (!clientPromise) {
     clientPromise = createEVMClient({
       dapp: {
-        name: 'My RN DApp',
+        name: 'My RN Dapp',
         url: 'https://mydapp.com',
       },
       api: {

--- a/metamask-connect/evm/reference/methods.md
+++ b/metamask-connect/evm/reference/methods.md
@@ -87,7 +87,7 @@ eventHandlers: {
 
 ```javascript
 const signature = await evmClient.connectAndSign({
-  message: 'Sign in to My DApp',
+  message: 'Sign in to My Dapp',
   chainIds: ['0x1'],
 })
 console.log('Signature:', signature)
@@ -264,7 +264,7 @@ A `Record<string, string>` mapping hex chain IDs to Infura RPC URLs. When `chain
 import { createEVMClient, getInfuraRpcUrls } from '@metamask/connect-evm'
 
 const evmClient = await createEVMClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   api: {
     supportedNetworks: {
       // Each chain must be active in your Infura dashboard

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -40,7 +40,7 @@ import { createMultichainClient, getInfuraRpcUrls } from '@metamask/connect-mult
 
 const client = await createMultichainClient({
   dapp: {
-    name: 'My DApp',
+    name: 'My Dapp',
     url: window.location.href,
   },
   api: {

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -98,11 +98,11 @@ When the MetaMask browser extension is installed and `ui.preferExtension` is `tr
 the SDK connects directly through the extension.
 No `display_uri` event fires because no QR code is needed.
 
-To force the MWP/QR flow even when the extension is available, set `ui.preferExtension` to `false`:
+To display the QR connection option even when the extension is available, set `ui.preferExtension` to `false`:
 
 ```javascript
 const client = await createMultichainClient({
-  dapp: { name: 'My DApp', url: window.location.href },
+  dapp: { name: 'My Dapp', url: window.location.href },
   ui: {
     headless: true,
     preferExtension: false,

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -112,7 +112,7 @@ const client = await createMultichainClient({
 
 ### Monitor connection status
 
-Use the `stateChanged` event to track the connection lifecycle and update your UI accordingly:
+Use the [`stateChanged`](../reference/methods.md#events) event to track the connection lifecycle and update your UI accordingly:
 
 ```javascript
 client.on('stateChanged', status => {

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -55,7 +55,7 @@ const client = await createMultichainClient({
 ### 2. Register a `display_uri` listener before connecting
 
 The `display_uri` event fires during the connecting phase with a one-time-use pairing URI.
-You **must** register the listener before calling `connect()`, or you may miss the event:
+You **must** register the listener before calling `connect`, or you may miss the event:
 
 ```javascript
 client.on('display_uri', uri => {

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -1,0 +1,139 @@
+---
+title: 'Use Headless Mode - MetaMask Connect Multichain'
+sidebar_label: Use headless mode
+description: Render a custom QR code or connection UI by using headless mode with MetaMask Connect Multichain.
+keywords:
+  [
+    headless,
+    QR code,
+    custom UI,
+    display_uri,
+    multichain,
+    MetaMask,
+    Connect,
+    connection,
+    modal,
+    deeplink,
+  ]
+---
+
+# Use headless mode
+
+By default, MetaMask Connect renders its own QR code modal when connecting to MetaMask Mobile
+via MetaMask Wallet Protocol (MWP).
+Headless mode suppresses this built-in modal so you can render your own connection UI.
+
+Use headless mode when you want to:
+
+- Display a custom-styled QR code that matches your dapp's design.
+- Show the connection URI in a different format (for example, a deeplink button instead of a QR code).
+- Integrate the connection flow into an existing modal or onboarding wizard.
+
+## Set up headless mode
+
+### 1. Create the client with headless mode enabled
+
+Set `ui.headless` to `true` in the client options:
+
+```javascript
+import { createMultichainClient, getInfuraRpcUrls } from '@metamask/connect-multichain'
+
+const client = await createMultichainClient({
+  dapp: {
+    name: 'My DApp',
+    url: window.location.href,
+  },
+  api: {
+    supportedNetworks: {
+      ...getInfuraRpcUrls({ infuraApiKey: '<YOUR_INFURA_API_KEY>' }),
+    },
+  },
+  ui: { headless: true },
+})
+```
+
+### 2. Register a `display_uri` listener before connecting
+
+The `display_uri` event fires during the connecting phase with a one-time-use pairing URI.
+You **must** register the listener before calling `connect()`, or you may miss the event:
+
+```javascript
+client.on('display_uri', uri => {
+  showCustomQrModal(uri)
+})
+```
+
+### 3. Connect and handle the result
+
+```javascript
+try {
+  await client.connect(['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'], [])
+  hideCustomQrModal()
+} catch (err) {
+  hideCustomQrModal()
+  if (err.code === 4001) {
+    // User rejected — show retry UI
+  } else {
+    console.error('Connection failed:', err)
+  }
+}
+```
+
+## Important considerations
+
+### URI is one-time-use
+
+The pairing URI delivered by `display_uri` is a one-time-use token.
+Once used or expired, it cannot be reused.
+If the connection fails, start a new `connect()` call to generate a fresh URI.
+
+### `display_uri` only fires during connecting
+
+The event fires only while the client status is `'connecting'`.
+After the connection resolves (success or error), `display_uri` stops firing.
+
+### Extension connections skip QR
+
+When the MetaMask browser extension is installed and `ui.preferExtension` is `true` (the default),
+the SDK connects directly through the extension.
+No `display_uri` event fires because no QR code is needed.
+
+To force the MWP/QR flow even when the extension is available, set `ui.preferExtension` to `false`:
+
+```javascript
+const client = await createMultichainClient({
+  dapp: { name: 'My DApp', url: window.location.href },
+  ui: {
+    headless: true,
+    preferExtension: false,
+  },
+})
+```
+
+### Monitor connection status
+
+Use the `stateChanged` event to track the connection lifecycle and update your UI accordingly:
+
+```javascript
+client.on('stateChanged', status => {
+  // status: 'loaded' | 'pending' | 'connecting' | 'connected' | 'disconnected'
+  switch (status) {
+    case 'connecting':
+      showLoadingIndicator()
+      break
+    case 'connected':
+      hideCustomQrModal()
+      showConnectedUI()
+      break
+    case 'disconnected':
+      showDisconnectedUI()
+      break
+  }
+})
+```
+
+## Next steps
+
+- [Send transactions on EVM and Solana](send-transactions.md) using `invokeMethod`.
+- [Sign messages on EVM and Solana](sign-transactions.md) using `invokeMethod`.
+- See the [Multichain methods reference](../reference/methods.md) for the full API.

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -85,7 +85,7 @@ try {
 
 The pairing URI delivered by `display_uri` is a one-time-use token.
 Once used or expired, it cannot be reused.
-If the connection fails, start a new `connect()` call to generate a fresh URI.
+If the connection fails, call `connect` again to generate a fresh URI.
 
 ### `display_uri` only fires during connecting
 

--- a/metamask-connect/multichain/guides/headless-mode.md
+++ b/metamask-connect/multichain/guides/headless-mode.md
@@ -31,9 +31,9 @@ Use headless mode when you want to:
 
 ## Set up headless mode
 
-### 1. Create the client with headless mode enabled
+### 1. Configure the client with headless mode
 
-Set `ui.headless` to `true` in the client options:
+Initialize a MetaMask Connect Multichain client, and set `ui.headless` to `true` in the configuration options:
 
 ```javascript
 import { createMultichainClient, getInfuraRpcUrls } from '@metamask/connect-multichain'

--- a/metamask-connect/multichain/guides/sign-transactions.md
+++ b/metamask-connect/multichain/guides/sign-transactions.md
@@ -100,7 +100,7 @@ const typedData = {
   },
   primaryType: 'Mail',
   domain: {
-    name: 'My DApp',
+    name: 'My Dapp',
     version: '1',
     chainId: 1,
     verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',

--- a/metamask-connect/multichain/quickstart/javascript.md
+++ b/metamask-connect/multichain/quickstart/javascript.md
@@ -124,7 +124,7 @@ const client = await createMultichainClient({
   dapp: {
     name: 'My Multichain Dapp',
     url: window.location.href,
-    iconUrl: 'https://mydapp.com/icon.png',
+    iconUrl: 'https://mydapp.com/icon.png', // Or use base64Icon for embedded icons (e.g., React Native)
   },
   api: {
     supportedNetworks: {

--- a/metamask-connect/multichain/quickstart/react-native.md
+++ b/metamask-connect/multichain/quickstart/react-native.md
@@ -265,7 +265,7 @@ function getClient() {
   if (!clientPromise) {
     clientPromise = createMultichainClient({
       dapp: {
-        name: 'My Multichain RN DApp',
+        name: 'My Multichain RN Dapp',
         url: 'https://mydapp.com',
       },
       api: {

--- a/metamask-connect/multichain/reference/methods.md
+++ b/metamask-connect/multichain/reference/methods.md
@@ -276,7 +276,7 @@ Include all supported chains:
 import { createMultichainClient, getInfuraRpcUrls } from '@metamask/connect-multichain'
 
 const client = await createMultichainClient({
-  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
+  dapp: { name: 'My Dapp', url: 'https://mydapp.com' },
   api: {
     supportedNetworks: {
       ...getInfuraRpcUrls({ infuraApiKey: 'YOUR_INFURA_API_KEY' }),
@@ -291,7 +291,7 @@ Include only specific chains using `caipChainIds`:
 import { createMultichainClient, getInfuraRpcUrls } from '@metamask/connect-multichain'
 
 const client = await createMultichainClient({
-  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
+  dapp: { name: 'My Dapp', url: 'https://mydapp.com' },
   api: {
     supportedNetworks: {
       // Each chain must be active in your Infura dashboard

--- a/metamask-connect/multichain/reference/methods.md
+++ b/metamask-connect/multichain/reference/methods.md
@@ -65,9 +65,13 @@ await client.connect(['eip155:1', 'eip155:137', 'solana:5eykt4UsFv8P8NJdTREpY1vz
 Returns the current multichain session, including the approved scopes and accounts.
 Call this after [`connect`](#connect) to retrieve the accounts the user authorized.
 
+Access `getSession` through the `provider` property on the multichain client
+(`client.provider.getSession()`).
+
 ### Returns
 
-A promise that resolves to the current `Session` object containing `sessionScopes`, a map of CAIP-2 scope IDs to their approved accounts.
+A promise that resolves to the current `Session` object containing `sessionScopes`, a map of
+CAIP-2 scope IDs to their approved accounts.
 
 ### Example
 
@@ -335,9 +339,36 @@ client.on('stateChanged', status => {
 })
 ```
 
+## Error classes
+
+`@metamask/connect-multichain` exports typed error classes for granular error handling:
+
+| Class           | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `RpcError`      | JSON-RPC errors from the wallet (includes `code` and `data`). |
+| `ProtocolError` | Connection protocol failures (transport, pairing, handshake). |
+| `StorageError`  | Session persistence issues (read/write failures).             |
+
+```javascript
+import { ProtocolError, RpcError, StorageError } from '@metamask/connect-multichain'
+
+try {
+  await client.connect(['eip155:1'], [])
+} catch (err) {
+  if (err instanceof RpcError) {
+    // Check err.code for specific RPC error codes (4001, -32002, etc.)
+  } else if (err instanceof ProtocolError) {
+    // Connection protocol failure
+  } else if (err instanceof StorageError) {
+    // Session persistence issue
+  }
+}
+```
+
 ## Next steps
 
 - Follow the [JavaScript quickstart](../quickstart/javascript.md) to set up MetaMask Connect Multichain in a dapp.
 - [Send transactions on EVM and Solana](../guides/send-transactions.md) using `invokeMethod`.
 - [Sign messages on EVM and Solana](../guides/sign-transactions.md) using `invokeMethod`.
+- [Use headless mode](../guides/headless-mode.md) for custom QR code rendering.
 - See the [Multichain API reference](api.md) for the underlying CAIP-25 protocol methods.

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -37,7 +37,7 @@ import {
 
 const solanaClient = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: window.location.origin,
   },
 })

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -53,7 +53,7 @@ const connection = new Connection('https://solana-devnet.infura.io/v3/<YOUR_INFU
 
 ### 1. Build the transactions
 
-Construct each transaction with a fresh blockhash and fee payer.
+Construct each transaction with a new block hash and fee payer.
 Serialize each with `verifySignatures: false` since the wallet adds signatures:
 
 ```javascript

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -1,0 +1,151 @@
+---
+title: 'Send Batch Solana Transactions - MetaMask Connect'
+sidebar_label: Send batch transactions
+description: Sign and send multiple Solana transactions in a single wallet interaction using the signAndSendAllTransactions wallet-standard feature.
+keywords:
+  [
+    solana,
+    batch transactions,
+    signAndSendAllTransactions,
+    wallet-standard,
+    MetaMask,
+    Connect,
+    multiple transactions,
+  ]
+---
+
+# Send batch transactions
+
+The `solana:signAndSendAllTransactions` wallet-standard feature lets you sign and send multiple
+Solana transactions in a single wallet interaction.
+This is useful for operations that span several transactions, such as initializing multiple accounts,
+batch token transfers, or multi-step program interactions.
+
+## Prerequisites
+
+Set up a Solana client and connect to the user's wallet:
+
+```javascript
+import { createSolanaClient } from '@metamask/connect-solana'
+import {
+  Connection,
+  Transaction,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js'
+
+const solanaClient = await createSolanaClient({
+  dapp: {
+    name: 'My Solana DApp',
+    url: window.location.origin,
+  },
+})
+
+const wallet = solanaClient.getWallet()
+const { accounts } = await wallet.features['standard:connect'].connect()
+const account = accounts[0]
+const publicKey = new PublicKey(account.address)
+const connection = new Connection('https://solana-devnet.infura.io/v3/<YOUR_INFURA_API_KEY>')
+```
+
+## Build and send batch transactions
+
+### 1. Build the transactions
+
+Construct each transaction with a fresh blockhash and fee payer.
+Serialize each with `verifySignatures: false` since the wallet adds signatures:
+
+```javascript
+const { blockhash } = await connection.getLatestBlockhash()
+
+const recipients = ['RECIPIENT_ADDRESS_1', 'RECIPIENT_ADDRESS_2', 'RECIPIENT_ADDRESS_3']
+
+const serializedTransactions = recipients.map(recipient => {
+  const transaction = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: publicKey,
+      toPubkey: new PublicKey(recipient),
+      lamports: 0.001 * LAMPORTS_PER_SOL,
+    })
+  )
+  transaction.recentBlockhash = blockhash
+  transaction.feePayer = publicKey
+
+  return transaction.serialize({ verifySignatures: false })
+})
+```
+
+### 2. Sign and send all transactions
+
+Use the `solana:signAndSendAllTransactions` feature to submit the batch:
+
+```javascript
+const batchFeature = wallet.features['solana:signAndSendAllTransactions']
+
+const results = await batchFeature.signAndSendAllTransactions({
+  account,
+  transactions: serializedTransactions,
+  chain: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+})
+```
+
+### 3. Confirm each transaction
+
+Always confirm transactions before updating the UI:
+
+```javascript
+for (const { signature } of results) {
+  const confirmation = await connection.confirmTransaction(
+    {
+      signature,
+      blockhash,
+      lastValidBlockHeight: (await connection.getLatestBlockhash()).lastValidBlockHeight,
+    },
+    'confirmed'
+  )
+
+  if (confirmation.value.err) {
+    console.error('Transaction failed on-chain:', confirmation.value.err)
+  } else {
+    console.log('Transaction confirmed:', signature)
+  }
+}
+```
+
+## Error handling
+
+```javascript
+try {
+  const results = await batchFeature.signAndSendAllTransactions({
+    account,
+    transactions: serializedTransactions,
+    chain: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+  })
+} catch (err) {
+  if (err.code === 4001) {
+    // User rejected the batch — show retry UI
+  } else if (err.code === -32002) {
+    // Request already pending — ask user to check MetaMask
+  } else {
+    console.error('Batch transaction error:', err)
+  }
+}
+```
+
+## Important considerations
+
+- **Fresh blockhash:** Blockhashes expire after ~60 seconds.
+  Fetch `getLatestBlockhash()` immediately before building the batch.
+- **Transaction size:** Each individual transaction is limited to 1,232 bytes.
+  If a single transaction exceeds this limit, split it into smaller transactions.
+- **Confirmation:** A submitted transaction is not finalized until `confirmTransaction` returns.
+  Always confirm before reporting success to the user.
+- **Devnet and testnet** are only supported in the MetaMask browser extension, not the mobile wallet.
+
+## Next steps
+
+- [Send a legacy transaction](send-legacy-transaction.md) for single transactions.
+- [Send a versioned transaction](send-versioned-transaction.md) for transactions with Address
+  Lookup Tables.
+- [MetaMask Connect Solana methods](../reference/methods.md) for the full API reference.

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -1,7 +1,7 @@
 ---
 title: 'Send Batch Solana Transactions - MetaMask Connect'
 sidebar_label: Send batch transactions
-description: Sign and send multiple Solana transactions in a single wallet interaction using the signAndSendAllTransactions wallet-standard feature.
+description: Sign and send multiple Solana transactions in a single wallet interaction using the signAndSendAllTransactions Wallet Standard feature.
 keywords:
   [
     solana,

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -135,8 +135,8 @@ try {
 
 ## Important considerations
 
-- **Fresh blockhash:** Blockhashes expire after ~60 seconds.
-  Fetch `getLatestBlockhash()` immediately before building the batch.
+- **New block hash:** Block hashes expire after ~60 seconds.
+  Call `getLatestBlockhash` immediately before building the batch.
 - **Transaction size:** Each individual transaction is limited to 1,232 bytes.
   If a single transaction exceeds this limit, split it into smaller transactions.
 - **Confirmation:** A submitted transaction is not finalized until `confirmTransaction` returns.

--- a/metamask-connect/solana/guides/batch-transactions.md
+++ b/metamask-connect/solana/guides/batch-transactions.md
@@ -16,7 +16,7 @@ keywords:
 
 # Send batch transactions
 
-The `solana:signAndSendAllTransactions` wallet-standard feature lets you sign and send multiple
+The `solana:signAndSendAllTransactions` Wallet Standard feature lets you sign and send multiple
 Solana transactions in a single wallet interaction.
 This is useful for operations that span several transactions, such as initializing multiple accounts,
 batch token transfers, or multi-step program interactions.

--- a/metamask-connect/solana/guides/send-legacy-transaction.md
+++ b/metamask-connect/solana/guides/send-legacy-transaction.md
@@ -1,7 +1,7 @@
 ---
 title: 'Send Solana Legacy Transactions - MetaMask Connect'
 sidebar_label: Send a legacy transaction
-description: Sign and send Solana legacy transactions through MetaMask Connect using the wallet-standard signAndSendTransaction feature with @solana/web3.js.
+description: Sign and send Solana legacy transactions through MetaMask Connect using the Wallet Standard signAndSendTransaction feature with @solana/web3.js.
 keywords:
   [
     solana,

--- a/metamask-connect/solana/guides/send-legacy-transaction.md
+++ b/metamask-connect/solana/guides/send-legacy-transaction.md
@@ -116,7 +116,7 @@ await connection.getSignatureStatus(txSignature)
 
 :::caution Chrome Android
 There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
-wallet-standard provider from `@metamask/connect-solana`.
+Wallet Standard provider from `@metamask/connect-solana`.
 Test Solana transaction flows on desktop Chrome and the MetaMask browser extension before targeting
 mobile.
 See [Troubleshooting](../../troubleshooting/index.md#chrome-android) for details.

--- a/metamask-connect/solana/guides/send-legacy-transaction.md
+++ b/metamask-connect/solana/guides/send-legacy-transaction.md
@@ -114,6 +114,14 @@ const txSignature = await connection.sendRawTransaction(signedTransaction)
 await connection.getSignatureStatus(txSignature)
 ```
 
+:::caution Chrome Android
+There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
+wallet-standard provider from `@metamask/connect-solana`.
+Test Solana transaction flows on desktop Chrome and the MetaMask browser extension before targeting
+mobile.
+See [Troubleshooting](../../troubleshooting/index.md#chrome-android) for details.
+:::
+
 ## Next steps
 
 To efficiently load more addresses in a single transaction, learn how to [send a versioned transaction](send-versioned-transaction.md) with Address Lookup Tables.

--- a/metamask-connect/solana/guides/send-legacy-transaction.md
+++ b/metamask-connect/solana/guides/send-legacy-transaction.md
@@ -33,7 +33,7 @@ import { Connection, Transaction, SystemProgram, PublicKey } from '@solana/web3.
 
 const solanaClient = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: window.location.origin,
   },
 })

--- a/metamask-connect/solana/guides/send-versioned-transaction.md
+++ b/metamask-connect/solana/guides/send-versioned-transaction.md
@@ -38,7 +38,7 @@ import {
 
 const solanaClient = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: window.location.origin,
   },
 })

--- a/metamask-connect/solana/guides/sign-data/sign-message.md
+++ b/metamask-connect/solana/guides/sign-data/sign-message.md
@@ -31,7 +31,7 @@ import { createSolanaClient } from '@metamask/connect-solana'
 
 const solanaClient = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: window.location.origin,
   },
 })

--- a/metamask-connect/solana/guides/sign-data/sign-message.md
+++ b/metamask-connect/solana/guides/sign-data/sign-message.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sign Messages on Solana - MetaMask Connect'
 sidebar_label: Sign messages
-description: Request offchain cryptographic signatures from users on Solana using MetaMask Connect's signMessage wallet-standard feature.
+description: Request offchain cryptographic signatures from users on Solana using MetaMask Connect's signMessage Wallet Standard feature.
 keywords:
   [
     solana sign message,
@@ -58,4 +58,4 @@ async function signMessage() {
 - [Sign in with Solana (SIWS)](siws.md) to authenticate users with domain-bound, phishing-resistant sign-in messages.
 - [Send a legacy transaction](../send-legacy-transaction.md) to transfer SOL or interact with Solana programs.
 - [Send a versioned transaction](../send-versioned-transaction.md) to use Address Lookup Tables for complex operations.
-- [MetaMask Connect Solana methods](../../reference/methods.md) for the full list of wallet-standard features.
+- [MetaMask Connect Solana methods](../../reference/methods.md) for the full list of Wallet Standard features.

--- a/metamask-connect/solana/guides/sign-data/siws.md
+++ b/metamask-connect/solana/guides/sign-data/siws.md
@@ -54,7 +54,7 @@ import { createSolanaClient } from '@metamask/connect-solana'
 
 const solanaClient = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: window.location.origin,
   },
 })

--- a/metamask-connect/solana/guides/sign-data/siws.md
+++ b/metamask-connect/solana/guides/sign-data/siws.md
@@ -98,4 +98,4 @@ See the [JavaScript quickstart](../../quickstart/javascript.md) for a complete w
 
 - [Sign messages](sign-message.md) for general-purpose offchain signatures without domain binding.
 - [Send a legacy transaction](../send-legacy-transaction.md) to transfer SOL or interact with Solana programs.
-- [MetaMask Connect Solana methods](../../reference/methods.md) for the full list of wallet-standard features.
+- [MetaMask Connect Solana methods](../../reference/methods.md) for the full list of Wallet Standard features.

--- a/metamask-connect/solana/guides/use-wallet-adapter.md
+++ b/metamask-connect/solana/guides/use-wallet-adapter.md
@@ -94,8 +94,20 @@ export const SolanaProvider: FC<SolanaProviderProps> = ({ children }) => {
 };
 ```
 
-Calling [`createSolanaClient`](../reference/methods.md#createsolanaclient) registers MetaMask with the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) registry.
-This displays MetaMask as a connection option in the wallet modal, even if the user doesn't have MetaMask installed.
+Calling [`createSolanaClient`](../reference/methods.md#createsolanaclient) registers MetaMask with
+the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) registry.
+This displays MetaMask as a connection option in the wallet modal, even if the user doesn't have
+MetaMask installed.
+
+:::tip Timing
+The `useEffect` pattern above works because `createSolanaClient` typically resolves before the user
+opens the wallet modal.
+If MetaMask does not appear in the wallet list, ensure `createSolanaClient` has resolved before the
+`WalletProvider` renders.
+One approach is to await the client in your app's entry point before calling `createRoot().render()`.
+See [Troubleshooting: MetaMask wallet not appearing](../../troubleshooting/index.md#metamask-wallet-not-appearing-in-solana-wallet-adapter)
+for details.
+:::
 
 ### 3. Add the provider to your root layout
 
@@ -136,6 +148,14 @@ export const ConnectWallet = () => {
 ```
 
 The button automatically displays a wallet selection modal that includes MetaMask.
+
+:::caution Chrome Android
+There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
+wallet-standard provider from `@metamask/connect-solana`.
+Test Solana wallet-adapter flows on desktop Chrome and the MetaMask browser extension before
+targeting mobile.
+See [Troubleshooting](../../troubleshooting/index.md#chrome-android) for details.
+:::
 
 ## Next steps
 

--- a/metamask-connect/solana/guides/use-wallet-adapter.md
+++ b/metamask-connect/solana/guides/use-wallet-adapter.md
@@ -151,8 +151,8 @@ The button automatically displays a wallet selection modal that includes MetaMas
 
 :::caution Chrome Android
 There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
-wallet-standard provider from `@metamask/connect-solana`.
-Test Solana wallet-adapter flows on desktop Chrome and the MetaMask browser extension before
+Wallet Standard provider from `@metamask/connect-solana`.
+Test Solana Wallet Adapter flows on desktop Chrome and the MetaMask browser extension before
 targeting mobile.
 See [Troubleshooting](../../troubleshooting/index.md#chrome-android) for details.
 :::

--- a/metamask-connect/solana/guides/use-wallet-adapter.md
+++ b/metamask-connect/solana/guides/use-wallet-adapter.md
@@ -78,7 +78,7 @@ export const SolanaProvider: FC<SolanaProviderProps> = ({ children }) => {
   useEffect(() => {
     createSolanaClient({
       dapp: {
-        name: 'My Solana DApp',
+        name: 'My Solana Dapp',
         url: window.location.origin,
       },
     });

--- a/metamask-connect/solana/index.md
+++ b/metamask-connect/solana/index.md
@@ -2,7 +2,7 @@
 title: 'MetaMask Connect Solana - Solana Dapp Integration'
 sidebar_label: Introduction
 toc_max_heading_level: 2
-description: Connect your dapp to Solana using MetaMask Connect Solana. Use wallet-standard features, Wallet Adapter, or Framework Kit for React and vanilla JS apps.
+description: Connect your dapp to Solana using MetaMask Connect Solana. Use Wallet Standard features, Wallet Adapter, or Framework Kit for React and vanilla JS apps.
 keywords:
   [
     solana,
@@ -33,7 +33,7 @@ You interact with the wallet through the client APIs.
 
 :::tip Ready to code?
 Jump to the [Wallet Adapter guide](./guides/use-wallet-adapter.md) for a React dapp, or
-the [JavaScript quickstart](./quickstart/javascript.md) to use wallet-standard features
+the [JavaScript quickstart](./quickstart/javascript.md) to use Wallet Standard features
 directly.
 :::
 
@@ -57,7 +57,7 @@ description: 'Use Solana\'s Wallet Adapter to connect a React dapp to MetaMask.'
 {
 href: '/metamask-connect/solana/quickstart/javascript',
 title: 'JavaScript',
-description: 'Use wallet-standard features directly in a JavaScript dapp.',
+description: 'Use Wallet Standard features directly in a JavaScript dapp.',
 },
 {
 href: '/metamask-connect/solana/guides/use-framework-kit',

--- a/metamask-connect/solana/quickstart/javascript.md
+++ b/metamask-connect/solana/quickstart/javascript.md
@@ -1,6 +1,6 @@
 ---
 title: 'JavaScript Quickstart - MetaMask Connect Solana'
-description: Set up MetaMask Connect Solana in a vanilla JavaScript dapp using wallet-standard features, signAndSendTransaction, and createSolanaClient.
+description: Set up MetaMask Connect Solana in a vanilla JavaScript dapp using Wallet Standard features, signAndSendTransaction, and createSolanaClient.
 sidebar_label: JavaScript
 keywords:
   [

--- a/metamask-connect/solana/quickstart/react-native.md
+++ b/metamask-connect/solana/quickstart/react-native.md
@@ -261,7 +261,7 @@ function getClient() {
   if (!clientPromise) {
     clientPromise = createMultichainClient({
       dapp: {
-        name: 'My Solana RN DApp',
+        name: 'My Solana RN Dapp',
         url: 'https://mydapp.com',
       },
       api: {

--- a/metamask-connect/solana/reference/methods.md
+++ b/metamask-connect/solana/reference/methods.md
@@ -59,7 +59,7 @@ import { createSolanaClient, getInfuraRpcUrls } from '@metamask/connect-solana'
 
 const client = await createSolanaClient({
   dapp: {
-    name: 'My Solana DApp',
+    name: 'My Solana Dapp',
     url: 'https://mydapp.com',
   },
   api: {
@@ -109,7 +109,7 @@ const supportedNetworks = getInfuraRpcUrls({
 // }
 
 const client = await createSolanaClient({
-  dapp: { name: 'My Solana DApp', url: 'https://mydapp.com' },
+  dapp: { name: 'My Solana Dapp', url: 'https://mydapp.com' },
   api: { supportedNetworks },
 })
 ```
@@ -145,7 +145,7 @@ A promise that resolves when registration is complete.
 
 ```javascript
 const client = await createSolanaClient({
-  dapp: { name: 'My Solana DApp', url: 'https://mydapp.com' },
+  dapp: { name: 'My Solana Dapp', url: 'https://mydapp.com' },
   skipAutoRegister: true,
 })
 

--- a/metamask-connect/solana/reference/methods.md
+++ b/metamask-connect/solana/reference/methods.md
@@ -1,6 +1,6 @@
 ---
 title: 'MetaMask Connect Solana methods'
-description: Complete methods reference for MetaMask Connect Solana, including createSolanaClient, getInfuraRpcUrls, and wallet-standard features.
+description: Complete methods reference for MetaMask Connect Solana, including createSolanaClient, getInfuraRpcUrls, and Wallet Standard features.
 keywords:
   [
     solana,
@@ -10,7 +10,7 @@ keywords:
     dapp,
     createSolanaClient,
     getInfuraRpcUrls,
-    wallet-standard features,
+    Wallet Standard features,
     signTransaction,
     signMessage,
     API reference,

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -119,7 +119,7 @@ Do **not** call `connect` again; the original promise resolves once the user act
 
 ### Chain not configured in `supportedNetworks`
 
-The chain ID passed to `connect()` or `wallet_switchEthereumChain` is not listed in the
+The chain ID passed to `connect` or `wallet_switchEthereumChain` is not listed in the
 `api.supportedNetworks` configuration.
 
 Add every chain the dapp needs to `supportedNetworks` with a valid RPC URL:

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -167,7 +167,7 @@ No QR is generated because none is needed.
 
 ```javascript
 const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
+  dapp: { name: 'My Dapp' },
   ui: { preferExtension: false },
 })
 ```

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -228,9 +228,9 @@ provider.on('wallet_sessionChanged', session => {
 })
 ```
 
-Do not call `connect()` again immediately on page load if a session already exists.
+Do not call `connect` again immediately on page load if a session already exists.
 
-### `disconnect()` doesn't fully disconnect
+### `disconnect` doesn't fully disconnect
 
 Calling `disconnect(scopes)` with specific CAIP scopes only revokes those scopes, not the entire
 session.

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -111,11 +111,11 @@ try {
 
 ### Connection already pending (code `-32002`)
 
-A previous `connect()` call has not yet resolved.
+A previous `connect` call has not yet resolved.
 The user may still have the MetaMask approval dialog open on mobile.
 
 Show a message like "Check MetaMask to approve the connection."
-Do **not** call `connect()` again — the original promise resolves once the user acts.
+Do **not** call `connect` again; the original promise resolves once the user acts.
 
 ### Chain not configured in `supportedNetworks`
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -80,12 +80,12 @@ The SDK falls through to MetaMask Wallet Protocol (MWP) but has nowhere to rende
 
 ```javascript
 const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
+  dapp: { name: 'My Dapp' },
   ui: { preferExtension: false },
 })
 ```
 
-**Cause B:** A concurrent `connect()` call is already in progress over MWP.
+**Cause B:** A concurrent `connect` call is already in progress over MWP.
 
 **Fix:** Guard against double-clicks with a loading state.
 Look for error code `-32002` and show a "check MetaMask" message instead of retrying.

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -262,8 +262,8 @@ const client = await createEVMClient({
 ### Chrome Android Solana wallet-adapter issue {#chrome-android}
 
 There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
-wallet-standard provider from `@metamask/connect-solana`.
-Treat Solana wallet-adapter flows on mobile Chrome as fragile until verified explicitly.
+Wallet Standard provider from `@metamask/connect-solana`.
+Treat Solana Wallet Adapter flows on mobile Chrome as fragile until verified explicitly.
 
 Test Solana flows on desktop Chrome and the MetaMask browser extension before targeting mobile.
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -334,24 +334,25 @@ See [React Native Metro polyfill issues](metro-polyfill-issues.md) for the full 
 
 ## Diagnostic checklist
 
-Run through this checklist when any MetaMask Connect integration is misbehaving:
+When any MetaMask Connect integration is misbehaving, ensure the following are true:
 
-- [ ] `supportedNetworks` has valid RPC URLs for every chain the dapp uses.
-- [ ] Chain IDs are hex strings for EVM (`'0x1'`, not `1` or `'1'`).
-- [ ] Polyfills loaded (React Native): `react-native-get-random-values` is first entry-file
-      import; `window` shim present; `Event`/`CustomEvent` shims present **only if using wagmi**;
-      `Buffer` set as safety net for peer deps.
-- [ ] `preferredOpenLink` set (React Native) for deeplinks to open MetaMask Mobile.
-- [ ] Import order correct: polyfills before SDK imports; `react-native-get-random-values` is the
+- `supportedNetworks` has valid RPC URLs for every chain the dapp uses.
+- Chain IDs are hex strings for EVM (`'0x1'`, not `1` or `'1'`).
+- In React Native dapps:
+  - Polyfills are loaded: `react-native-get-random-values` is the first entry-file
+      import; `window` shim is present; `Event`/`CustomEvent` shims are present **only if using Wagmi**;
+      `Buffer` is set as a safety net for peer dependencies.
+  - `preferredOpenLink` is set for deeplinks to open MetaMask Mobile.
+  - Import order is correct: polyfills before SDK imports; `react-native-get-random-values` is the
       very first import.
-- [ ] Error codes handled in catch blocks: at minimum handle `4001` (user rejected) and `-32002`
+- Error codes are handled in catch blocks: at minimum handle `4001` (user rejected) and `-32002`
       (pending).
-- [ ] Singleton client not recreated: `createEVMClient` / `createMultichainClient` called once;
-      subsequent calls merge into existing instance.
-- [ ] `display_uri` listener registered before `connect()` in headless mode for QR codes.
-- [ ] Solana `wallets` prop is `[]`: MetaMask uses wallet-standard discovery, not manual registration.
-- [ ] Solana devnet/testnet only supported in the browser extension, not mobile.
-- [ ] `debug: true` enabled in client options for verbose console output when debugging.
+- A singleton client is not recreated: `createEVMClient` / `createMultichainClient` is called once;
+      subsequent calls merge into the existing instance.
+- `display_uri` listener is registered before calling `connect` in headless mode for QR codes.
+- Solana `wallets` prop is `[]`: MetaMask uses Wallet Standard discovery, not manual registration.
+- Solana devnet/testnet is used only with the browser extension.
+- `debug: true` is set for verbose console output when debugging.
 
 ## Next steps
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -42,7 +42,7 @@ Always check `err.code` before `err.message` for reliable error categorization.
 | `-32002` | Request already pending           | Show "Check MetaMask to approve the pending request." Do **not** call `connect()` again.   |
 | `-32602` | Invalid parameters                | Verify that parameters match the expected types (for example, hex chain IDs, not decimal). |
 | `-32603` | Internal error                    | Unexpected server-side error. Retry with exponential backoff.                              |
-| `-32000` | Execution reverted / server error | Transaction would fail on-chain. Check contract inputs and sender balance.                 |
+| `-32000` | Execution reverted / server error | Transaction would fail onchain. Check contract inputs and sender balance.                 |
 | `1013`   | Internal transport disconnect     | The SDK handles reconnection internally. Do not treat this as a user-facing disconnect.    |
 
 For the complete list of provider errors, see

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -126,7 +126,7 @@ Add every chain the dapp needs to `supportedNetworks` with a valid RPC URL:
 
 ```javascript
 const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
+  dapp: { name: 'My Dapp' },
   api: {
     supportedNetworks: {
       ...getInfuraRpcUrls({

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -194,7 +194,7 @@ bootstrap()
 ```
 
 **Cause B:** The `wallets` prop on `WalletProvider` is not an empty array.
-MetaMask uses the wallet-standard auto-discovery protocol and must **not** be listed manually.
+MetaMask uses the Wallet Standard auto-discovery protocol and must **not** be listed manually.
 
 **Fix:** Always pass `wallets={[]}`:
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -32,8 +32,8 @@ instructions.
 
 ## Error codes
 
-The following error codes appear in `err.code` on rejected promises from `connect()`,
-`invokeMethod()`, and `provider.request()` calls.
+The following error codes appear in `err.code` on rejected promises from `connect`,
+`invokeMethod`, and `provider.request` calls.
 Always check `err.code` before `err.message` for reliable error categorization.
 
 | Code     | Meaning                           | Recommended handling                                                                       |

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -42,7 +42,7 @@ Always check `err.code` before `err.message` for reliable error categorization.
 | `-32002` | Request already pending           | Show "Check MetaMask to approve the pending request." Do **not** call `connect()` again.   |
 | `-32602` | Invalid parameters                | Verify that parameters match the expected types (for example, hex chain IDs, not decimal). |
 | `-32603` | Internal error                    | Unexpected server-side error. Retry with exponential backoff.                              |
-| `-32000` | Execution reverted / server error | Transaction would fail onchain. Check contract inputs and sender balance.                 |
+| `-32000` | Execution reverted / server error | Transaction would fail onchain. Check contract inputs and sender balance.                  |
 | `1013`   | Internal transport disconnect     | The SDK handles reconnection internally. Do not treat this as a user-facing disconnect.    |
 
 For the complete list of provider errors, see
@@ -161,9 +161,10 @@ await client.connect({ chainIds: ['0x1'] })
 ```
 
 **Cause B:** The MetaMask extension is detected and the SDK uses the extension transport.
-No QR is generated because none is needed.
+`preferExtension` defaults to `true`, so when the extension is installed the client prefers it and does not generate a QR code, because none is needed for that path.
+The same situation applies if you want a mobile QR flow while the extension is present.
 
-**Fix:** Force the MWP/QR flow by disabling extension preference:
+**Fix:** Force the MetaMask Wallet Protocol (MWP) / QR flow by setting `preferExtension` to `false` when creating the client:
 
 ```javascript
 const client = await createEVMClient({
@@ -245,20 +246,6 @@ await client.disconnect(['eip155:1'])
 await client.disconnect()
 ```
 
-### Extension transport used but want mobile QR
-
-`preferExtension` defaults to `true`.
-When the MetaMask browser extension is installed, the SDK always prefers it.
-
-Set `ui.preferExtension` to `false`:
-
-```javascript
-const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
-  ui: { preferExtension: false },
-})
-```
-
 ### Chrome Android Solana wallet-adapter issue {#chrome-android}
 
 There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
@@ -269,68 +256,7 @@ Test Solana flows on desktop Chrome and the MetaMask browser extension before ta
 
 ## React Native issues
 
-The following issues are specific to React Native.
-For full setup instructions, see the
-[React Native Metro polyfill guide](metro-polyfill-issues.md).
-
-### `Buffer is not defined`
-
-A dependency loaded before `@metamask/connect-multichain` uses `Buffer`.
-The Connect package self-polyfills `Buffer` via its React Native entry point, but peer dependencies
-like `eciesjs` may execute first.
-
-Add this to `polyfills.ts` and import it early (after `react-native-get-random-values`, before other
-imports):
-
-```typescript
-import { Buffer } from 'buffer'
-global.Buffer = Buffer
-```
-
-### `crypto.getRandomValues is not a function`
-
-`react-native-get-random-values` is either not installed or not imported as the very first import.
-
-Import it as the **first line** of your entry file, before any other import:
-
-```typescript
-import 'react-native-get-random-values'
-// all other imports follow
-```
-
-### `Event is not defined` / `CustomEvent is not defined`
-
-React Native does not provide `Event` or `CustomEvent` globals.
-These polyfills are **only required when using wagmi** — the Connect packages themselves use
-`eventemitter3` internally and do not need DOM events.
-
-If you use wagmi, add `Event` and `CustomEvent` polyfills in your polyfills file.
-See [React Native Metro polyfill issues](metro-polyfill-issues.md) for the full polyfill code.
-
-### Deeplinks not opening MetaMask app
-
-The `mobile.preferredOpenLink` callback is not configured.
-
-Pass a function that calls `Linking.openURL`:
-
-```typescript
-import { Linking } from 'react-native'
-
-const client = await createEVMClient({
-  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
-  mobile: {
-    preferredOpenLink: deeplink => Linking.openURL(deeplink),
-  },
-})
-```
-
-### App crashes on import of SDK
-
-Metro cannot resolve Node.js built-in modules (`stream`, `crypto`, `http`, etc.) that SDK
-dependencies reference.
-
-Add `extraNodeModules` shims in `metro.config.js`.
-See [React Native Metro polyfill issues](metro-polyfill-issues.md) for the full Metro configuration.
+Polyfill setup, Metro `extraNodeModules`, entry-file import order, common bundler errors, and deeplinks to MetaMask Mobile are documented in [React Native Metro polyfill issues](metro-polyfill-issues.md).
 
 ## Diagnostic checklist
 
@@ -340,15 +266,15 @@ When any MetaMask Connect integration is misbehaving, ensure the following are t
 - Chain IDs are hex strings for EVM (`'0x1'`, not `1` or `'1'`).
 - In React Native dapps:
   - Polyfills are loaded: `react-native-get-random-values` is the first entry-file
-      import; `window` shim is present; `Event`/`CustomEvent` shims are present **only if using Wagmi**;
-      `Buffer` is set as a safety net for peer dependencies.
-  - `preferredOpenLink` is set for deeplinks to open MetaMask Mobile.
+    import; `window` shim is present; `Event`/`CustomEvent` shims are present **only if using wagmi**;
+    `Buffer` is set as a safety net for peer dependencies.
+  - `preferredOpenLink` is set for deeplinks to open MetaMask Mobile (see [Deeplinks not opening MetaMask app](metro-polyfill-issues.md#deeplinks-not-opening-metamask-app)).
   - Import order is correct: polyfills before SDK imports; `react-native-get-random-values` is the
-      very first import.
+    very first import.
 - Error codes are handled in catch blocks: at minimum handle `4001` (user rejected) and `-32002`
-      (pending).
+  (pending).
 - A singleton client is not recreated: `createEVMClient` / `createMultichainClient` is called once;
-      subsequent calls merge into the existing instance.
+  subsequent calls merge into the existing instance.
 - `display_uri` listener is registered before calling `connect` in headless mode for QR codes.
 - Solana `wallets` prop is `[]`: MetaMask uses Wallet Standard discovery, not manual registration.
 - Solana devnet/testnet is used only with the browser extension.

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -1,14 +1,361 @@
 ---
 title: Troubleshooting - MetaMask Connect
-description: Solve common polyfill and bundler issues when using MetaMask Connect packages in React Native.
+description: Diagnose and fix common MetaMask Connect issues including connection failures, error codes, React Native polyfills, and session management.
 sidebar_label: Overview
-keywords: [MetaMask, Connect, polyfill, bundler, troubleshooting, Metro, React Native]
+keywords:
+  [
+    MetaMask,
+    Connect,
+    troubleshooting,
+    error codes,
+    connection,
+    polyfill,
+    React Native,
+    QR code,
+    headless,
+    session,
+  ]
 ---
 
 # Troubleshooting
 
-MetaMask Connect packages (`@metamask/connect-multichain`, `@metamask/connect-evm`, `@metamask/connect-solana`) work out of the box in modern browsers and Vite/Webpack-based setups without needing Node.js polyfills. The SDK handles its transport and crypto needs internally using browser-native APIs.
+MetaMask Connect packages (`@metamask/connect-multichain`, `@metamask/connect-evm`,
+`@metamask/connect-solana`) work out of the box in modern browsers and Vite/Webpack-based setups
+without polyfills.
+The SDK handles its transport and crypto needs internally using browser-native APIs.
 
-**React Native** is the exception. The React Native runtime lacks certain Web and Node.js APIs (`Buffer`, `crypto.getRandomValues`, `stream`, `Event`, `CustomEvent`), so polyfills and Metro configuration are required.
+**React Native** is the exception.
+The React Native runtime lacks certain Web and Node.js APIs (`Buffer`, `crypto.getRandomValues`,
+`stream`, `Event`, `CustomEvent`), so polyfills and Metro configuration are required.
+See the [React Native Metro polyfill guide](metro-polyfill-issues.md) for step-by-step setup
+instructions.
 
-See the [React Native Metro polyfill guide](metro-polyfill-issues.md) for step-by-step setup instructions and common error solutions.
+## Error codes
+
+The following error codes appear in `err.code` on rejected promises from `connect()`,
+`invokeMethod()`, and `provider.request()` calls.
+Always check `err.code` before `err.message` for reliable error categorization.
+
+| Code     | Meaning                           | Recommended handling                                                                       |
+| -------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `4001`   | User rejected the request         | Show a retry button. Do not log this to error-tracking services.                           |
+| `-32002` | Request already pending           | Show "Check MetaMask to approve the pending request." Do **not** call `connect()` again.   |
+| `-32602` | Invalid parameters                | Verify that parameters match the expected types (for example, hex chain IDs, not decimal). |
+| `-32603` | Internal error                    | Unexpected server-side error. Retry with exponential backoff.                              |
+| `-32000` | Execution reverted / server error | Transaction would fail on-chain. Check contract inputs and sender balance.                 |
+| `1013`   | Internal transport disconnect     | The SDK handles reconnection internally. Do not treat this as a user-facing disconnect.    |
+
+For the complete list of provider errors, see
+[EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) and
+[EIP-1474](https://eips.ethereum.org/EIPS/eip-1474#error-codes).
+
+MetaMask Connect Multichain also exports typed error classes for granular `instanceof` checks:
+
+```typescript
+import { ProtocolError, RpcError, StorageError } from '@metamask/connect-multichain'
+
+try {
+  await client.connect(['eip155:1'], [])
+} catch (err) {
+  if (err instanceof RpcError) {
+    console.log('RPC error code:', err.code)
+  } else if (err instanceof ProtocolError) {
+    console.log('Protocol failure:', err.message)
+  } else if (err instanceof StorageError) {
+    console.log('Session persistence issue:', err.message)
+  }
+}
+```
+
+## Common issues
+
+### Connection hangs after `connect()`
+
+**Cause A:** The MetaMask extension is not detected, `preferExtension` is `true` (the default), and
+headless mode is on without a `display_uri` listener.
+The SDK falls through to MetaMask Wallet Protocol (MWP) but has nowhere to render the QR code.
+
+**Fix:** Register a `display_uri` event listener before calling `connect()`, or set
+`ui.preferExtension: false` to force the QR/MWP flow:
+
+```javascript
+const client = await createEVMClient({
+  dapp: { name: 'My DApp' },
+  ui: { preferExtension: false },
+})
+```
+
+**Cause B:** A concurrent `connect()` call is already in progress over MWP.
+
+**Fix:** Guard against double-clicks with a loading state.
+Look for error code `-32002` and show a "check MetaMask" message instead of retrying.
+
+### User rejected request (code `4001`)
+
+The user clicked "Reject" in MetaMask. This is normal behavior.
+
+Handle gracefully by showing a retry button.
+Do not treat this as an application error:
+
+```javascript
+try {
+  await client.connect({ chainIds: ['0x1'] })
+} catch (err) {
+  if (err.code === 4001) {
+    // User rejected — show retry UI
+    return
+  }
+  throw err
+}
+```
+
+### Connection already pending (code `-32002`)
+
+A previous `connect()` call has not yet resolved.
+The user may still have the MetaMask approval dialog open on mobile.
+
+Show a message like "Check MetaMask to approve the connection."
+Do **not** call `connect()` again — the original promise resolves once the user acts.
+
+### Chain not configured in `supportedNetworks`
+
+The chain ID passed to `connect()` or `wallet_switchEthereumChain` is not listed in the
+`api.supportedNetworks` configuration.
+
+Add every chain the dapp needs to `supportedNetworks` with a valid RPC URL:
+
+```javascript
+const client = await createEVMClient({
+  dapp: { name: 'My DApp' },
+  api: {
+    supportedNetworks: {
+      ...getInfuraRpcUrls({
+        infuraApiKey: '<YOUR_INFURA_API_KEY>',
+        chainIds: ['0x1', '0x89', '0xaa36a7'],
+      }),
+      '0xa4b1': 'https://arb1.arbitrum.io/rpc',
+    },
+  },
+})
+```
+
+### QR code not appearing
+
+**Cause A:** Headless mode is enabled but no `display_uri` listener is registered.
+The SDK generates the URI but has nowhere to render it.
+
+**Fix:** Register a `display_uri` listener **before** calling `connect()`:
+
+```javascript
+const client = await createEVMClient({
+  dapp: { name: 'My DApp' },
+  ui: { headless: true },
+})
+
+const provider = client.getProvider()
+provider.on('display_uri', uri => {
+  renderQrCode(uri) // your QR rendering logic
+})
+
+await client.connect({ chainIds: ['0x1'] })
+```
+
+**Cause B:** The MetaMask extension is detected and the SDK uses the extension transport.
+No QR is generated because none is needed.
+
+**Fix:** Force the MWP/QR flow by disabling extension preference:
+
+```javascript
+const client = await createEVMClient({
+  dapp: { name: 'My DApp' },
+  ui: { preferExtension: false },
+})
+```
+
+### MetaMask wallet not appearing in Solana wallet adapter
+
+**Cause A:** `createSolanaClient` has not resolved before the `WalletProvider` renders.
+MetaMask uses the wallet-standard auto-discovery protocol, but the wallet must be registered before
+discovery runs.
+
+**Fix:** Await client creation before rendering your app:
+
+```javascript
+import { createSolanaClient } from '@metamask/connect-solana'
+
+async function bootstrap() {
+  await createSolanaClient({
+    dapp: { name: 'My DApp', url: window.location.href },
+  })
+  const root = createRoot(document.getElementById('root'))
+  root.render(<App />)
+}
+bootstrap()
+```
+
+**Cause B:** The `wallets` prop on `WalletProvider` is not an empty array.
+MetaMask uses the wallet-standard auto-discovery protocol and must **not** be listed manually.
+
+**Fix:** Always pass `wallets={[]}`:
+
+```jsx
+<WalletProvider wallets={[]} autoConnect>
+  <WalletModalProvider>
+    <App />
+  </WalletModalProvider>
+</WalletProvider>
+```
+
+### Solana devnet or testnet not working
+
+Solana devnet and testnet are only supported in the **MetaMask browser extension**, not in the
+MetaMask mobile wallet.
+Ensure the user is connecting via the browser extension.
+
+### Session lost after page reload
+
+The app is not waiting for the `wallet_sessionChanged` event on initialization.
+The SDK restores sessions asynchronously.
+
+Listen for `wallet_sessionChanged` before assuming the client is ready:
+
+```javascript
+const provider = client.getProvider()
+provider.on('wallet_sessionChanged', session => {
+  if (session.accounts.length > 0) {
+    // Session restored — update UI
+  }
+})
+```
+
+Do not call `connect()` again immediately on page load if a session already exists.
+
+### `disconnect()` doesn't fully disconnect
+
+Calling `disconnect(scopes)` with specific CAIP scopes only revokes those scopes, not the entire
+session.
+
+Call `disconnect()` with **no arguments** to revoke all scopes and fully terminate the session:
+
+```javascript
+// Partial — only revokes the specified scope
+await client.disconnect(['eip155:1'])
+
+// Full disconnect
+await client.disconnect()
+```
+
+### Extension transport used but want mobile QR
+
+`preferExtension` defaults to `true`.
+When the MetaMask browser extension is installed, the SDK always prefers it.
+
+Set `ui.preferExtension` to `false`:
+
+```javascript
+const client = await createEVMClient({
+  dapp: { name: 'My DApp' },
+  ui: { preferExtension: false },
+})
+```
+
+### Chrome Android Solana wallet-adapter issue {#chrome-android}
+
+There is a known issue with `@solana/wallet-adapter-react` on Chrome Android when used with the
+wallet-standard provider from `@metamask/connect-solana`.
+Treat Solana wallet-adapter flows on mobile Chrome as fragile until verified explicitly.
+
+Test Solana flows on desktop Chrome and the MetaMask browser extension before targeting mobile.
+
+## React Native issues
+
+The following issues are specific to React Native.
+For full setup instructions, see the
+[React Native Metro polyfill guide](metro-polyfill-issues.md).
+
+### `Buffer is not defined`
+
+A dependency loaded before `@metamask/connect-multichain` uses `Buffer`.
+The Connect package self-polyfills `Buffer` via its React Native entry point, but peer dependencies
+like `eciesjs` may execute first.
+
+Add this to `polyfills.ts` and import it early (after `react-native-get-random-values`, before other
+imports):
+
+```typescript
+import { Buffer } from 'buffer'
+global.Buffer = Buffer
+```
+
+### `crypto.getRandomValues is not a function`
+
+`react-native-get-random-values` is either not installed or not imported as the very first import.
+
+Import it as the **first line** of your entry file, before any other import:
+
+```typescript
+import 'react-native-get-random-values'
+// all other imports follow
+```
+
+### `Event is not defined` / `CustomEvent is not defined`
+
+React Native does not provide `Event` or `CustomEvent` globals.
+These polyfills are **only required when using wagmi** — the Connect packages themselves use
+`eventemitter3` internally and do not need DOM events.
+
+If you use wagmi, add `Event` and `CustomEvent` polyfills in your polyfills file.
+See [React Native Metro polyfill issues](metro-polyfill-issues.md) for the full polyfill code.
+
+### Deeplinks not opening MetaMask app
+
+The `mobile.preferredOpenLink` callback is not configured.
+
+Pass a function that calls `Linking.openURL`:
+
+```typescript
+import { Linking } from 'react-native'
+
+const client = await createEVMClient({
+  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
+  mobile: {
+    preferredOpenLink: deeplink => Linking.openURL(deeplink),
+  },
+})
+```
+
+### App crashes on import of SDK
+
+Metro cannot resolve Node.js built-in modules (`stream`, `crypto`, `http`, etc.) that SDK
+dependencies reference.
+
+Add `extraNodeModules` shims in `metro.config.js`.
+See [React Native Metro polyfill issues](metro-polyfill-issues.md) for the full Metro configuration.
+
+## Diagnostic checklist
+
+Run through this checklist when any MetaMask Connect integration is misbehaving:
+
+- [ ] `supportedNetworks` has valid RPC URLs for every chain the dapp uses.
+- [ ] Chain IDs are hex strings for EVM (`'0x1'`, not `1` or `'1'`).
+- [ ] Polyfills loaded (React Native): `react-native-get-random-values` is first entry-file
+      import; `window` shim present; `Event`/`CustomEvent` shims present **only if using wagmi**;
+      `Buffer` set as safety net for peer deps.
+- [ ] `preferredOpenLink` set (React Native) for deeplinks to open MetaMask Mobile.
+- [ ] Import order correct: polyfills before SDK imports; `react-native-get-random-values` is the
+      very first import.
+- [ ] Error codes handled in catch blocks: at minimum handle `4001` (user rejected) and `-32002`
+      (pending).
+- [ ] Singleton client not recreated: `createEVMClient` / `createMultichainClient` called once;
+      subsequent calls merge into existing instance.
+- [ ] `display_uri` listener registered before `connect()` in headless mode for QR codes.
+- [ ] Solana `wallets` prop is `[]`: MetaMask uses wallet-standard discovery, not manual registration.
+- [ ] Solana devnet/testnet only supported in the browser extension, not mobile.
+- [ ] `debug: true` enabled in client options for verbose console output when debugging.
+
+## Next steps
+
+- [React Native Metro polyfill issues](metro-polyfill-issues.md)
+- [EVM quickstart](../evm/quickstart/javascript.md)
+- [Solana quickstart](../solana/quickstart/javascript.md)
+- [Production readiness checklist](../evm/guides/best-practices/production-readiness.md)

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -92,7 +92,7 @@ Look for error code `-32002` and show a "check MetaMask" message instead of retr
 
 ### User rejected request (code `4001`)
 
-The user clicked "Reject" in MetaMask. This is normal behavior.
+The user selected **Reject** in MetaMask. This is normal behavior.
 
 Handle gracefully by showing a retry button.
 Do not treat this as an application error:

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -175,7 +175,7 @@ const client = await createEVMClient({
 ### MetaMask wallet not appearing in Solana wallet adapter
 
 **Cause A:** `createSolanaClient` has not resolved before the `WalletProvider` renders.
-MetaMask uses the wallet-standard auto-discovery protocol, but the wallet must be registered before
+MetaMask uses the Wallet Standard auto-discovery protocol, but the wallet must be registered before
 discovery runs.
 
 **Fix:** Await client creation before rendering your app:
@@ -185,7 +185,7 @@ import { createSolanaClient } from '@metamask/connect-solana'
 
 async function bootstrap() {
   await createSolanaClient({
-    dapp: { name: 'My DApp', url: window.location.href },
+    dapp: { name: 'My Dapp', url: window.location.href },
   })
   const root = createRoot(document.getElementById('root'))
   root.render(<App />)

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -144,11 +144,11 @@ const client = await createEVMClient({
 **Cause A:** Headless mode is enabled but no `display_uri` listener is registered.
 The SDK generates the URI but has nowhere to render it.
 
-**Fix:** Register a `display_uri` listener **before** calling `connect()`:
+**Fix:** Register a `display_uri` listener **before** calling `connect`:
 
 ```javascript
 const client = await createEVMClient({
-  dapp: { name: 'My DApp' },
+  dapp: { name: 'My Dapp' },
   ui: { headless: true },
 })
 

--- a/metamask-connect/troubleshooting/metro-polyfill-issues.md
+++ b/metamask-connect/troubleshooting/metro-polyfill-issues.md
@@ -260,7 +260,7 @@ If MetaMask Mobile does not open when your dapp initiates a connection, the `mob
 import { Linking } from 'react-native'
 
 const client = await createEVMClient({
-  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
+  dapp: { name: 'My Dapp', url: 'https://mydapp.com' },
   mobile: {
     preferredOpenLink: deeplink => Linking.openURL(deeplink),
   },

--- a/metamask-connect/troubleshooting/metro-polyfill-issues.md
+++ b/metamask-connect/troubleshooting/metro-polyfill-issues.md
@@ -1,6 +1,6 @@
 ---
 title: React Native Metro Polyfill Issues - MetaMask Connect
-description: Resolve bundler polyfill issues when using MetaMask Connect packages with React Native Metro.
+description: Resolve Metro bundler polyfills, import order, and React Native issues such as deeplinks when using MetaMask Connect.
 sidebar_label: React Native Metro polyfill issues
 keywords:
   [
@@ -16,6 +16,8 @@ keywords:
     Event,
     CustomEvent,
     crypto,
+    deeplink,
+    preferredOpenLink,
   ]
 ---
 
@@ -25,9 +27,11 @@ import TabItem from "@theme/TabItem";
 # React Native Metro polyfill issues
 
 React Native uses the Metro bundler, which cannot resolve Node.js built-in modules.
-MetaMask Connect packages and their dependencies reference modules like `stream`, `crypto`, `buffer`, and `http`, and also rely on browser globals (`window`, `Event`, `CustomEvent`) that do not exist in React Native.
+MetaMask Connect packages and their dependencies reference modules like `stream`, `crypto`, `buffer`, and `http`.
+Some code paths expect a browser-like `window` object, which React Native does not provide.
+MetaMask Connect uses `eventemitter3` internally and does not require DOM `Event` or `CustomEvent` globals; if you use **wagmi**, you may need to polyfill those separately.
 
-This guide walks through the required polyfills and Metro configuration.
+This guide walks through the required polyfills, Metro configuration, and related React Native setup (including deeplinks to MetaMask Mobile).
 
 :::info Expo-managed workflow
 Polyfilling is not supported with the "Expo Go" app.
@@ -125,7 +129,11 @@ module.exports = config
 
 ### 3. Create the polyfills file
 
-Create `polyfills.ts` at the project root (or `src/polyfills.ts`) with all required global shims:
+Create `polyfills.ts` at the project root (or `src/polyfills.ts`) with the following global shims.
+
+#### Base polyfills (MetaMask Connect)
+
+These cover `Buffer`, `crypto.getRandomValues` (via your entry import), and a minimal `window` shim:
 
 ```typescript title="polyfills.ts"
 import { Buffer } from 'buffer'
@@ -161,7 +169,13 @@ if (typeof windowObj.dispatchEvent !== 'function') {
 if (typeof global !== 'undefined') {
   global.window = windowObj
 }
+```
 
+#### Optional wagmi polyfills for Event and CustomEvent
+
+If you use **wagmi**, add the following to `polyfills.ts` after the `window` shim (React Native does not provide DOM `Event` or `CustomEvent`, which wagmi-related code may expect):
+
+```typescript
 // Polyfill Event if missing
 if (typeof global.Event === 'undefined') {
   class EventPolyfill {
@@ -238,6 +252,23 @@ import '../polyfills' // Must be second
   </TabItem>
 </Tabs>
 
+## Deeplinks not opening MetaMask app
+
+If MetaMask Mobile does not open when your dapp initiates a connection, the `mobile.preferredOpenLink` callback is probably not set. Pass a function that calls `Linking.openURL`:
+
+```typescript
+import { Linking } from 'react-native'
+
+const client = await createEVMClient({
+  dapp: { name: 'My DApp', url: 'https://mydapp.com' },
+  mobile: {
+    preferredOpenLink: deeplink => Linking.openURL(deeplink),
+  },
+})
+```
+
+Use the same `mobile.preferredOpenLink` pattern with [`createMultichainClient`](../multichain/reference/methods.md) or [`createSolanaClient`](../solana/reference/methods.md) when you initialize those clients in React Native.
+
 ## Common errors and solutions
 
 ### `crypto.getRandomValues is not a function`
@@ -248,9 +279,9 @@ import '../polyfills' // Must be second
 
 ### `Buffer is not defined`
 
-**Cause**: The `Buffer` polyfill was not loaded before MetaMask Connect accessed it.
+**Cause**: The `Buffer` polyfill was not loaded before something in the bundle accessed `Buffer`, or a peer dependency (for example `eciesjs`) ran before MetaMask Connect’s React Native entry could apply its own `Buffer` shim.
 
-**Fix**: Ensure `global.Buffer = Buffer` is set in your polyfills file, and the polyfills file is imported immediately after `react-native-get-random-values`.
+**Fix**: Set `global.Buffer = Buffer` in your polyfills file, and import that file immediately after `react-native-get-random-values` so the global is defined before other imports run.
 
 ### `Cannot resolve module 'stream'` (or `crypto`, `http`, etc.)
 
@@ -260,9 +291,9 @@ import '../polyfills' // Must be second
 
 ### `Event is not defined` or `CustomEvent is not defined`
 
-**Cause**: React Native does not provide browser `Event`/`CustomEvent` classes that MetaMask Connect's internal event system requires.
+**Cause**: React Native does not provide browser `Event` or `CustomEvent` classes. This typically appears when using **wagmi** (or another dependency that expects DOM events). MetaMask Connect uses `eventemitter3` internally and does not require these globals.
 
-**Fix**: Ensure the `Event` and `CustomEvent` polyfills are included in your polyfills file as shown in [Step 3](#3-create-the-polyfills-file).
+**Fix**: If you use wagmi, append the `Event` and `CustomEvent` polyfills from [Optional wagmi polyfills for Event and CustomEvent](#optional-wagmi-polyfills-for-event-and-customevent) to your `polyfills.ts` after the base `window` shim.
 
 ### Expo Go not working
 

--- a/mm-connect-sidebar.js
+++ b/mm-connect-sidebar.js
@@ -74,7 +74,11 @@ const metamaskConnectSidebar = {
       label: 'Guides',
       collapsible: false,
       collapsed: false,
-      items: ['multichain/guides/sign-transactions', 'multichain/guides/send-transactions'],
+      items: [
+        'multichain/guides/sign-transactions',
+        'multichain/guides/send-transactions',
+        'multichain/guides/headless-mode',
+      ],
     },
     {
       type: 'category',
@@ -278,6 +282,7 @@ const metamaskConnectSidebar = {
           items: [
             'solana/guides/send-legacy-transaction',
             'solana/guides/send-versioned-transaction',
+            'solana/guides/batch-transactions',
           ],
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8994,6 +8994,7 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@metamask/sdk/-/sdk-0.33.1.tgz",
       "integrity": "sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==",
+      "deprecated": "No longer maintained, superseded by https://docs.metamask.io/metamask-connect",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@metamask/onboarding": "^1.0.1",


### PR DESCRIPTION
# Description

Add a new Multichain headless-mode guide and a Solana batch-transactions guide; expand troubleshooting and several SDK docs. Updates include: headless-mode guide describing display_uri flow and UI.headless usage; new Solana signAndSendAllTransactions guidance and Chrome Android cautions; added Wallet Adapter timing tip and Chrome Android warning; expanded Multichain methods reference with error classes and getSession access; small EVM/Multichain quickstart copy edits (base64Icon guidance) and migrate-from-sdk event docs; register new guides in the sidebar. Also apply minor copy/formatting edits across related docs.

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only (new guides and copy/clarity updates) with no runtime code changes; the main risk is confusing users if any API details are inaccurate.
> 
> **Overview**
> Adds new documentation for **Multichain headless mode** (custom QR/deeplink UI via `ui.headless` and `display_uri`) and a **Solana batch transactions** guide using `solana:signAndSendAllTransactions`.
> 
> Expands docs to clarify event semantics/naming (`displayUri` vs `display_uri`), `getSession` access via `client.provider.getSession()`, and available Multichain typed error classes (`RpcError`, `ProtocolError`, `StorageError`).
> 
> Broadens `troubleshooting/index.md` from React Native polyfills to connection/session diagnostics (error code table, headless/QR pitfalls, session restore, partial disconnect, Solana wallet-adapter timing + Chrome Android cautions), wires the new guides into `mm-connect-sidebar.js`, and applies small consistency/copy edits (e.g., “Dapp” naming, `base64Icon` note, Wallet Standard capitalization) plus a `package-lock.json` deprecation note for `@metamask/sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80a0ad998d163ce14c02c4340a055d40b65d8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->