### PR TITLE
Update new URL and method for backend verification

### DIFF
--- a/embedded-wallets/authentication/id-token.mdx
+++ b/embedded-wallets/authentication/id-token.mdx
@@ -132,6 +132,25 @@ To validate an ID token server-side, use Web3Auth's JWKS endpoint or project-spe
 
 ### Using the JWKS endpoint
 
+:::warning Always validate `issuer` and `audience`
+
+Every JWKS-based verification call **must** include both `issuer` and `audience` options:
+
+- **`audience`** must equal your **Project Client ID**. Without it, a token issued by Web3Auth for any other project will pass signature verification — because all projects share the same signing infrastructure.
+- **`issuer`** must match the Web3Auth endpoint that issued the token (`https://api-auth.web3auth.io` for social logins, `https://authjs.web3auth.io` for external wallets).
+
+**Who is at risk without `audience` validation?**
+
+| User identifier used by dapp | Exploitable without `aud`? | Reason |
+|---|---|---|
+| `userId` / `email` / `authConnectionId` | **Yes** | These claims are set by verifier configuration, which an attacker controls via their own project |
+| `wallets[].public_key` (app-scoped key) | No | App keys are derived per-project; a different project produces different keys |
+| `wallets[].address` (on-chain address) | No | Bound to the user's cryptographic keys, cannot be forged |
+
+If your backend matches users by `userId`, `email`, or `authConnectionId` — the common pattern for Web2-style user management — always validate `audience`.
+
+:::
+
 <Tabs>
 <TabItem value="Social Login">
 
@@ -161,9 +180,14 @@ export async function POST(req: NextRequest) {
 
     //focus-start
     // Verify JWT using Web3Auth JWKS
-    // highlight-next-line
+    // highlight-start
     const jwks = jose.createRemoteJWKSet(new URL('https://api-auth.web3auth.io/jwks'))
-    const { payload } = await jose.jwtVerify(idToken, jwks, { algorithms: ['ES256'] })
+    const { payload } = await jose.jwtVerify(idToken, jwks, {
+      algorithms: ['ES256'],
+      issuer: 'https://api-auth.web3auth.io',
+      audience: process.env.WEB3AUTH_CLIENT_ID,
+    })
+    // highlight-end
 
     // Find matching wallet in JWT
     const wallets = (payload as any).wallets || []
@@ -232,9 +256,14 @@ export async function POST(req: NextRequest) {
 
     //focus-start
     // Verify JWT using AuthJS JWKS
-    // highlight-next-line
+    // highlight-start
     const jwks = jose.createRemoteJWKSet(new URL('https://authjs.web3auth.io/jwks'))
-    const { payload } = await jose.jwtVerify(idToken, jwks, { algorithms: ['ES256'] })
+    const { payload } = await jose.jwtVerify(idToken, jwks, {
+      algorithms: ['ES256'],
+      issuer: 'https://authjs.web3auth.io',
+      audience: process.env.WEB3AUTH_CLIENT_ID,
+    })
+    // highlight-end
 
     // Find matching wallet in JWT
     const wallets = (payload as any).wallets || []
@@ -390,7 +419,7 @@ If the token is valid, the payload will contain identity claims (such as, userId
 
 ## Troubleshooting
 
-- The `iss` field in the token must be `https://api-auth.web3auth.io`.
-- The `aud` field must match your **Project Client ID**.
-- The `exp` field must be in the future.
-- The `iat` field must be in the past.
+- Validate that `iss` equals `https://api-auth.web3auth.io` (social logins) or `https://authjs.web3auth.io` (external wallets). A mismatch means the token was not issued by the expected Web3Auth service.
+- Validate that `aud` equals your **Project Client ID**. A mismatch means the token was issued for a different project and must be rejected.
+- Validate that `exp` is in the future. Expired tokens must be rejected.
+- Validate that `iat` is in the past. A future `iat` indicates a malformed or tampered token.

--- a/embedded-wallets/dashboard/advanced/session-management.mdx
+++ b/embedded-wallets/dashboard/advanced/session-management.mdx
@@ -258,7 +258,11 @@ import jwt from 'jsonwebtoken'
 // Validate session token
 function validateSession(token) {
   try {
-    const decoded = jwt.verify(token, publicKey)
+    const decoded = jwt.verify(token, publicKey, {
+      algorithms: ['ES256'],
+      issuer: 'https://api-auth.web3auth.io',
+      audience: process.env.WEB3AUTH_CLIENT_ID,
+    })
     const now = Math.floor(Date.now() / 1000)
 
     if (decoded.exp < now) {

--- a/embedded-wallets/dashboard/advanced/user-details.mdx
+++ b/embedded-wallets/dashboard/advanced/user-details.mdx
@@ -45,7 +45,7 @@ When **enabled**, the identity token includes comprehensive user profile informa
 
 ```json
 {
-  "iss": "https://api.web3auth.io",
+  "iss": "https://api-auth.web3auth.io",
   "sub": "user_unique_identifier",
   "aud": "your_client_id",
   "exp": 1640995200,
@@ -68,7 +68,7 @@ When **disabled**, the identity token contains only essential identification inf
 
 ```json
 {
-  "iss": "https://api.web3auth.io",
+  "iss": "https://api-auth.web3auth.io",
   "sub": "user_unique_identifier",
   "aud": "your_client_id",
   "exp": 1640995200,
@@ -83,7 +83,7 @@ When **userIdentifier is set to email**, only the user's email is included in th
 
 ```json
 {
-  "iss": "https://api.web3auth.io",
+  "iss": "https://api-auth.web3auth.io",
   "sub": "user_unique_identifier",
   "aud": "your_client_id",
   "exp": 1640995200,
@@ -106,7 +106,7 @@ async function processUserToken(idToken) {
   try {
     // Verify and decode the token
     const decoded = jwt.verify(idToken, publicKey, {
-      issuer: 'https://api.web3auth.io',
+      issuer: 'https://api-auth.web3auth.io',
       audience: 'your_client_id',
     })
 

--- a/embedded-wallets/dashboard/project-settings.mdx
+++ b/embedded-wallets/dashboard/project-settings.mdx
@@ -131,7 +131,7 @@ A public endpoint that exposes the JSON Web Key Set (JWKS) used by Web3Auth to s
 Pass the request to the JWKS endpoint with your project ID as the identifier:
 
 ```
-https://api.web3auth.io/jwks?project_id=<YOUR_PROJECT_ID>
+https://api-auth.web3auth.io/jwks
 ```
 
 ##### Implementation example
@@ -141,7 +141,7 @@ import jwt from 'jsonwebtoken'
 import jwksClient from 'jwks-rsa'
 
 const client = jwksClient({
-  jwksUri: 'https://api.web3auth.io/jwks?project_id=YOUR_PROJECT_ID',
+  jwksUri: 'https://api-auth.web3auth.io/jwks',
 })
 
 function getKey(header, callback) {
@@ -152,13 +152,22 @@ function getKey(header, callback) {
 }
 
 // Verify token
-jwt.verify(token, getKey, options, (err, decoded) => {
-  if (err) {
-    console.error('Token verification failed:', err)
-  } else {
-    console.log('Token verified:', decoded)
-  }
-})
+jwt.verify(
+  token,
+  getKey,
+  {
+    algorithms: ['ES256'],
+    issuer: 'https://api-auth.web3auth.io',
+    audience: process.env.WEB3AUTH_CLIENT_ID,
+  },
+  (err, decoded) => {
+    if (err) {
+      console.error('Token verification failed:', err)
+    } else {
+      console.log('Token verified:', decoded)
+    }
+  },
+)
 ```
 
 ### Project verification key
@@ -187,13 +196,22 @@ YOUR_PROJECT_VERIFICATION_KEY_HERE
 -----END PUBLIC KEY-----`
 
 // Verify token with static key
-jwt.verify(token, PROJECT_VERIFICATION_KEY, { algorithms: ['RS256'] }, (err, decoded) => {
-  if (err) {
-    console.error('Token verification failed:', err)
-  } else {
-    console.log('Token verified:', decoded)
-  }
-})
+jwt.verify(
+  token,
+  PROJECT_VERIFICATION_KEY,
+  {
+    algorithms: ['ES256'],
+    issuer: 'https://api-auth.web3auth.io',
+    audience: process.env.WEB3AUTH_CLIENT_ID,
+  },
+  (err, decoded) => {
+    if (err) {
+      console.error('Token verification failed:', err)
+    } else {
+      console.log('Token verified:', decoded)
+    }
+  },
+)
 ```
 
 ## Project management


### PR DESCRIPTION
Fix missing issuer and audience validation in JWKS-based JWT verification examples across the Embedded Wallets documentation. Without these checks, a token signed by Web3Auth for any other project passes signature verification, enabling cross-project token reuse against backends that identify users by userId, email, or authConnectionId.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change, but it updates security-critical guidance; incorrect values could cause token verification failures or misconfiguration if not reviewed carefully.
> 
> **Overview**
> Updates Embedded Wallets docs to **require `issuer` and `audience` validation** in all JWKS-based JWT verification examples, and explains the cross-project token reuse risk when `aud` is not checked.
> 
> Refreshes examples and troubleshooting to use the correct endpoints/issuers (e.g., `https://api-auth.web3auth.io/jwks` for social logins and `https://authjs.web3auth.io/jwks` for external wallets), and aligns `jsonwebtoken`/`jose` snippets to pass `algorithms: ['ES256']`, `issuer`, and `audience` consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d91b25914030ee78fb599f607710ff0601150b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->