### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -481,6 +481,7 @@ const config = {
         ],
       },
     ],
+    'docusaurus-plugin-copy-page-button',
   ],
   clientModules: [require.resolve('./src/client/scroll-fix.js')],
   themeConfig:

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "copy-to-clipboard": "^3.3.3",
+        "docusaurus-plugin-copy-page-button": "^0.6.1",
         "docusaurus-plugin-llms": "^0.2.2",
         "docusaurus-plugin-sass": "^0.2.5",
         "dotenv": "^17.2.1",
@@ -16756,6 +16757,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.1.tgz",
+      "integrity": "sha512-84LUG23owdGlUx5rgg7lcyuuxFZ+84u9u+adYjFZ1E5lM+g6bkduOGcZXLUqbI0R2Ve2RjG0OPv2KaL01tGW4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-llms": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
+    "docusaurus-plugin-copy-page-button": "^0.6.1",
     "docusaurus-plugin-llms": "^0.2.2",
     "docusaurus-plugin-sass": "^0.2.5",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary
- add `docusaurus-plugin-copy-page-button` to the docs dependencies
- register the plugin in `docusaurus.config.js`

## Why
MetaMask docs include wallet, SDK, API, Snaps, and service documentation that developers often bring into AI tools. This adds a page-level copy/open button that exports the current page as clean markdown and includes one-click Open in ChatGPT, Claude, and Gemini actions.

The plugin has no runtime dependencies and uses peer dependencies for Docusaurus and React. It is already used by docs sites including Sui, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, Arbitrum, Ethereum execution-apis, and Puppeteer.

## Validation
- `git diff --check`
- package manifest, lockfile, and config sanity check

Not run locally: full docs build, due the dependency install/build footprint in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds and registers a third-party Docusaurus plugin plus lockfile updates, with no changes to business logic or data handling.
> 
> **Overview**
> Adds `docusaurus-plugin-copy-page-button` as a dependency and registers it in `docusaurus.config.js` so docs pages can expose a copy/export action.
> 
> Updates `package-lock.json` to include the new plugin’s resolved package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08efc682af94612912358a19a4ec8d72c241bcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->