### PR TITLE
Update docs links for Avalanche, Celo, and Sei

### DIFF
--- a/services/reference/avalanche-c-chain/json-rpc-methods/index.md
+++ b/services/reference/avalanche-c-chain/json-rpc-methods/index.md
@@ -16,5 +16,5 @@ Avalanche-specific methods (`avax.*`) that have a dependency on the P-Chain and 
 
 :::
 
-Refer to the [Avalanche documentation](https://docs.avax.network/api-reference/c-chain/api) for more
+Refer to the [Avalanche documentation](https://docs.avax.network/docs/rpcs/c-chain) for more
 information about supported methods.

--- a/services/reference/celo/index.md
+++ b/services/reference/celo/index.md
@@ -8,7 +8,7 @@ import CardList from '@site/src/components/CardList'
 
 :::note Decentralized Infrastructure Network (DIN)
 
-Celo is supported through the [DIN](https://www.din.build/) service,
+Celo is supported through the [DIN](https://www.infura.io/solutions/decentralized-infrastructure-service) service,
 meaning calls to the network are routed to [partner infrastructure providers](#partners-and-privacy-policies).
 
 :::

--- a/services/reference/sei/index.md
+++ b/services/reference/sei/index.md
@@ -18,7 +18,7 @@ parallelized EVM architecture, native order matching, and subsystems that addres
 limitations while maintaining Ethereum compatibility.
 
 :::info See also
-Refer to the [official Sei documentation](https://www.docs.sei.io/) for more information.
+Refer to the [official Sei documentation](https://docs.sei.io/) for more information.
 :::
 
 Select an option below to get started with the Sei network.

--- a/services/reference/sei/json-rpc-methods/index.md
+++ b/services/reference/sei/json-rpc-methods/index.md
@@ -9,5 +9,5 @@ sidebar_key: sei-json-rpc-api
 The standard Ethereum methods documented in this section are supported by Infura on the Sei network.
 
 :::info See also
-Refer to the [official Sei documentation](https://www.docs.sei.io/) for more information.
+Refer to the [official Sei documentation](https://docs.sei.io/) for more information.
 :::


### PR DESCRIPTION
# Description

Refresh external documentation links: update the Avalanche C-Chain docs URL to the new /docs/rpcs/c-chain path, replace the Celo DIN link with Infura's Decentralized Infrastructure Service page, and normalize the Sei documentation URLs (remove the redundant www). Documentation-only changes to keep external references current.



<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates; risk is limited to potential broken/incorrect external URLs and no runtime impact.
> 
> **Overview**
> Refreshes external references in network docs: updates the Avalanche C-Chain JSON-RPC link to the new `docs.avax.network/docs/rpcs/c-chain` path and points the Celo DIN reference at Infura’s Decentralized Infrastructure Service page.
> 
> Normalizes Sei documentation URLs (removes the `www` subdomain) in both the main Sei page and the Sei JSON-RPC methods page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80fedee7d8897e71e5149172a4e80e95a3c0543b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->