### PR TITLE
Remove ERC-20 token revocation permission

### DIFF
--- a/gator_versioned_docs/version-1.2.0/get-started/supported-advanced-permissions.md
+++ b/gator_versioned_docs/version-1.2.0/get-started/supported-advanced-permissions.md
@@ -16,6 +16,5 @@ emailing [hellogators@consensys.net](mailto:hellogators@consensys.net).
 | ------------------------------------------------------------------------------------------------------------------------ | ------------------ | -------------- | ----------- |
 | [ERC-20 periodic](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-periodic-permission)              | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
 | [ERC-20 stream](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-stream-permission)                  | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
-| [ERC-20 revocation](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-revocation-permission)          | >= v0.3.0          | >= v13.14.0    | >= 13.18.1  |
 | [Native token periodic](../guides/advanced-permissions/use-permissions/native-token.md#native-token-periodic-permission) | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
 | [Native token stream](../guides/advanced-permissions/use-permissions/native-token.md#native-token-stream-permission)     | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |

--- a/gator_versioned_docs/version-1.2.0/guides/advanced-permissions/use-permissions/erc20-token.md
+++ b/gator_versioned_docs/version-1.2.0/guides/advanced-permissions/use-permissions/erc20-token.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to use the ERC-20 token permissions with Advanced Permissions (ERC-7715).
-keywords: [permissions, spending limit, restrict, 7715, erc-7715, erc20-permissions, revocation]
+keywords: [permissions, spending limit, restrict, 7715, erc-7715, erc20-permissions]
 ---
 
 import Tabs from "@theme/Tabs";
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 # Use ERC-20 token permissions
 
 [Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports ERC-20 token permission types that allow you to request fine-grained
-permissions for ERC-20 token transfers with time-based (periodic), streaming, or revocation conditions, depending on your use case.
+permissions for ERC-20 token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites
 
@@ -148,56 +148,3 @@ export const walletClient = createWalletClient({
 </TabItem>
 </Tabs>
 
-## ERC-20 revocation permission
-
-This permission type enables revoking an existing ERC-20 token allowance on behalf of the user.
-
-For example, a user signs an ERC-7715 permission that lets a dapp revoke any ERC-20 token allowances
-periodically, or during an ongoing exploit.
-
-See the [ERC-20 revocation permission API reference](../../../reference/advanced-permissions/permissions.md#erc-20-revocation-permission) for more information.
-
-<Tabs>
-<TabItem value="example.ts">
-
-```typescript
-import { sepolia as chain } from 'viem/chains'
-import { walletClient } from './client.ts'
-
-// Since current time is in seconds, convert milliseconds to seconds.
-const currentTime = Math.floor(Date.now() / 1000)
-// 1 week from now.
-const expiry = currentTime + 604800
-
-const grantedPermissions = await walletClient.requestExecutionPermissions([
-  {
-    chainId: chain.id,
-    expiry,
-    // The requested permissions will granted to the
-    // session account.
-    to: sessionAccount.address,
-    permission: {
-      type: 'erc20-token-revocation',
-      data: {
-        justification: 'Permission to revoke ERC-20 token allowances',
-      },
-      isAdjustmentAllowed: true,
-    },
-  },
-])
-```
-
-</TabItem>
-<TabItem value="client.ts">
-
-```typescript
-import { createWalletClient, custom } from 'viem'
-import { erc7715ProviderActions } from '@metamask/smart-accounts-kit/actions'
-
-export const walletClient = createWalletClient({
-  transport: custom(window.ethereum),
-}).extend(erc7715ProviderActions())
-```
-
-</TabItem>
-</Tabs>

--- a/gator_versioned_docs/version-1.2.0/reference/advanced-permissions/permissions.md
+++ b/gator_versioned_docs/version-1.2.0/reference/advanced-permissions/permissions.md
@@ -85,28 +85,6 @@ const permission = {
 }
 ```
 
-### ERC-20 revocation permission
-
-Enables revoking an existing ERC-20 token allowance on behalf of the user.
-
-#### Parameters
-
-| Name            | Type     | Required | Description                                                            |
-| --------------- | -------- | -------- | ---------------------------------------------------------------------- |
-| `justification` | `string` | No       | A human-readable explanation of why the permission is being requested. |
-
-#### Example
-
-```typescript
-const permission = {
-  type: 'erc20-token-revocation',
-  data: {
-    justification: 'Permission to revoke ERC-20 token allowances',
-  },
-  isAdjustmentAllowed: true,
-}
-```
-
 ## Native token permissions
 
 ### Native token periodic permission

--- a/smart-accounts-kit/get-started/supported-advanced-permissions.md
+++ b/smart-accounts-kit/get-started/supported-advanced-permissions.md
@@ -16,6 +16,5 @@ emailing [`hellogators@consensys.net`](mailto:hellogators@consensys.net).
 | ------------------------------------------------------------------------------------------------------------------------ | ------------------ | -------------- | ----------- |
 | [ERC-20 periodic](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-periodic-permission)              | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
 | [ERC-20 stream](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-stream-permission)                  | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
-| [ERC-20 revocation](../guides/advanced-permissions/use-permissions/erc20-token.md#erc-20-revocation-permission)          | >= v0.3.0          | >= v13.14.0    | >= 13.18.1  |
 | [Native token periodic](../guides/advanced-permissions/use-permissions/native-token.md#native-token-periodic-permission) | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |
 | [Native token stream](../guides/advanced-permissions/use-permissions/native-token.md#native-token-stream-permission)     | >= v0.1.0          | >= v13.5.0     | >= v13.23.0 |

--- a/smart-accounts-kit/guides/advanced-permissions/use-permissions/erc20-token.md
+++ b/smart-accounts-kit/guides/advanced-permissions/use-permissions/erc20-token.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to use the ERC-20 token permissions with Advanced Permissions (ERC-7715).
-keywords: [permissions, spending limit, restrict, 7715, erc-7715, erc20-permissions, revocation]
+keywords: [permissions, spending limit, restrict, 7715, erc-7715, erc20-permissions]
 ---
 
 import Tabs from "@theme/Tabs";
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 # Use ERC-20 token permissions
 
 [Advanced Permissions (ERC-7715)](../../../concepts/advanced-permissions.md) supports ERC-20 token permission types that allow you to request fine-grained
-permissions for ERC-20 token transfers with time-based (periodic), streaming, or revocation conditions, depending on your use case.
+permissions for ERC-20 token transfers with time-based (periodic) or streaming conditions, depending on your use case.
 
 ## Prerequisites
 
@@ -148,56 +148,3 @@ export const walletClient = createWalletClient({
 </TabItem>
 </Tabs>
 
-## ERC-20 revocation permission
-
-This permission type enables revoking an existing ERC-20 token allowance on behalf of the user.
-
-For example, a user signs an ERC-7715 permission that lets a dapp revoke any ERC-20 token allowances
-periodically, or during an ongoing exploit.
-
-See the [ERC-20 revocation permission API reference](../../../reference/advanced-permissions/permissions.md#erc-20-revocation-permission) for more information.
-
-<Tabs>
-<TabItem value="example.ts">
-
-```typescript
-import { sepolia as chain } from 'viem/chains'
-import { walletClient } from './client.ts'
-
-// Since current time is in seconds, convert milliseconds to seconds.
-const currentTime = Math.floor(Date.now() / 1000)
-// 1 week from now.
-const expiry = currentTime + 604800
-
-const grantedPermissions = await walletClient.requestExecutionPermissions([
-  {
-    chainId: chain.id,
-    expiry,
-    // The requested permissions will granted to the
-    // session account.
-    to: sessionAccount.address,
-    permission: {
-      type: 'erc20-token-revocation',
-      data: {
-        justification: 'Permission to revoke ERC-20 token allowances',
-      },
-      isAdjustmentAllowed: true,
-    },
-  },
-])
-```
-
-</TabItem>
-<TabItem value="client.ts">
-
-```typescript
-import { createWalletClient, custom } from 'viem'
-import { erc7715ProviderActions } from '@metamask/smart-accounts-kit/actions'
-
-export const walletClient = createWalletClient({
-  transport: custom(window.ethereum),
-}).extend(erc7715ProviderActions())
-```
-
-</TabItem>
-</Tabs>

--- a/smart-accounts-kit/reference/advanced-permissions/permissions.md
+++ b/smart-accounts-kit/reference/advanced-permissions/permissions.md
@@ -85,28 +85,6 @@ const permission = {
 }
 ```
 
-### ERC-20 revocation permission
-
-Enables revoking an existing ERC-20 token allowance on behalf of the user.
-
-#### Parameters
-
-| Name            | Type     | Required | Description                                                            |
-| --------------- | -------- | -------- | ---------------------------------------------------------------------- |
-| `justification` | `string` | No       | A human-readable explanation of why the permission is being requested. |
-
-#### Example
-
-```typescript
-const permission = {
-  type: 'erc20-token-revocation',
-  data: {
-    justification: 'Permission to revoke ERC-20 token allowances',
-  },
-  isAdjustmentAllowed: true,
-}
-```
-
 ## Native token permissions
 
 ### Native token periodic permission


### PR DESCRIPTION
# Description

Removes ERC-20 token revocation permission.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes references to an ERC-20 revocation permission; main risk is confusing users if the feature still exists elsewhere or external links now point to removed anchors.
> 
> **Overview**
> **Removes documentation for the `ERC-20 revocation` Advanced Permission type** across both current and `version-1.2.0` docs.
> 
> Updates the supported-permissions tables and the ERC-20 permissions guide/reference to drop the revocation section, examples, and related keywords, leaving only periodic and stream ERC-20 permission coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 863f264b3c1b60696eb63bc2b857cd980a8040b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->