### PR TITLE
[Smart Accounts Kit] Minor fixes

### DIFF
--- a/smart-accounts-kit/get-started/smart-account-quickstart/eip7702.md
+++ b/smart-accounts-kit/get-started/smart-account-quickstart/eip7702.md
@@ -12,6 +12,10 @@ This quickstart demonstrates how to upgrade your <GlossaryTerm term="Externally 
 functionality using an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) transaction.
 This enables your EOA to leverage the benefits of <GlossaryTerm term="Account abstraction">account abstraction</GlossaryTerm>, such as batch transactions, gas sponsorship, and <GlossaryTerm term="Delegation">delegation</GlossaryTerm>.
 
+:::note
+This guide is for embedded wallets. To upgrade a MetaMask account, you can [use MetaMask Connect to upgrade to a smart account](/tutorials/upgrade-eoa-to-smart-account).
+:::
+
 ## Prerequisites
 
 - Install [Node.js](https://nodejs.org/en/blog/release/v18.18.0) v18 or later.
@@ -167,4 +171,3 @@ const userOperationHash = await bundlerClient.sendUserOperation({
 
 - To grant specific permissions to other accounts from your smart account, [create a delegation](../../guides/delegation/execute-on-smart-accounts-behalf.md).
 - To quickly bootstrap a MetaMask Smart Accounts project, [use the CLI](../use-the-cli.md).
-- You can also [use MetaMask Connect to upgrade a MetaMask account to a smart account](/tutorials/upgrade-eoa-to-smart-account).

--- a/smart-accounts-kit/guides/x402/seller.md
+++ b/smart-accounts-kit/guides/x402/seller.md
@@ -30,11 +30,11 @@ through the MetaMask facilitator.
 
 The following table lists the available MetaMask facilitator endpoints:
 
-| Name         | ID             | URL                                                                     |
-| ------------ | -------------- | ----------------------------------------------------------------------- |
-| Base         | `eip155:8453`  | `https://tx-sentinel-base-mainnet.api.cx.metamask.io/platform/v2/x402`  |
-| Base Sepolia | `eip155:84532` | `https://tx-sentinel-base-sepolia.api.cx.metamask.io/platform/v2/x402`  |
-| Monad        | `eip155:143`   | `https://tx-sentinel-monad-mainnet.api.cx.metamask.io/platform/v2/x402` |
+| Name         | ID             | URL                                                                         |
+| ------------ | -------------- | --------------------------------------------------------------------------- |
+| Base         | `eip155:8453`  | `https://tx-sentinel-monad-mainnet.dev-api.cx.metamask.io/platform/v2/x402` |
+| Base Sepolia | `eip155:84532` | `https://tx-sentinel-base-sepolia.dev-api.cx.metamask.io/platform/v2/x402`  |
+| Monad        | `eip155:143`   | `https://tx-sentinel-base-mainnet.dev-api.cx.metamask.io/platform/v2/x402`  |
 
 ## Steps
 

--- a/smart-accounts-kit/reference/x402.md
+++ b/smart-accounts-kit/reference/x402.md
@@ -15,7 +15,7 @@ The following API methods are related to x402 to create payments using <Glossary
 
 ## `createx402DelegationProvider`
 
-Creates a delegation provider function too be used with `x402Client`.
+Creates a delegation provider function too be used with `x402Erc7710Client`.
 
 The provider resolves creates an <GlossaryTerm term="Open delegation">open delegation</GlossaryTerm>, signs it, and returns an ABI-encoded delegation
 chain as a hex string. The provider internally appends redeemer, payee, and expiry <GlossaryTerm term="Caveat">caveats</GlossaryTerm> when the


### PR DESCRIPTION
# Description

- Minor fixes

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The x402 facilitator table appears to swap Base and Monad sentinel hostnames relative to network names, which could mislead integrators if incorrect; otherwise changes are documentation-only.
> 
> **Overview**
> Documentation-only updates across the Smart Accounts Kit EIP-7702 quickstart, x402 seller guide, and x402 API reference.
> 
> The **EIP-7702 quickstart** now states the flow is for **embedded wallets** and points MetaMask users to the Connect upgrade tutorial via a note admonition, while the duplicate “Next steps” link to that tutorial is removed.
> 
> The **x402 seller** facilitator URL table switches hosts to **`dev-api.cx.metamask.io`** and changes which sentinel hostname is listed for each network row (Base, Base Sepolia, Monad).
> 
> The **`createx402DelegationProvider`** reference now says the provider is used with **`x402Erc7710Client`** instead of **`x402Client`**, matching the buyer guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8419e6f0fd52c663ead9d6f4aed8b17f546028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->