### PR TITLE
[Smart Accounts Kit] Improve Smart Accounts Kit docs

### DIFF
--- a/gator_versioned_docs/version-1.6.0/concepts/advanced-permissions.md
+++ b/gator_versioned_docs/version-1.6.0/concepts/advanced-permissions.md
@@ -18,9 +18,9 @@ This feature requires [MetaMask Flask 13.5.0](/snaps/get-started/install-flask) 
 
 ## ERC-7715 technical overview
 
-[ERC-7715](https://eips.ethereum.org/EIPS/eip-7715) defines a JSON-RPC method `wallet_grantPermissions`.
+[ERC-7715](https://eips.ethereum.org/EIPS/eip-7715) defines a JSON-RPC method `wallet_requestExecutionPermissions`.
 Dapps can use this method to request a wallet to grant the dapp permission to execute transactions on a user's behalf.
-`wallet_grantPermissions` requires a `signer` parameter, which identifies the entity requesting or managing the permission.
+`wallet_requestExecutionPermissions` requires a `signer` parameter, which identifies the entity requesting or managing the permission.
 Common signer implementations include wallet signers, single key and multisig signers, and account signers.
 
 The Smart Accounts Kit supports multiple signer types. The documentation uses [an account signer](../guides/advanced-permissions/execute-on-metamask-users-behalf.md) as a common implementation example.

--- a/gator_versioned_docs/version-1.6.0/get-started/use-skills.md
+++ b/gator_versioned_docs/version-1.6.0/get-started/use-skills.md
@@ -24,7 +24,7 @@ capabilities into your dapp, including smart account creation, delegations, and 
 Permissions.
 
 ```bash
-npx skills add MetaMask/skills/domains/web3-tools/skills/smart-accounts-kit
+npx skills add MetaMask/smart-accounts-kit
 ```
 
 ### Key capabilities

--- a/smart-accounts-kit/concepts/advanced-permissions.md
+++ b/smart-accounts-kit/concepts/advanced-permissions.md
@@ -13,14 +13,16 @@ Advanced Permissions eliminate the need for users to approve every transaction, 
 It also enables dapps to execute transactions for users without an active wallet connection.
 
 :::note
-This feature requires [MetaMask Flask 13.5.0](/snaps/get-started/install-flask) or later.
+This feature requires [MetaMask](https://metamask.io/download) v13.23.0 or later.
+See [supported Advanced Permissions](../get-started/supported-advanced-permissions.md) for the
+minimum version required for each permission type.
 :::
 
 ## ERC-7715 technical overview
 
-[ERC-7715](https://eips.ethereum.org/EIPS/eip-7715) defines a JSON-RPC method `wallet_grantPermissions`.
+[ERC-7715](https://eips.ethereum.org/EIPS/eip-7715) defines a JSON-RPC method `wallet_requestExecutionPermissions`.
 Dapps can use this method to request a wallet to grant the dapp permission to execute transactions on a user's behalf.
-`wallet_grantPermissions` requires a `signer` parameter, which identifies the entity requesting or managing the permission.
+`wallet_requestExecutionPermissions` requires a `signer` parameter, which identifies the entity requesting or managing the permission.
 Common signer implementations include wallet signers, single key and multisig signers, and account signers.
 
 The Smart Accounts Kit supports multiple signer types. The documentation uses [an account signer](../guides/advanced-permissions/execute-on-metamask-users-behalf.md) as a common implementation example.

--- a/smart-accounts-kit/get-started/use-skills.md
+++ b/smart-accounts-kit/get-started/use-skills.md
@@ -24,7 +24,7 @@ capabilities into your dapp, including smart account creation, delegations, and 
 Permissions.
 
 ```bash
-npx skills add MetaMask/skills/domains/web3-tools/skills/smart-accounts-kit
+npx skills add MetaMask/smart-accounts-kit
 ```
 
 ### Key capabilities

--- a/smart-accounts-kit/guides/advanced-permissions/execute-on-metamask-users-behalf.md
+++ b/smart-accounts-kit/guides/advanced-permissions/execute-on-metamask-users-behalf.md
@@ -31,14 +31,14 @@ In this guide, you'll request an ERC-20 periodic transfer permission from a Meta
 ## Prerequisites
 
 - [Install and set up the Smart Accounts Kit.](../../get-started/install.md)
-- [Install MetaMask Flask 13.5.0 or later.](/snaps/get-started/install-flask)
+- [Install MetaMask v13.23.0 or later](https://metamask.io/download)
 
 ## Steps
 
 ### 1. Set up a Wallet Client
 
 Set up a Wallet Client using Viem's [`createWalletClient`](https://viem.sh/docs/clients/wallet) function. This client will
-help you interact with MetaMask Flask.
+help you interact with MetaMask.
 
 Then, extend the Wallet Client functionality using `erc7715ProviderActions`.
 These actions enable you to request <GlossaryTerm term="Advanced Permissions" /> from the user.
@@ -107,51 +107,7 @@ const sessionAccount = privateKeyToAccount('0x...')
 </TabItem>
 </Tabs>
 
-### 4. Check the EOA account code
-
-With MetaMask Flask 13.9.0 or later, Advanced Permissions support automatically upgrading a user's
-account to a [MetaMask smart account](../../concepts/smart-accounts.md). On earlier versions, upgrade
-the user to a smart account before requesting Advanced Permissions.
-
-If the user has not yet been upgraded, you can handle the upgrade [programmatically](/metamask-connect/evm/guides/send-transactions/batch-transactions) or ask the
-user to [switch to a smart account manually](https://support.metamask.io/configure/accounts/switch-to-or-revert-from-a-smart-account/#how-to-switch-to-a-metamask-smart-account).
-
-:::info Why is a Smart Account upgrade is required?
-MetaMask's Advanced Permissions (ERC-7715) implementation requires the user to be upgraded to a MetaMask
-Smart Account because, under the hood, you're requesting a signature for an [ERC-7710 delegation](../../concepts/delegation/overview.md).
-ERC-7710 delegation is one of the core features supported only by MetaMask Smart Accounts.
-:::
-
-```typescript
-import { getSmartAccountsEnvironment } from '@metamask/smart-accounts-kit'
-import { sepolia as chain } from 'viem/chains'
-
-const addresses = await walletClient.requestAddresses()
-const address = addresses[0]
-
-// Get the EOA account code
-const code = await publicClient.getCode({
-  address,
-})
-
-if (code) {
-  // The address to which EOA has delegated. According to EIP-7702, 0xef0100 || address
-  // represents the delegation.
-  //
-  // You need to remove the first 8 characters (0xef0100) to get the delegator address.
-  const delegatorAddress = `0x${code.substring(8)}`
-
-  const statelessDelegatorAddress = getSmartAccountsEnvironment(chain.id).implementations
-    .EIP7702StatelessDeleGatorImpl
-
-  // If account is not upgraded to MetaMask smart account, you can
-  // either upgrade programmatically or ask the user to switch to a smart account manually.
-  const isAccountUpgraded =
-    delegatorAddress.toLowerCase() === statelessDelegatorAddress.toLowerCase()
-}
-```
-
-### 5. Request Advanced Permissions
+### 4. Request Advanced Permissions
 
 Request Advanced Permissions from the user with the Wallet Client's `requestExecutionPermissions` action.
 In this example, you'll request an
@@ -194,7 +150,7 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([
 ])
 ```
 
-### 6. Set up a Viem client
+### 5. Set up a Viem client
 
 Set up a Viem client depending on your session account type.
 
@@ -240,7 +196,7 @@ const sessionAccountWalletClient = createWalletClient({
 </TabItem>
 </Tabs>
 
-### 7. Redeem Advanced Permissions
+### 6. Redeem Advanced Permissions
 
 The session account can now redeem the permissions. The redeem transaction is sent to the `DelegationManager` contract, which validates the delegation and executes actions on the user's behalf.
 

--- a/smart-accounts-kit/guides/smart-accounts/signers/passkey.md
+++ b/smart-accounts-kit/guides/smart-accounts/signers/passkey.md
@@ -15,6 +15,12 @@ secp256r1 (P-256) elliptic curve.
 
 MetaMask Smart Accounts is signer-agnostic and natively supports passkeys (P-256 elliptic curve signatures), so you can use a passkey as the signer.
 
+:::note
+Unlike EOA ECDSA signatures, passkey (WebAuthn) signatures are non-deterministic.
+Signing the same message twice produces different signatures, because the authenticator includes
+fresh data such as counter in each assertion.
+:::
+
 ## Prerequisites
 
 - Install [Node.js](https://nodejs.org/en/blog/release/v18.18.0) v18 or later.

--- a/smart-accounts-kit/reference/delegation/index.md
+++ b/smart-accounts-kit/reference/delegation/index.md
@@ -482,11 +482,14 @@ const enableDelegationData = DelegationManager.encode.enableDelegation({
 
 Encodes an array of delegations to an ABI-encoded hex string.
 
+The delegations must be ordered from leaf to root delegation, with each
+delegation's `authority` referencing the hash of the next entry in the array.
+
 ### Parameters
 
-| Name          | Type                                       | Required | Description                         |
-| ------------- | ------------------------------------------ | -------- | ----------------------------------- |
-| `delegations` | [`Delegation`](../types.md#delegation)`[]` | Yes      | The delegation array to be encoded. |
+| Name          | Type                                       | Required | Description                                                           |
+| ------------- | ------------------------------------------ | -------- | --------------------------------------------------------------------- |
+| `delegations` | [`Delegation`](../types.md#delegation)`[]` | Yes      | The delegation chain to encode, ordered from leaf to root delegation. |
 
 ### Example
 
@@ -704,13 +707,15 @@ export const environment: SmartAccountsEnvironment = {
 Encodes calldata for redeeming delegations.
 This method supports batch redemption, allowing multiple delegations to be processed within a single transaction.
 
+Each inner delegation array must be ordered from leaf to root delegation, with each delegation's `authority` referencing the hash of the next entry in the array.
+
 ### Parameters
 
-| Name          | Type                                                   | Required | Description                                                                                                                                            |
-| ------------- | ------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `delegations` | [`Delegation`](../types.md#delegation)`[][]`           | Yes      | A nested collection representing chains of delegations. Each inner collection contains a chain of delegations to be redeemed.                          |
-| `modes`       | [`ExecutionMode`](../types.md#executionmode)`[]`       | Yes      | A collection specifying the [execution mode](../../concepts/delegation/delegation-manager.md#execution-modes) for each corresponding delegation chain. |
-| `executions`  | [`ExecutionStruct`](../types.md#executionstruct)`[][]` | Yes      | A nested collection where each inner collection contains a list of `ExecutionStruct` objects associated with a specific delegation chain.              |
+| Name          | Type                                                   | Required | Description                                                                                                                                                         |
+| ------------- | ------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `delegations` | [`Delegation`](../types.md#delegation)`[][]`           | Yes      | A nested collection representing chains of delegations. Each inner collection contains a chain of delegations to be redeemed, ordered from leaf to root delegation. |
+| `modes`       | [`ExecutionMode`](../types.md#executionmode)`[]`       | Yes      | A collection specifying the [execution mode](../../concepts/delegation/delegation-manager.md#execution-modes) for each corresponding delegation chain.              |
+| `executions`  | [`ExecutionStruct`](../types.md#executionstruct)`[][]` | Yes      | A nested collection where each inner collection contains a list of `ExecutionStruct` objects associated with a specific delegation chain.                           |
 
 ### Example
 
@@ -789,6 +794,60 @@ export const delegation = createDelegation({
   to: delegate,
   from: account.address,
   environment,
+  scope: {
+    type: ScopeType.NativeTokenTransferAmount,
+    // 0.001 ETH in wei format.
+    maxAmount: parseEther('0.001'),
+  },
+})
+```
+
+</TabItem>
+</Tabs>
+
+## `toDelegationStruct`
+
+Converts a [`Delegation`](../types.md#delegation) object to a
+[`DelegationStruct`](../types.md#delegationstruct) object.
+
+Use when you need to pass a delegation directly to a
+<GlossaryTerm term="Delegation Framework" /> contract call or other onchain interaction that expects
+the struct form.
+
+### Parameters
+
+| Name         | Type                                   | Required | Description                |
+| ------------ | -------------------------------------- | -------- | -------------------------- |
+| `delegation` | [`Delegation`](../types.md#delegation) | Yes      | The delegation to convert. |
+
+### Example
+
+<Tabs>
+<TabItem value="example.ts">
+
+```ts
+import { toDelegationStruct } from '@metamask/smart-accounts-kit/utils'
+import { delegation } from './delegation.ts'
+
+const delegationStruct = toDelegationStruct(delegation)
+```
+
+</TabItem>
+<TabItem value="delegation.ts">
+
+```ts
+import {
+  createDelegation,
+  getSmartAccountsEnvironment,
+  ScopeType,
+} from '@metamask/smart-accounts-kit'
+import { sepolia } from 'viem/chains'
+import { parseEther } from 'viem'
+
+export const delegation = createDelegation({
+  from: '0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1',
+  to: '0x2B2dBd1D5fbeB77C4613B66e9F35dBfE12cB0488',
+  environment: getSmartAccountsEnvironment(sepolia.id),
   scope: {
     type: ScopeType.NativeTokenTransferAmount,
     // 0.001 ETH in wei format.

--- a/smart-accounts-kit/reference/smart-account.md
+++ b/smart-accounts-kit/reference/smart-account.md
@@ -271,6 +271,94 @@ export const smartAccount = await toMetaMaskSmartAccount({
 </TabItem>
 </Tabs>
 
+## `isDeployed`
+
+Checks whether the MetaMask smart account has been deployed on the current chain.
+
+### Example
+
+<Tabs>
+<TabItem value="example.ts">
+
+```ts
+import { smartAccount } from './config.ts'
+
+const isDeployed = await smartAccount.isDeployed()
+```
+
+</TabItem>
+<TabItem value="config.ts">
+
+```ts
+import { createPublicClient, http } from 'viem'
+import { sepolia as chain } from 'viem/chains'
+import { Implementation, toMetaMaskSmartAccount } from '@metamask/smart-accounts-kit'
+
+const publicClient = createPublicClient({
+  chain,
+  transport: http(),
+})
+
+export const smartAccount = await toMetaMaskSmartAccount({
+  client: publicClient,
+  implementation: Implementation.Hybrid,
+  address: '<SMART_ACCOUNT_ADDRESS>',
+})
+```
+
+</TabItem>
+</Tabs>
+
+## `isValid7702Implementation`
+
+Checks whether an <GlossaryTerm term="Externally owned account (EOA)">EOA</GlossaryTerm> has
+been upgraded to MetaMask smart account using [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
+
+### Parameters
+
+| Name             | Type                                                              | Required | Description                                                                                         |
+| ---------------- | ----------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `client`         | `Client`                                                          | Yes      | Viem Client used to read the account's bytecode.                                                    |
+| `accountAddress` | `Address`                                                         | Yes      | The address to check for an EIP-7702 delegation.                                                    |
+| `environment`    | [`SmartAccountsEnvironment`](./types.md#smartaccountsenvironment) | Yes      | Environment to resolve `EIP7702StatelessDeleGatorImpl` smart account address for the current chain. |
+
+### Example
+
+<Tabs>
+<TabItem value="example.ts">
+
+```ts
+import { isValid7702Implementation } from '@metamask/smart-accounts-kit/actions'
+import { publicClient, environment, accountAddress } from './config.ts'
+
+const isUpgraded = await isValid7702Implementation({
+  client: publicClient,
+  accountAddress,
+  environment,
+})
+```
+
+</TabItem>
+<TabItem value="config.ts">
+
+```ts
+import { createPublicClient, http } from 'viem'
+import { sepolia as chain } from 'viem/chains'
+import { getSmartAccountsEnvironment } from '@metamask/smart-accounts-kit'
+
+export const publicClient = createPublicClient({
+  chain,
+  transport: http(),
+})
+
+export const environment = getSmartAccountsEnvironment(chain.id)
+
+export const accountAddress = '0x7E48cA6b7fe6F3d57fdd0448B03b839958416fC1'
+```
+
+</TabItem>
+</Tabs>
+
 ## `signDelegation`
 
 Signs the delegation and returns the delegation signature.

--- a/smart-accounts-kit/reference/types.md
+++ b/smart-accounts-kit/reference/types.md
@@ -144,6 +144,21 @@ Represents a delegation that grants permissions from a <GlossaryTerm term="Deleg
 | `salt`      | `Hex`                   | Yes      | The salt for generating the delegation hash. This helps prevent hash collisions when creating identical delegations.               |
 | `signature` | `Hex`                   | Yes      | The signature to validate the delegation.                                                                                          |
 
+### `DelegationStruct`
+
+The onchain representation of a [`Delegation`](#delegation), used when ABI-encoding or interacting
+directly with the <GlossaryTerm term="Delegation Framework" /> contracts.
+It has the same fields as `Delegation`, except `salt` is a `bigint` instead of a `Hex` string.
+
+| Name        | Type                    | Required | Description                                                                                                                        |
+| ----------- | ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `delegate`  | `Hex`                   | Yes      | The address to which the delegation is being granted.                                                                              |
+| `delegator` | `Hex`                   | Yes      | The address that is granting the delegation.                                                                                       |
+| `authority` | `Hex`                   | Yes      | The parent delegation hash, or `ROOT_AUTHORITY` for creating <GlossaryTerm term="Root delegation">root delegations</GlossaryTerm>. |
+| `caveats`   | [`Caveat`](#caveat)`[]` | Yes      | An array of [caveats](delegation/caveats.md) that constrain the delegation.                                                        |
+| `salt`      | `bigint`                | Yes      | The salt for generating the delegation hash. This helps prevent hash collisions when creating identical delegations.               |
+| `signature` | `Hex`                   | Yes      | The signature to validate the delegation.                                                                                          |
+
 ### `DecodedRevertReason`
 
 Represents a decoded revert reason from a <GlossaryTerm term="Delegation Framework" /> error. Returned by [`decodeRevertData`](delegation/index.md#decoderevertdata) and [`decodeRevertReason`](delegation/index.md#decoderevertreason).


### PR DESCRIPTION
# Description

- Improves the docs based on the Hackathon feedbacks.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits; no runtime or security behavior changes, though removed upgrade guidance could affect integrators who relied on the old Flask-specific flow.
> 
> **Overview**
> Updates Smart Accounts Kit documentation for **Advanced Permissions**, **agent skills**, and **API reference** based on hackathon feedback.
> 
> **ERC-7715 / wallet:** Concept and versioned docs now name the JSON-RPC method **`wallet_requestExecutionPermissions`** (replacing `wallet_grantPermissions`). Current docs require **MetaMask v13.23.0+** and link to per-permission version requirements; the v1.6.0 snapshot only gets the RPC rename.
> 
> **Execute-on-behalf guide:** Prerequisites and copy target standard MetaMask instead of Flask. The **EOA smart-account upgrade** step (`getCode` / EIP-7702 check) is removed and later steps are renumbered (7 → 6).
> 
> **Skills:** The Smart Accounts Kit install command is shortened to **`npx skills add MetaMask/smart-accounts-kit`**.
> 
> **Reference additions:** Documents **`DelegationStruct`**, **`toDelegationStruct`**, **`isDeployed`**, **`isValid7702Implementation`**, and clarifies **leaf-to-root** ordering for `encodeDelegations` / `redeemDelegations`. The passkey guide adds a note that **WebAuthn signatures are non-deterministic**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b592cf9e2c8f6bf0e77cc906d78103a5178d0548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->