### PR TITLE
Minor agent doc updates

### DIFF
--- a/agent-wallet/README.mdx
+++ b/agent-wallet/README.mdx
@@ -20,13 +20,13 @@ After setup, prompt your agent in plain language:
 
 <!-- vale off -->
 
-| You ask your agent                                 | What happens                                                      |
-| -------------------------------------------------- | ----------------------------------------------------------------- |
-| "Show the wallet address and USDC balance on Base" | Your agent checks auth, then queries balances.                    |
-| "Send 10 USDT to 0x123… on Base"                   | Your agent confirms details, then submits a transfer.             |
-| "Swap 0.1 ETH to USDC on Base"                     | Your agent fetches a quote, confirms with you, then executes.     |
-| "Open a 5x long on BTC with $100 on Hyperliquid"   | Your agent deposits if needed, quotes, and opens the position.    |
-| "Bet 10 USDT on YES for BTC 5-min price up"        | Your agent searches markets, confirms odds, and places the order. |
+| You ask your agent                               | What happens                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------------- |
+| "Show the wallet address and USDC balance"       | Your agent checks auth, then queries balances.                    |
+| "Send 10 USDT to 0x123… on Ethereum"             | Your agent confirms details, then submits a transfer.             |
+| "Swap 0.1 ETH to USDC on Base"                   | Your agent fetches a quote, confirms with you, then executes.     |
+| "Open a 5x long on BTC with $100 on Hyperliquid" | Your agent deposits if needed, quotes, and opens the position.    |
+| "Bet 10 USDT on YES for BTC 5-min price up"      | Your agent searches markets, confirms odds, and places the order. |
 
 <!-- vale on -->
 

--- a/agent-wallet/guides/check-balances-and-prices.md
+++ b/agent-wallet/guides/check-balances-and-prices.md
@@ -10,7 +10,7 @@ Query wallet balances, spot prices, and token metadata without submitting transa
 ## Ask your agent
 
 ```text
-You (to your agent): "What's my USDC balance on Base?"
+You (to your agent): "What's my USDC balance?"
 ```
 
 ```text
@@ -18,7 +18,7 @@ You (to your agent): "What's the current price of ETH?"
 ```
 
 ```text
-You (to your agent): "Show me trending tokens on Base"
+You (to your agent): "Show me trending tokens"
 ```
 
 Read-only queries like these do not require confirmation before your agent runs them.

--- a/agent-wallet/guides/send-tokens.md
+++ b/agent-wallet/guides/send-tokens.md
@@ -10,7 +10,7 @@ Transfer native currency or ERC-20 tokens to a recipient on one EVM chain.
 ## Ask your agent
 
 ```text
-You (to your agent): "Send 10 USDC to 0xabc... on Base"
+You (to your agent): "Send 10 USDC to 0xabc..."
 ```
 
 Your agent confirms the recipient, amount, token, and chain before executing.

--- a/agent-wallet/guides/sign-messages-and-transactions.md
+++ b/agent-wallet/guides/sign-messages-and-transactions.md
@@ -14,7 +14,7 @@ You (to your agent): "Sign this message on Ethereum: Hello, world"
 ```
 
 ```text
-You (to your agent): "Sign this EIP-712 typed data on Base: <paste JSON payload>"
+You (to your agent): "Sign this EIP-712 typed data: <paste JSON payload>"
 ```
 
 Your agent shows the exact payload and asks you to confirm before signing.

--- a/agent-wallet/guides/swap-and-bridge.md
+++ b/agent-wallet/guides/swap-and-bridge.md
@@ -10,7 +10,7 @@ Get a quote, review the route, and execute a same-chain swap or cross-chain brid
 ## Ask your agent
 
 ```text
-You (to your agent): "Swap 0.1 ETH to USDC on Base"
+You (to your agent): "Swap 0.1 ETH to USDC"
 ```
 
 For a cross-chain bridge:

--- a/vercel.json
+++ b/vercel.json
@@ -1024,6 +1024,11 @@
       "source": "/embedded-wallets/sdk/flutter/migration-guides/:path*",
       "destination": "/embedded-wallets/migration-guides/flutter",
       "permanent": true
+    },
+    {
+      "source": "/agent-wallet/get-started/quickstart",
+      "destination": "/agent-wallet/quickstart",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Minor agent doc updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and URL redirect only; no application or security logic changes.
> 
> **Overview**
> Agent Wallet docs now use **shorter natural-language examples** that drop redundant chain names where the agent can infer context (balances, trending tokens, sends, same-chain swaps, EIP-712). The overview table still shows chain where it matters (e.g. send on **Ethereum**, swap on **Base**, Hyperliquid/Polymarket flows unchanged) and tightens markdown table column alignment.
> 
> A **permanent redirect** in `vercel.json` maps `/agent-wallet/get-started/quickstart` → `/agent-wallet/quickstart` so old links resolve after the doc path change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0c90caabe8fa8f216dae0ded7f25ddc40f9bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->