### PR TITLE
Update shield wordings

### DIFF
--- a/.cursor/rules/product-agent-wallet.mdc
+++ b/.cursor/rules/product-agent-wallet.mdc
@@ -16,8 +16,8 @@ alwaysApply: false
 
 - **server-wallet** — private keys are held securely in a TEE-backed environment.
 - **Bring your own wallet** — user supplies a BIP-39 mnemonic. CLI flag: `byok`.
-- **Guard Mode (Recommended)** — trading mode (`--mode guard`). Designed for everyday traders. Enforces security check, network allowlist, token recipient allowlist, address allowlist, and rolling 24h outflow limit. 2-factor authentication on policy violations, malicious transactions, and raising outflow limit.
-- **Beast Mode** — trading mode (`--mode beast`). Designed for power users. Security check guardrail only. 2-factor authentication on malicious transactions and risky contracts.
+- **Guard Mode (Recommended)** — trading mode (`--mode guard`). Designed for everyday traders. Enforces threat scanning, network allowlist, token recipient allowlist, address allowlist, and rolling 24h outflow limit. 2-factor authentication on policy violations, malicious transactions, and raising outflow limit.
+- **Beast Mode** — trading mode (`--mode beast`). Designed for power users. Threat scanning guardrail only. 2-factor authentication on malicious transactions and risky contracts.
 
 Users choose wallet and trading modes during interactive `mm init` or by prompting their agent.
 Mark Guard Mode as **Recommended**; do not describe modes as opt-in, default, or preferred in other ways.
@@ -29,13 +29,17 @@ CLI flags use `server-wallet`, `byok`, `guard`, and `beast`.
 
 Use these terms consistently when describing the security stack:
 
-- **Transaction Protection** — guarantee for transactions deemed safe (up to $10,000 loss coverage).
-  Frame as backing for "security by default," not as a standalone scanning feature. Link eligibility
+- **Threat scanning** — powered by Blockaid; production-tested across millions of MetaMask
+  transactions. Malicious transactions get auto-bounced. Do not conflate with Transaction Shield.
+- **Transaction Protection** — guarantee for eligible transactions deemed safe (up to $10,000/month
+  loss coverage). Frame as optional coverage backing, not as a scanning feature. Link eligibility
   and terms to
   [Transaction Shield support](https://support.metamask.io/manage-crypto/transactions/transaction-shield/).
-- **Transaction Shield** — automated security checks for malicious contracts and scams. Link to
-  [Transaction Shield support](https://support.metamask.io/manage-crypto/transactions/transaction-shield/).
-  Do not lead with vendor names.
+- **Transaction Shield** — MetaMask subscription pairing Transaction Protection with priority support.
+  Link to
+  [Transaction Shield support](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)
+  for subscription details, eligibility, and terms. Do not describe Transaction Shield as a security
+  or threat-scanning feature.
 - **Smart Transactions** — optimizes how trades land onchain (fewer fails, better gas, built-in MEV
   protection). Link to
   [Smart Transactions support](https://support.metamask.io/manage-crypto/transactions/smart-transactions/).

--- a/agent-wallet/README.mdx
+++ b/agent-wallet/README.mdx
@@ -33,23 +33,26 @@ After setup, prompt your agent in plain language:
 ## MetaMask safety-checks every transaction before it lands
 
 Security by default, not configuration.
-Supported EVM transactions pass through a mandatory 3-step security pipeline.
-Backed by Transaction Protection: transactions through Agent Wallet deemed safe are guaranteed
-against loss up to $10,000.\*
+Supported EVM transactions pass through a mandatory 3-step pipeline before they land onchain.
 
 1. **Transaction simulation**: What will this transaction actually do? Balance changes, approvals,
    and gas are surfaced before signing.
-2. **[Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)**:
-   Automated security checks flag malicious contracts and scams; flagged transactions require your
-   approval before they execute.
+2. **Threat scanning**: Powered by Blockaid and production-tested across millions of MetaMask
+   transactions. Malicious transactions get auto-bounced. Flagged transactions require your approval
+   before they execute.
 3. **[Smart Transactions](https://support.metamask.io/manage-crypto/transactions/smart-transactions/)**:
    Smart transaction execution with built-in MEV protection, fewer fails, and better gas where
    supported on the target chain.
 
+Eligible transactions deemed safe are backed by
+[Transaction Protection](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)
+coverage up to $10,000/month.\*
+
 :::note
 
-Learn more in [Architecture](reference/architecture.md). See [Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)
-for eligibility, coverage limits, and terms.
+Learn more in [Architecture](reference/architecture.md). See
+[Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/) for
+subscription details, eligibility, coverage limits, and terms.
 
 :::
 
@@ -96,7 +99,7 @@ See [Supported chains](reference/supported-chains.md) for typical networks.
       href: '/agent-wallet/reference/architecture',
       title: 'Architecture',
       description:
-        'Wallet modes, Transaction Protection, Transaction Shield, Smart Transactions, and 2FA.',
+        'Wallet modes, threat scanning, Transaction Protection, Smart Transactions, and 2FA.',
     },
     {
       href: '/agent-wallet/guides/trade-perpetuals',

--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -89,10 +89,10 @@ During `mm init`, choose a wallet mode and, for server-wallet, a trading mode.
 
 #### Trading mode (server wallet only):
 
-- **Guard Mode (Recommended)**: designed for everyday traders. Enforces security checks, network
+- **Guard Mode (Recommended)**: designed for everyday traders. Enforces threat scanning, network
   and recipient allowlists, address allowlists, and a rolling 24-hour outflow limit. Transactions
   outside your policy limits require 2-factor authentication before they execute.
-- **Beast Mode**: designed for power users. Keeps the security check guardrail only. Malicious
+- **Beast Mode**: designed for power users. Keeps the threat scanning guardrail only. Malicious
   transactions and risky contracts are blocked and surfaced for 2-factor authentication approval.
 
 See [Trading modes](reference/architecture.md#trading-modes) for guardrails and approval conditions.

--- a/agent-wallet/reference/architecture.md
+++ b/agent-wallet/reference/architecture.md
@@ -9,7 +9,7 @@ keywords:
     server-wallet,
     polling,
     Transaction Protection,
-    Transaction Shield,
+    threat scanning,
     Smart Transactions,
     2FA,
   ]
@@ -61,12 +61,22 @@ Optionally encrypt the mnemonic at rest with `MM_PASSWORD` or `mm wallet passwor
 Before a transaction executes, the CLI simulates it to surface reverts, unexpected state changes,
 and other failures early.
 
-## Transaction Shield
+## Threat scanning
 
-[Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)
-runs automated security checks on each transaction, including malicious contracts and scams.
+Threat scanning is powered by Blockaid and production-tested across millions of MetaMask
+transactions.
+Malicious transactions get auto-bounced.
 When a transaction is flagged, it requires your approval before it executes.
 You receive details in the CLI output and through the approval flow.
+
+## Transaction Protection
+
+Eligible transactions deemed safe are backed by Transaction Protection coverage up to
+$10,000/month.
+[Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/) is
+MetaMask's subscription that pairs Transaction Protection with priority support.
+See [Transaction Shield](https://support.metamask.io/manage-crypto/transactions/transaction-shield/)
+for subscription details, eligibility, coverage limits, and terms.
 
 ## Smart Transactions
 
@@ -93,7 +103,7 @@ Transactions outside your policy limits require 2-factor authentication approval
 
 **Guardrails**
 
-- Security check
+- Threat scanning
 - Network allowlist
 - Token recipient allowlist
 - Address allowlist
@@ -114,7 +124,7 @@ Malicious transactions are still blocked and surfaced for 2-factor authenticatio
 
 **Guardrails**
 
-- Security check
+- Threat scanning
 
 **Approval required for**
 
@@ -140,8 +150,8 @@ See [Trading modes](../use-the-cli-directly.md#trading-modes-server-wallet-only)
 When you submit a signing or transaction request in server-wallet mode:
 
 1. The CLI submits the request to the wallet service.
-2. The service may simulate the transaction, run Transaction Shield, and evaluate policies.
-3. If policy requires 2-factor authentication or Transaction Shield flags the transaction, the job
+2. The service may simulate the transaction, run threat scanning, and evaluate policies.
+3. If policy requires 2-factor authentication or threat scanning flags the transaction, the job
    enters an `AWAITING_MFA` state until you approve via MetaMask Mobile or email.
 4. The CLI returns a `pollingId` unless you pass `--wait`.
 

--- a/agent-wallet/use-the-cli-directly.md
+++ b/agent-wallet/use-the-cli-directly.md
@@ -78,11 +78,11 @@ Optionally encrypt the mnemonic at rest with `mm wallet password set`.
 | Guard Mode (Recommended) | `--mode guard` | Designed for everyday traders. Transactions outside your policy limits require 2FA approval.      |
 | Beast Mode               | `--mode beast` | Designed for power users. Malicious transactions are still blocked and surfaced for 2FA approval. |
 
-Guard Mode enforces security checks, network and recipient allowlists, address allowlists, and a
+Guard Mode enforces threat scanning, network and recipient allowlists, address allowlists, and a
 rolling 24-hour outflow limit.
 2FA is required for malicious transactions, allowlist violations, and raising your outflow limit.
 
-Beast Mode keeps only the security check guardrail.
+Beast Mode keeps only the threat scanning guardrail.
 2FA is required for malicious transactions and risky contracts.
 
 See [Trading modes](reference/architecture.md#trading-modes) for the full guardrail and approval


### PR DESCRIPTION
Update shield according to marketing wordings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Cursor rules only; no product code or runtime behavior changes.
> 
> **Overview**
> Aligns Agent Wallet docs with updated marketing terminology by separating **threat scanning** from **Transaction Shield** and **Transaction Protection**.
> 
> The onchain security pipeline step that was labeled Transaction Shield / “security checks” is now **threat scanning** (Blockaid, auto-bounce for malicious txs, approval for flagged ones). **Transaction Protection** is described as optional loss coverage (up to **$10,000/month** for eligible safe txs), not a scanning feature. **Transaction Shield** is reframed as the MetaMask **subscription** that bundles Transaction Protection with priority support—not as threat scanning.
> 
> Trading modes (Guard/Beast) and the server-wallet async flow now refer to **threat scanning** instead of “security check.” The same definitions are added to `.cursor/rules/product-agent-wallet.mdc` for consistent future authoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d0bf01dc140c34286b7f666eb47b25e51c5c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->