### PR TITLE
Clarify JSX usage in notifications expanded viewdocs: add note explai…

### DIFF
--- a/snaps/features/notifications.md
+++ b/snaps/features/notifications.md
@@ -67,6 +67,9 @@ Each Snap can trigger up to:
 
 In-app notifications can include an optional expanded view that displays when selected.
 The expanded view includes a title, [custom UI](custom-ui/index.md) content, and an optional footer link.
+Note that the `content` field must use JSX components such as `Box` and `Text`. 
+If you are unfamiliar with JSX in Snaps, see the [custom UI](custom-ui/index.md) 
+documentation before proceeding.
 
 The following example displays a notification in MetaMask, with the message "Hello, world!"
 When the user selects the notification, the expanded view displays a page with a title, a paragraph, and a link to the MetaMask Snaps directory:


### PR DESCRIPTION
…ning JSX requirement for expanded notification view

The notifications page switches from plain JS to JSX in the expanded  view example without explanation, which can confuse new developers.

Added a sentence clarifying that the content field requires JSX  components such as Box and Text, with a link to the Custom UI docs  for context.

Fixes #2895

# Description

<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies usage; no runtime behavior or APIs are modified.
> 
> **Overview**
> Clarifies the notifications expanded-view docs by explicitly stating that the `content` field must be authored using JSX components (e.g., `Box`, `Text`) and links readers to the Custom UI documentation for background before following the example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f205c485738a9335dd17953815ad862713aa01ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->