### PR TITLE
docs(services): update Infura introduction with MetaMask context and architecture overview

### DIFF
--- a/developer-tools/dashboard/index.mdx
+++ b/developer-tools/dashboard/index.mdx
@@ -13,6 +13,8 @@ import Banner from '@site/src/components/Banner'
 The [Infura dashboard](https://app.infura.io/) is the central hub for managing your Infura service.
 Use it to create and manage API keys, monitor usage, and access account and billing information.
 
+The dashboard is where you create the API keys your dapps or services (and server-side components) use to call Infura's RPC endpoints — MetaMask documents these endpoints and usage patterns but does not manage your Infura account or API keys for you.
+
 <Banner>Don't have an API key? Sign up for a free plan and start using the Infura service!</Banner>
 
 Select one of the cards below to learn more about using the dashboard.

--- a/services/index.md
+++ b/services/index.md
@@ -8,12 +8,9 @@ import SectionNetworks from "@site/src/components/Sections/SectionNetworks.jsx";
 
 # Build and scale your dapp using services
 
-MetaMask, in partnership with [Infura](https://www.infura.io/), offers a comprehensive set of
-services to facilitate dapp and Snap development.
-This includes JSON-RPC APIs for easy access to key networks and REST APIs aimed at automating and
-optimizing essential development tasks.
-These services streamline development workflows to help developers build and scale robust
-dapps and Snaps.
+MetaMask provides developer guidance for using hosted node services such as [Infura](https://www.infura.io/) so you can reliably access blockchains without running your own nodes. MetaMask handles wallet responsibilities (key management and signing); hosted providers like Infura run nodes and expose JSON‑RPC and REST APIs that dapps and servers use to read chain data and broadcast signed transactions.
+
+These docs explain how to use Infura endpoints with MetaMask-enabled workflows, including when to sign locally, which calls are broadcast by a provider, and how to choose endpoints for different networks.
 
 ## Features
 
@@ -37,6 +34,34 @@ include:
   Infura can leverage DIN to provide access to archive data that may not be natively supported.
 - **Expansion APIs** -
   [Access Infura's multichain Gas API](reference/gas-api/api-reference/index.md). Use the Gas API used by the MetaMask wallet to analyze and optimize gas costs on EIP-1559 compatible chains.
+
+## How it works
+
+```mermaid
+flowchart TD
+  U[User / Dapp] -->|Interacts with dapp UI| MM[MetaMask (wallet)]
+  MM -->|Prompts user to sign — private keys never leave the wallet| SIG[Signing (local)]
+  SIG -->|Signed transaction (raw tx)| INF[Provider (Infura) — JSON-RPC / REST]
+  INF -->|Broadcasts signed tx to network| NET[Blockchain network (Mainnet, L2s, Testnets)]
+  INF -->|Serves read queries (eth_call, eth_getBalance, archive data)| MM
+  subgraph Notes[ ]
+    direction LR
+    MM -. "Signs transactions locally; stores keys" .-> SIG
+    INF -. "Runs nodes; provides JSON-RPC endpoints, broadcasting, and historical data" .-> NET
+  end
+```
+
+MetaMask prompts users to sign transactions locally; the wallet creates a signed payload which can then be broadcast to the network through a provider endpoint such as Infura (for example, `eth_sendRawTransaction`). Infura provides read APIs (`eth_call`, `eth_getBalance`, block queries) and features like archive access and failover (DIN).
+
+### Signing vs broadcasting
+
+:::important
+MetaMask signs transactions locally using keys stored in the user's wallet. Hosted providers (like Infura) do not hold your private keys — they accept signed transactions (for example via `eth_sendRawTransaction`) and broadcast them to the network. Never share private keys or unencrypted signing material with a provider.
+:::
+
+### Network switching
+
+MetaMask controls the active network in the wallet UI. Dapps should detect the active `chainId` and, where server-side calls are needed, call the matching Infura endpoint for that network (see `/services/get-started/endpoints`). If your backend uses Infura to submit or monitor transactions, ensure it targets the same chain the user is interacting with in MetaMask.
 
 <head>
 <meta httpEquiv="cache-control" content="no-cache" />


### PR DESCRIPTION
## Description

Fixes #1387

This PR updates the Services introduction to better explain the relationship between MetaMask and Infura, providing additional context for developers using Infura as an RPC provider.

### Changes

* Reworked the introductory content to be more MetaMask-focused.
* Added clarification on the distinct responsibilities of MetaMask and Infura.
* Explained the transaction lifecycle, including:

  * Transaction signing in MetaMask.
  * Transaction broadcasting through Infura endpoints.
* Added guidance on accessing blockchain data through Infura.
* Added context around network switching and endpoint selection.
* Added a simplified architecture diagram illustrating:

  * User interaction flow.
  * MetaMask transaction signing.
  * Infura RPC endpoint communication.
  * Blockchain network access.

### Why

The previous introduction primarily described Infura services but did not clearly explain how those services fit into a typical MetaMask developer workflow.

These updates provide a clearer mental model for developers by explaining:

* How MetaMask and Infura work together.
* The difference between signing and broadcasting transactions.
* How Infura provides scalable blockchain data access.
* How developers can use Infura endpoints across supported networks.

### Files Updated

* `services/index.md`
* `developer-tools/dashboard/index.mdx` (if applicable)

### Testing

* Verified documentation builds successfully.
* Verified internal links and navigation.
* Reviewed content for consistency with existing Services documentation style.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or data-path changes.
> 
> **Overview**
> **Services introduction** is reframed around MetaMask + Infura: wallet signing and key custody vs hosted JSON-RPC/REST for reads and broadcasting, plus what these docs cover (local signing, provider broadcast, endpoint choice).
> 
> A new **How it works** section adds a Mermaid flow (user → MetaMask → local sign → Infura → chain), narrative on `eth_sendRawTransaction` and read methods, an **important** admonition on signing vs broadcasting and never sharing keys, and **network switching** guidance (`chainId` and matching Infura endpoints).
> 
> **Infura dashboard** intro gains one sentence clarifying that API keys are created in Infura and that MetaMask documents usage but does not manage Infura accounts or keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e3aee3a9cb81502522191e0c911ec1b80466ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->