### PR TITLE
Docs: Add CSP QR-code troubleshooting

### DIFF
--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -194,16 +194,16 @@ A minimal working policy looks like:
   " />
 ```
 
-- `data:` in `connect-src` and `img-src` — required for the fox SVG embedded in the QR code.
-- `wss://mm-sdk-relay.api.cx.metamask.io` — the relay used for remote (no-extension and mobile)
+- `data:` in `connect-src` and `img-src` - Required for the fox SVG embedded in the QR code.
+- `wss://mm-sdk-relay.api.cx.metamask.io` - The relay used for remote (no-extension and mobile)
   connections.
-- `https://mm-sdk-analytics.api.cx.metamask.io` — the default analytics endpoint emitted during the
+- `https://mm-sdk-analytics.api.cx.metamask.io` - The default analytics endpoint emitted during the
   connection lifecycle.
-- `style-src 'unsafe-inline'` — `@metamask/multichain-ui` injects component styles at runtime
+- `style-src 'unsafe-inline'` - `@metamask/multichain-ui` injects component styles at runtime
   inside Shadow DOM (Stencil).
 
-For the full reference, see the
-[Content Security Policy section of the connect-monorepo README](https://github.com/MetaMask/connect-monorepo#content-security-policy).
+For the full reference, see
+[Content Security Policy](https://github.com/MetaMask/connect-monorepo#content-security-policy) in `metamask/connect-monorepo`.
 
 ### MetaMask wallet not appearing in Solana wallet adapter
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -173,6 +173,38 @@ const client = await createEVMClient({
 })
 ```
 
+**Cause C:** A strict Content Security Policy (CSP) is blocking the QR code from rendering.
+The QR code embeds the MetaMask fox SVG as a `data:` URI, which `@metamask/multichain-ui`
+materializes via a `fetch`-style call.
+A CSP without `data:` in `connect-src` (or `img-src`) blocks this and the QR code fails to appear.
+A symptom in the browser console looks like:
+
+`Refused to connect to 'data:image/svg+xml;base64,...' because it violates the following Content Security Policy directive: "connect-src 'self' https: wss:".`
+
+**Fix:** Allow the `data:` scheme and the MetaMask relay and analytics origins in your CSP.
+A minimal working policy looks like:
+
+```html
+<meta
+  http-equiv="Content-Security-Policy"
+  content="
+    connect-src 'self' data: https://*.infura.io wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io;
+    img-src 'self' data:;
+    style-src 'self' 'unsafe-inline';
+  " />
+```
+
+- `data:` in `connect-src` and `img-src` — required for the fox SVG embedded in the QR code.
+- `wss://mm-sdk-relay.api.cx.metamask.io` — the relay used for remote (no-extension and mobile)
+  connections.
+- `https://mm-sdk-analytics.api.cx.metamask.io` — the default analytics endpoint emitted during the
+  connection lifecycle.
+- `style-src 'unsafe-inline'` — `@metamask/multichain-ui` injects component styles at runtime
+  inside Shadow DOM (Stencil).
+
+For the full reference, see the
+[Content Security Policy section of the connect-monorepo README](https://github.com/MetaMask/connect-monorepo#content-security-policy).
+
 ### MetaMask wallet not appearing in Solana wallet adapter
 
 **Cause A:** `createSolanaClient` has not resolved before the `WalletProvider` renders.


### PR DESCRIPTION
# Description

Add a new troubleshooting 'Cause C' that explains how a strict Content Security Policy can prevent the MetaMask QR code from rendering (the fox SVG is embedded as a data: URI and materialized via a fetch-style call). The entry documents the console error, outlines the required CSP directives (allow data: in connect-src/img-src, include mm-sdk relay and analytics origins, and style-src 'unsafe-inline'), provides a minimal meta-tag example, and links to the connect-monorepo CSP reference.

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main risk is integrators misconfiguring CSP if the example is copied without adapting to their environment.
> 
> **Overview**
> Adds a new *QR code not appearing* troubleshooting entry describing how strict CSP settings can block the QR code (due to a `data:` URI SVG and related network requests), including the expected console error.
> 
> Documents a minimal CSP example and explicitly calls out required directives/origins (`data:` in `connect-src`/`img-src`, MetaMask relay + analytics endpoints, and `style-src 'unsafe-inline'`), with a link to the full CSP reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fac99418983b1e40df1937816316695c771e24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->