### PR TITLE
Update Facilitator Urls

### DIFF
--- a/gator_versioned_docs/version-1.6.0/guides/x402/seller.md
+++ b/gator_versioned_docs/version-1.6.0/guides/x402/seller.md
@@ -32,9 +32,9 @@ The following table lists the available MetaMask facilitator endpoints:
 
 | Name         | ID             | URL                                                                         |
 | ------------ | -------------- | --------------------------------------------------------------------------- |
-| Base         | `eip155:8453`  | `https://tx-sentinel-monad-mainnet.dev-api.cx.metamask.io/platform/v2/x402` |
+| Base         | `eip155:8453`  | `https://tx-sentinel-base-mainnet.dev-api.cx.metamask.io/platform/v2/x402`  |
 | Base Sepolia | `eip155:84532` | `https://tx-sentinel-base-sepolia.dev-api.cx.metamask.io/platform/v2/x402`  |
-| Monad        | `eip155:143`   | `https://tx-sentinel-base-mainnet.dev-api.cx.metamask.io/platform/v2/x402`  |
+| Monad        | `eip155:143`   | `https://tx-sentinel-monad-mainnet.dev-api.cx.metamask.io/platform/v2/x402` |
 
 ## Steps
 

--- a/smart-accounts-kit/guides/x402/seller.md
+++ b/smart-accounts-kit/guides/x402/seller.md
@@ -32,9 +32,9 @@ The following table lists the available MetaMask facilitator endpoints:
 
 | Name         | ID             | URL                                                                         |
 | ------------ | -------------- | --------------------------------------------------------------------------- |
-| Base         | `eip155:8453`  | `https://tx-sentinel-monad-mainnet.dev-api.cx.metamask.io/platform/v2/x402` |
+| Base         | `eip155:8453`  | `https://tx-sentinel-base-mainnet.dev-api.cx.metamask.io/platform/v2/x402`  |
 | Base Sepolia | `eip155:84532` | `https://tx-sentinel-base-sepolia.dev-api.cx.metamask.io/platform/v2/x402`  |
-| Monad        | `eip155:143`   | `https://tx-sentinel-base-mainnet.dev-api.cx.metamask.io/platform/v2/x402`  |
+| Monad        | `eip155:143`   | `https://tx-sentinel-monad-mainnet.dev-api.cx.metamask.io/platform/v2/x402` |
 
 ## Steps
 


### PR DESCRIPTION
# Description

- Fix the wrong urls, Base and Monad was interchanged. 

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction of endpoint hostnames; no application or security logic changes.
> 
> **Overview**
> Corrects **swapped MetaMask x402 facilitator URLs** in the seller guides for **Base** (`eip155:8453`) and **Monad** (`eip155:143`): each chain now points to its own `tx-sentinel-*-mainnet` endpoint instead of the other network’s host.
> 
> The same table fix is applied in **`gator_versioned_docs/version-1.6.0/guides/x402/seller.md`** and **`smart-accounts-kit/guides/x402/seller.md`**. Base Sepolia is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d497125d3a28c161861027f1e49623ad6fc3cbb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->