### PR TITLE
docs: fix placeholders and syntax highlighting

### DIFF
--- a/services/tutorials/ethereum/deploy-a-contract-using-web3.js.md
+++ b/services/tutorials/ethereum/deploy-a-contract-using-web3.js.md
@@ -88,7 +88,7 @@ SIGNER_PRIVATE_KEY = "<YOUR-PRIVATE-KEY>"
 Ensure you replace the following values in the `.env` file:
 
 - `<YOUR-API-KEY>` with the API key of the Ethereum project.
-- `<Private-Key>` with the [private key of your Ethereum account](https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key).
+- `<YOUR-PRIVATE-KEY>` with the [private key of your Ethereum account](https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key).
 - If using a network other than Sepolia, ensure you update `ETHEREUM_NETWORK` with the network name.
 
 :::danger
@@ -101,7 +101,7 @@ Never disclose your private key. Anyone with your private keys can steal any ass
 
 Using an editor, create a smart contract. In this example, we'll create a basic contract called `Demo.sol`.
 
-```javascript
+```solidity
 pragma solidity >=0.5.8;
 
 contract Demo {


### PR DESCRIPTION
## Description
Fixed inconsistencies in the `web3.js` contract deployment tutorial:
- Unified placeholder names in `.env` example and text description
- Corrected code block language from `javascript` to `solidity`

## Changes
- Replaced `<Private-Key>` with `<YOUR-PRIVATE-KEY>` to match .env variable
- Changed code fence from ```javascript to ```solidity for the Demo.sol contract

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tutorial markdown only; no runtime, config, or security-sensitive code paths change.
> 
> **Overview**
> **Documentation-only** fixes in `deploy-a-contract-using-web3.js.md` so the tutorial reads consistently.
> 
> The `.env` setup step now tells readers to substitute **`<YOUR-PRIVATE-KEY>`** (aligned with the sample `SIGNER_PRIVATE_KEY` line) instead of the mismatched **`<Private-Key>`** placeholder.
> 
> The **`Demo.sol`** snippet is fenced as **`solidity`** instead of **`javascript`**, so syntax highlighting matches the contract source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce1f1ccbedc8dc458db721aeb1f11cad76dcd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->