### PR TITLE
docs(services): improve Infura tutorials with MetaMask workflow and signing guidance

### DIFF
--- a/services/tutorials/ethereum/call-a-contract.md
+++ b/services/tutorials/ethereum/call-a-contract.md
@@ -7,9 +7,29 @@ sidebar_position: 3
 
 This tutorial uses Web3.js to execute a function in a smart contract. Calling the contract function is a type of transaction that requires paying gas.
 
+## Why this tutorial matters for MetaMask developers
+
+This tutorial shows how to call and execute contract functions in contexts where users may sign transactions with MetaMask. It clarifies when a dapp should request signatures from the user's wallet versus when server-side transactions are appropriate.
+
 ## Prerequisites
 
 Before attempting this tutorial, ensure you completed the tutorial to [deploy a contract](deploy-a-contract-using-web3.js.md) and [updated the `.env` file with the smart contract address](deploy-a-contract-using-web3.js.md#10-update-the-env-file).
+
+### Network selection
+
+Before running example transactions, ensure MetaMask is connected to the correct network and your account has sufficient test ETH.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Connect the user's wallet (for example, `await window.ethereum.request({ method: 'eth_requestAccounts' })`).
+2. Create a provider from the injected provider and obtain a signer.
+3. Request the user to sign the call/transaction via MetaMask; the extension will prompt for confirmation.
+4. Allow MetaMask to broadcast the signed transaction via the connected provider.
 
 ## Steps
 

--- a/services/tutorials/ethereum/deploy-a-contract-using-web3.js.md
+++ b/services/tutorials/ethereum/deploy-a-contract-using-web3.js.md
@@ -7,6 +7,10 @@ sidebar_position: 2
 
 In this tutorial, you'll create a simple smart contract and use the Web3 JavaScript library to compile and then deploy the smart contract.
 
+## Why this tutorial matters for MetaMask developers
+
+This tutorial covers both developer-focused deployment scripts and the wallet-driven flow used when users sign transactions via MetaMask. It clarifies when to deploy from a script (CI or admin) versus when to use a wallet-driven signer in a dapp.
+
 ## Prerequisites
 
 - An [Ethereum project](../../get-started/infura.md) on Infura
@@ -20,6 +24,22 @@ You can use [MetaMask](https://metamask.io) or similar to create an Ethereum acc
 :::
 
 ## Steps
+
+### Network selection
+
+Before running the example, ensure MetaMask is connected to the correct network, your account has sufficient test tokens, and the RPC endpoint in the example matches the selected network.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Connect the user's wallet using `window.ethereum` and request accounts.
+2. Use a wallet provider (for example, `ethers.providers.Web3Provider(window.ethereum)`) to obtain a signer and have the user confirm the deployment transaction.
+3. MetaMask will prompt the user to sign; once signed the transaction is broadcast via the connected provider.
+4. For automated deployments or CI, use secure key management and do not place production keys in `.env` files in the repository.
 
 ### 1. Fund your Ethereum account
 
@@ -74,6 +94,10 @@ Install the `dotenv` package:
 ```
 npm install dotenv
 ```
+
+:::warning
+The `.env` example below includes a private key. This approach is intended for local development, testing, or backend automation only. For production, use secure key management (secrets manager or hardware keys) and avoid exporting user keys. When building dapps, prefer in-browser signing with MetaMask instead of placing private keys in files.
+:::
 
 ### 4. Create the `.env` file
 

--- a/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
+++ b/services/tutorials/ethereum/send-a-transaction/send-a-transaction-ethers.md
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 In this tutorial, you'll send a transaction of 0.001 ETH from one account to another using the [`ethers.js`](https://docs.ethers.io/v5/) JavaScript library.
 
+## Why this tutorial matters for MetaMask developers
+
+This tutorial demonstrates both script-based and wallet-driven transaction flows you may use when building dapps with MetaMask. It clarifies what MetaMask handles (signing and user consent) and what Infura provides (RPC access and broadcasting).
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/en/download/)
@@ -21,6 +25,26 @@ Use [MetaMask](https://metamask.io) or similar to create an Ethereum account for
 :::
 
 ## Steps
+
+### Network selection
+
+Before running the example, ensure MetaMask is connected to the correct network, your account has sufficient test tokens, and the RPC endpoint in the example matches the selected network.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Connect the user's wallet with `await window.ethereum.request({ method: 'eth_requestAccounts' })`.
+2. Create a provider from the injected provider (`new ethers.providers.Web3Provider(window.ethereum)`) and get a signer.
+3. Build the transaction object and request the user to sign it through MetaMask. The extension will prompt the user for confirmation.
+4. Broadcast — MetaMask will typically broadcast the signed transaction automatically.
+
+:::warning
+This workflow (exporting private keys to `.env`) is intended for local development, testing, or backend automation only. For production dapps, request transaction signatures from users' wallets (for example, MetaMask) instead of exporting private keys.
+:::
 
 ### 1. Select your network and verify funds
 

--- a/services/tutorials/ethereum/send-a-transaction/send-a-transaction-viem.md
+++ b/services/tutorials/ethereum/send-a-transaction/send-a-transaction-viem.md
@@ -22,7 +22,31 @@ Use [MetaMask](https://metamask.io/) or similar to create an Ethereum account 
 :::
 
 ## Steps
+### Network selection
 
+Before running the example, ensure MetaMask is connected to the correct network, your account has sufficient test tokens, and the RPC endpoint in the example matches the selected network.
+
+## Why this tutorial matters for MetaMask developers
+
+This tutorial shows typical transaction flows for TypeScript developers and offers a clear separation between wallet-based (MetaMask) signing and server-side signing. Use the wallet flow for user-driven transactions and the key-based flow only for automation or testing.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Connect the user's wallet (for example, `await window.ethereum.request({ method: 'eth_requestAccounts' })`).
+2. Use the injected provider with a `Web3Provider` wrapper to obtain a signer and build a transaction.
+3. Request the signature via MetaMask and then broadcast it through the provider.
+4. For server-side automation, keep private keys secure and avoid exporting user keys.
+
+:::warning
+The example that stores a private key in `config.ts` is intended for local development, testing, or backend automation only. For production dapps, request transaction signatures from users' wallets (for example, MetaMask) instead of storing or exporting private keys.
+:::
+
+ 
 ### 1. Select your network and verify funds
 
 - **Sepolia** - To use the Sepolia testnet, ensure that your account has Sepolia ETH.

--- a/services/tutorials/ethereum/send-a-transaction/use-web3.js.md
+++ b/services/tutorials/ethereum/send-a-transaction/use-web3.js.md
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 In this tutorial, you'll send a regular transaction of 0.001 ETH from one account to another using the Web3 JavaScript library.
 
+## Why this tutorial matters for MetaMask developers
+
+This tutorial shows common transaction flows developers encounter when building dapps that interact with MetaMask. It explains when MetaMask handles signing, when Infura provides RPC access and broadcasting, and when you should use a wallet-driven flow vs a server-side automation.
+
 ## Prerequisites
 
 - A [Web3 project](../../../get-started/infura.md) on Infura
@@ -22,6 +26,25 @@ Use [MetaMask](https://metamask.io) or similar to create an Ethereum account for
 :::
 
 ## Steps
+### Network selection
+
+Before running the example, ensure MetaMask is connected to the correct network, your account has sufficient test tokens, and the RPC endpoint in the example matches the selected network.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Connect the user's wallet (for example, `await window.ethereum.request({ method: 'eth_requestAccounts' })`).
+2. Create a provider using the injected provider (for example, `new ethers.providers.Web3Provider(window.ethereum)`) and request the signer.
+3. Build the transaction object and request the user to sign it through MetaMask (the extension or mobile app will prompt).
+4. Broadcast the signed transaction through the connected provider (MetaMask will typically handle broadcasting automatically).
+
+:::warning
+This workflow (exporting private keys to `.env`) is intended for local development, testing, or backend automation only. For production dapps, request transaction signatures from users' wallets (for example, MetaMask) instead of exporting private keys.
+:::
 
 ### 1. Select your network and verify funds
 

--- a/services/tutorials/layer-2-networks/send-a-transaction.md
+++ b/services/tutorials/layer-2-networks/send-a-transaction.md
@@ -11,6 +11,26 @@ As with Ethereum, [transactions](https://ethereum.org/en/developers/docs/transac
 
 This tutorial uses the Ethereum Web3 JavaScript library to send a transaction between two accounts on the Polygon Amoy testnet.
 
+## Why this tutorial matters for MetaMask developers
+
+This tutorial explains how to send transactions on Polygon networks, and highlights how MetaMask integrates for network switching and user signing. Use the wallet-driven approach when building dapps with MetaMask, and use key-based scripts only for automation or testing.
+
+### Network selection
+
+Before running the example, ensure MetaMask is connected to the Polygon network you intend to use, your account has sufficient test MATIC, and that the RPC endpoint matches the selected network.
+
+## Signing and broadcasting
+
+- MetaMask signs transactions locally in the user's browser or device. Private keys remain in the wallet and are not shared.
+- Infura accepts and broadcasts signed transactions to the network; Infura does not manage private keys or perform signing.
+
+### Using MetaMask for user signing
+
+1. Add the Polygon network to MetaMask and switch to it.
+2. Request account access from the user (for example, `await window.ethereum.request({ method: 'eth_requestAccounts' })`).
+3. Use the injected provider to obtain a signer and request the signature via MetaMask.
+4. MetaMask will broadcast the signed transaction to the network via the connected RPC provider.
+
 ## Prerequisites
 
 - An Infura [API key](/developer-tools/dashboard/get-started/create-api)


### PR DESCRIPTION
## Description

Fixes #1386

This PR refreshes several Services tutorials to provide clearer MetaMask context, improve workflow guidance, and align tutorial structure with existing MetaMask documentation standards.

### What Changed

The following tutorials were updated:

* `use-web3.js.md`
* `send-a-transaction-ethers.md`
* `send-a-transaction-viem.md`
* `deploy-a-contract-using-web3.js.md`
* `call-a-contract.md`
* `layer-2-networks/send-a-transaction.md`

### Improvements

#### Added MetaMask Context

Each tutorial now includes a short section explaining:

* Why the workflow is relevant for MetaMask developers.
* The role of MetaMask within the transaction lifecycle.
* When developers should use MetaMask versus direct RPC interactions.

#### Clarified Signing and Broadcasting

Added standardized guidance describing:

* Transaction signing in MetaMask.
* Transaction broadcasting through Infura endpoints.
* Wallet responsibilities versus provider responsibilities.
* Security considerations around private key management.

#### Improved Security Guidance

Added warnings before private-key-based examples to clarify that:

* These workflows are intended for local development, testing, or backend automation.
* Production dapps should request signatures through MetaMask or another wallet provider rather than exporting private keys.

#### Added Recommended MetaMask Workflows

Introduced a MetaMask-first workflow section that explains how developers can:

1. Connect a wallet.
2. Request account access.
3. Sign transactions through MetaMask.
4. Broadcast transactions through the connected provider.

#### Added Network Selection Guidance

Added notes for tutorials using Sepolia, Polygon, and other EVM networks to help developers:

* Verify the active MetaMask network.
* Confirm endpoint and network alignment.
* Ensure sufficient testnet funds are available before executing examples.

### Why

Many tutorials focused primarily on Infura-based workflows and private-key-driven examples without clearly explaining how those workflows fit into a typical MetaMask development experience.

These updates provide a clearer mental model for developers by:

* Explaining wallet and provider responsibilities.
* Promoting safer signing practices.
* Improving consistency across Services tutorials.
* Aligning tutorial content with broader MetaMask documentation patterns.

### Testing

* Verified documentation formatting.
* Reviewed Markdown structure for consistency.
* Confirmed updates are content-only and do not affect runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime or API changes; content improves security messaging for developers.
> 
> **Overview**
> Six Infura **Services** Ethereum/Polygon tutorials gain shared **MetaMask-oriented** prose: relevance for dapp builders, **network/RPC alignment** checks, a **signing vs broadcasting** split (wallet signs locally; Infura RPC only), and a **wallet-first** flow (`eth_requestAccounts`, injected provider/signer, user confirmation).
> 
> **Private-key** examples (`.env`, `config.ts`) are framed with **`:::warning`** blocks as **local dev, test, or automation only**, with production guidance to use **in-browser wallet signing** instead of exported keys. Tutorial steps and sample scripts are unchanged; updates are **markdown-only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d2aa188492d121b0f78c66f2b103dc123cf051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->