### PR TITLE
Embedded Wallets Email resubscription request form

### DIFF
--- a/embedded-wallets/authentication/basic-logins/email-passwordless.mdx
+++ b/embedded-wallets/authentication/basic-logins/email-passwordless.mdx
@@ -69,6 +69,13 @@ const web3AuthContextConfig: Web3AuthContextConfig = {
 export default web3AuthContextConfig
 ```
 
+## Troubleshooting
+
+If OTP or magic link emails do not arrive, the recipient may have unsubscribed from Embedded
+Wallets transactional email.
+See [Email OTP or magic link not received](/embedded-wallets/troubleshooting/email-otp-not-received/)
+for the resubscribe form and other checks.
+
 ## Next steps
 
 Follow our [quickstart](/quickstart/?product=EMBEDDED_WALLETS&walletAggregatorOnly=NO&framework=REACT&stepIndex=0) to set up the basic flow.

--- a/embedded-wallets/troubleshooting/README.mdx
+++ b/embedded-wallets/troubleshooting/README.mdx
@@ -45,6 +45,11 @@ export const GeneralErrors = [
         title: 'Popup blocked issue',
         path: 'popup-blocked-issue',
       },
+      {
+        key: 'email-otp-not-received',
+        title: 'Email OTP not received',
+        path: 'email-otp-not-received',
+      },
     ],
   },
 ]

--- a/embedded-wallets/troubleshooting/email-otp-not-received.mdx
+++ b/embedded-wallets/troubleshooting/email-otp-not-received.mdx
@@ -1,0 +1,57 @@
+---
+title: Email OTP or magic link not received
+image: 'img/metamaskog.jpg'
+sidebar_label: Email OTP not received
+description: 'Resubscribe to MetaMask Embedded Wallets email OTP delivery when passwordless sign-in emails stop arriving.'
+keywords: [email passwordless, OTP, magic link, unsubscribe, troubleshooting, Web3Auth]
+---
+
+If you or your users do not receive a one-time password (OTP) or magic link email during email
+passwordless sign-in, an accidental unsubscribe from MetaMask Embedded Wallets (formerly Web3Auth)
+transactional email may be the cause.
+
+## Problem
+
+During email passwordless sign-in, the expected OTP or magic link email never arrives.
+The sign-in flow may appear to hang or time out while waiting for the code.
+
+This often happens after someone clicks **Unsubscribe** on a previous OTP email from MetaMask
+Embedded Wallets or Web3Auth.
+Once unsubscribed, future OTP and magic link messages are blocked for that address.
+
+## Solution
+
+Submit the [MetaMask Embedded Wallets Email OTP resubscribe request](https://forms.gle/xswCARzSiDpTzxc67)
+with the following details:
+
+1. **Full name**
+2. **Email address** (the same address used for email passwordless sign-in)
+3. Confirmation that this is the email used to sign in to MetaMask Embedded Wallets or an
+   application that uses it
+
+After you submit the form, Embedded Wallets resubscribes the address automatically.
+Allow a few minutes for the change to take effect, then try signing in again.
+
+:::tip For dapp developers
+
+Share the resubscribe form link with end users who report missing OTP emails.
+No dashboard or API action is required on your side.
+
+:::
+
+## Other checks
+
+If emails still do not arrive after resubscribing, verify the following:
+
+- The email address entered at sign-in matches the address submitted on the resubscribe form.
+- The message is not in spam, junk, or promotions folders.
+- Corporate or school email filters are not blocking messages from the Embedded Wallets mail sender.
+- Email passwordless is enabled for your project in the [developer dashboard](https://developer.metamask.io).
+
+For custom email connections, confirm that your own email provider is delivering messages and that
+the recipient has not unsubscribed from your sender domain.
+
+## Related
+
+- [Email passwordless login](../authentication/basic-logins/email-passwordless.mdx)
+- [SMS OTP login](../authentication/basic-logins/sms-otp.mdx)

--- a/embedded-wallets/troubleshooting/email-otp-not-received.mdx
+++ b/embedded-wallets/troubleshooting/email-otp-not-received.mdx
@@ -13,7 +13,7 @@ transactional email may be the cause.
 ## Problem
 
 During email passwordless sign-in, the expected OTP or magic link email never arrives.
-The sign-in flow may appear to hang or time out while waiting for the code.
+The sign-in flow may appear to stop responding or time out while waiting for the code.
 
 This often happens after someone clicks **Unsubscribe** on a previous OTP email from MetaMask
 Embedded Wallets or Web3Auth.
@@ -53,5 +53,5 @@ the recipient has not unsubscribed from your sender domain.
 
 ## Related
 
-- [Email passwordless login](../authentication/basic-logins/email-passwordless.mdx)
-- [SMS OTP login](../authentication/basic-logins/sms-otp.mdx)
+- [Email passwordless sign-in](../authentication/basic-logins/email-passwordless.mdx)
+- [SMS OTP sign-in](../authentication/basic-logins/sms-otp.mdx)


### PR DESCRIPTION
Adds a troubleshooting page for people not receiving OTPs due to email unsubscription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Adds documentation for **missing email passwordless OTP/magic link** delivery when users have unsubscribed from Embedded Wallets transactional mail.
> 
> A new troubleshooting page explains the unsubscribe cause, points to the **Google resubscribe form**, lists follow-up checks (spam, dashboard settings, custom email providers), and links related auth docs. The Embedded Wallets troubleshooting index gains a tile for this page, and **email passwordless** sign-in docs get a short **Troubleshooting** section linking to it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f596fdafa42c35ce47a8f2fdb33000c4fbfb7d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->