### PR TITLE
Update cursor rules glob patterns

### DIFF
--- a/.cursor/rules/content-types.mdc
+++ b/.cursor/rules/content-types.mdc
@@ -1,6 +1,6 @@
 ---
 description: Maps folder conventions to Diataxis content types so AI tools produce the right structure for each doc category.
-globs: ["**/*.md", "**/*.mdx"]
+globs: **/*.md,**/*.mdx
 alwaysApply: false
 ---
 

--- a/.cursor/rules/editorial-voice.mdc
+++ b/.cursor/rules/editorial-voice.mdc
@@ -1,6 +1,6 @@
 ---
 description: Editorial voice and tone rules aligned with the Microsoft Writing Style Guide and Consensys documentation standards.
-globs: ["**/*.md", "**/*.mdx"]
+globs: **/*.md,**/*.mdx
 alwaysApply: false
 ---
 
@@ -44,12 +44,14 @@ The rules below are the most actionable subset for AI-assisted editing.
 
 ## Punctuation and formatting
 
-- Do not use em dashes or en dashes. Use commas, parentheses, semicolons, or rephrase the sentence.
+- Do not use em dashes (—) to set off extra information. Use commas, parentheses, semicolons, or rephrase the sentence.
 - Use only one space after periods, question marks, and colons.
 - Use sentence case for all headings and titles. Never use title case.
 - Do not end headings, subheadings, or UI titles with periods.
 - Use backticks for inline code, file names, and URLs referenced in prose.
-- Use bold for UI element names (buttons, menu items, field labels).
+- In general, do not use bold to emphasize words in a paragraph. Use bold sparingly:
+  - For UI element names (buttons, menu items, field labels).
+  - For emphasis in exceptional cases such as critical security warnings when an admonition is not enough.
 
 ## Developer content
 

--- a/.cursor/rules/markdown-formatting.mdc
+++ b/.cursor/rules/markdown-formatting.mdc
@@ -1,6 +1,6 @@
 ---
 description: Markdown formatting conventions for the MetaMask documentation site (Docusaurus).
-globs: ["**/*.md", "**/*.mdx"]
+globs: **/*.md,**/*.mdx
 alwaysApply: false
 ---
 

--- a/.cursor/rules/product-embedded-wallets.mdc
+++ b/.cursor/rules/product-embedded-wallets.mdc
@@ -1,6 +1,6 @@
 ---
 description: Product-specific guidance for Embedded Wallets documentation, including naming, content organization, and SDK conventions.
-globs: ["embedded-wallets/**/*.md", "embedded-wallets/**/*.mdx"]
+globs: embedded-wallets/**/*.md,embedded-wallets/**/*.mdx
 alwaysApply: false
 ---
 
@@ -22,10 +22,9 @@ Embedded Wallets uses domain-oriented folders rather than strict Diataxis catego
 
 | Folder               | Content                                          |
 |----------------------|--------------------------------------------------|
-| Root (`README.mdx`)  | Product overview and positioning                 |
+| Root (`README.mdx`)  | Product overview, positioning, and capability summary |
 | `sdk/`               | Per-platform integration docs (React, Vue, JS, Node, Android, iOS, React Native, Flutter, Unity, Unreal) |
 | `authentication/`    | Auth methods by type (social, basic, custom)     |
-| `features/`          | Product capabilities (MPC, smart accounts, funding, NFT minting, session management) |
 | `dashboard/`         | Developer console and project configuration      |
 | `connect-blockchain/`| Chain-specific connection guides (EVM, Solana, other) |
 | `infrastructure/`    | Architecture and security (MPC, SSS, nodes)      |

--- a/.cursor/rules/product-embedded-wallets.mdc
+++ b/.cursor/rules/product-embedded-wallets.mdc
@@ -22,9 +22,10 @@ Embedded Wallets uses domain-oriented folders rather than strict Diataxis catego
 
 | Folder               | Content                                          |
 |----------------------|--------------------------------------------------|
-| Root (`README.mdx`)  | Product overview, positioning, and capability summary |
+| Root (`README.mdx`)  | Product overview and positioning                 |
 | `sdk/`               | Per-platform integration docs (React, Vue, JS, Node, Android, iOS, React Native, Flutter, Unity, Unreal) |
 | `authentication/`    | Auth methods by type (social, basic, custom)     |
+| `features/`          | Product capabilities (MPC, smart accounts, funding, NFT minting, session management) |
 | `dashboard/`         | Developer console and project configuration      |
 | `connect-blockchain/`| Chain-specific connection guides (EVM, Solana, other) |
 | `infrastructure/`    | Architecture and security (MPC, SSS, nodes)      |

--- a/.cursor/rules/product-metamask-connect.mdc
+++ b/.cursor/rules/product-metamask-connect.mdc
@@ -1,6 +1,6 @@
 ---
 description: Product-specific guidance for MetaMask Connect documentation, including terminology, CAIP standards, and content organization.
-globs: ["metamask-connect/**/*.md", "metamask-connect/**/*.mdx"]
+globs: metamask-connect/**/*.md,metamask-connect/**/*.mdx
 alwaysApply: false
 ---
 

--- a/.cursor/rules/product-services.mdc
+++ b/.cursor/rules/product-services.mdc
@@ -1,6 +1,6 @@
 ---
 description: Product-specific guidance for Services (Infura) documentation, including naming, reference conventions, and partial reuse.
-globs: ["services/**/*.md", "services/**/*.mdx"]
+globs: services/**/*.md,services/**/*.mdx
 alwaysApply: false
 ---
 

--- a/.cursor/rules/product-smart-accounts-kit.mdc
+++ b/.cursor/rules/product-smart-accounts-kit.mdc
@@ -1,12 +1,6 @@
 ---
 description: Product-specific guidance for Smart Accounts Kit documentation, including terminology, delegation concepts, glossary/tooltips, and versioning.
-globs:
-  [
-    'smart-accounts-kit/**/*.md',
-    'smart-accounts-kit/**/*.mdx',
-    'src/lib/glossary.json',
-    'scripts/generate-smart-accounts-glossary.js',
-  ]
+globs: smart-accounts-kit/**/*.md,smart-accounts-kit/**/*.mdx,src/lib/glossary.json
 alwaysApply: false
 ---
 

--- a/.cursor/rules/product-snaps.mdc
+++ b/.cursor/rules/product-snaps.mdc
@@ -1,6 +1,6 @@
 ---
 description: Product-specific guidance for Snaps documentation, including naming, content areas, and generated-content constraints.
-globs: ["snaps/**/*.md", "snaps/**/*.mdx"]
+globs: snaps/**/*.md,snaps/**/*.mdx
 alwaysApply: false
 ---
 

--- a/.cursor/rules/terminology.mdc
+++ b/.cursor/rules/terminology.mdc
@@ -1,6 +1,6 @@
 ---
 description: Required spelling and casing for product names, industry terms, and standards referenced across MetaMask documentation.
-globs: ['**/*.md', '**/*.mdx']
+globs: **/*.md,**/*.mdx
 alwaysApply: false
 ---
 


### PR DESCRIPTION
# Description

<!-- Describe the changes made in your pull request (PR). -->

Cursor appears not to be applying all rules properly, possibly because of bad glob patterns. This PR updates to proper syntax (seems to be confusing for many: https://forum.cursor.com/t/correct-way-to-specify-rules-globs/71752).

Before:
<img width="560" height="222" alt="Screenshot 2026-04-22 at 4 21 21 PM" src="https://github.com/user-attachments/assets/09c48242-ba6a-4718-8610-f25125759052" />

After:
<img width="424" height="216" alt="Screenshot 2026-04-22 at 4 21 28 PM" src="https://github.com/user-attachments/assets/a87540a9-955c-4c21-9002-a585d1f5f0fd" />


## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to Cursor rule metadata and should only affect which files the editor applies rules to. Main risk is unintended widening/narrowing of rule scope due to the new glob strings.
> 
> **Overview**
> Updates Cursor rule frontmatter `globs` fields to use Cursor’s supported comma-separated syntax (for `**/*.md`/`**/*.mdx` and product-specific paths), improving rule matching across the docs.
> 
> Also refines the `editorial-voice` guidance by clarifying the em-dash rule and tightening when bold is allowed, and removes the `scripts/generate-smart-accounts-glossary.js` glob from the Smart Accounts Kit rule scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619c424e11cc71554bec4d350bd799799490db58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->