### PR TITLE
Add MetaMask Connect skills documentation

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -38,6 +38,7 @@ ignorePatterns:
   - pattern: 'https://0xfury.com/privacy'
   - pattern: '^https://docs.arbitrum.io'
   - pattern: '^https://nodefleet.org'
+  - pattern: '^https://bwarelabs.com'
 aliveStatusCodes:
   - 200
   - 206

--- a/metamask-connect/use-skills.md
+++ b/metamask-connect/use-skills.md
@@ -1,0 +1,41 @@
+---
+sidebar_label: Use skills
+description: Use MetaMask Connect skills to give your agent framework context on integrating the SDK into your dapp.
+keywords: [skill, ai, agent framework, metamask connect, sdk, evm, solana, multichain]
+---
+
+# Use skills
+
+Use skills to give your agent framework context on integrating MetaMask Connect into your dapp.
+Skills guide your agent through client setup for EVM, Solana, and multichain, connections and
+sessions, signing and sending transactions, and migrating from the legacy SDK.
+
+Skills are available through the open-source
+[`metamask/connect-monorepo`](https://github.com/metamask/connect-monorepo) repository.
+
+## MetaMask Connect
+
+This skill gives your agent context on MetaMask Connect and how to integrate its capabilities into
+your dapp, including client setup, connections, sessions, and signing and sending transactions
+across EVM and Solana.
+
+```bash
+npx skills add MetaMask/connect-monorepo
+```
+
+### Key capabilities
+
+| Capability               | Description                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Client setup             | Set up EVM, Solana, or multichain clients in browser JavaScript/TypeScript, React, or React Native.   |
+| Connections and sessions | Connect, disconnect, manage the provider and session state, and switch chains.                        |
+| Sign and send            | Sign messages (`personal_sign`, `eth_signTypedData_v4`, Solana `signMessage`) and send transactions.  |
+| Wagmi and migration      | Use the Wagmi `metaMask()` connector, or migrate an existing `@metamask/sdk` integration.             |
+| Headless mode            | Build Node.js CLI, server, or bot integrations that connect to the MetaMask mobile app via a QR code. |
+
+## Next steps
+
+- [Compare integration options](integration-options.md)
+- [Get started with EVM](evm/index.mdx)
+- [Get started with multichain](multichain/index.mdx)
+- [Get started with Solana](solana/index.mdx)

--- a/mm-connect-sidebar.js
+++ b/mm-connect-sidebar.js
@@ -7,6 +7,7 @@ const metamaskConnectSidebar = {
     'architecture',
     'integration-options',
     'supported-platforms',
+    'use-skills',
     {
       type: 'category',
       label: 'Reference',
@@ -58,6 +59,7 @@ const metamaskConnectSidebar = {
         'multichain/quickstart/react-native',
       ],
     },
+    { type: 'link', label: 'Use skills', href: '/metamask-connect/use-skills' },
     {
       type: 'category',
       label: 'Concepts',
@@ -113,6 +115,7 @@ const metamaskConnectSidebar = {
         // 'evm/quickstart/web3auth',
       ],
     },
+    { type: 'link', label: 'Use skills', href: '/metamask-connect/use-skills' },
     {
       type: 'category',
       label: 'Guides',
@@ -267,6 +270,7 @@ const metamaskConnectSidebar = {
         // 'solana/quickstart/web3auth',
       ],
     },
+    { type: 'link', label: 'Use skills', href: '/metamask-connect/use-skills' },
     {
       type: 'category',
       label: 'Guides',


### PR DESCRIPTION
# Description

Add 'Use skills' guide to help developers integrate MetaMask Connect skills into their agent frameworks. Includes instructions for EVM, Solana, and multichain client setup. Update sidebar navigation to include links to the new page across multiple sections.



<!-- Describe the changes made in your pull request (PR). -->

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and link-checker config only; no application or SDK code changes.
> 
> **Overview**
> Adds a **Use skills** doc page under MetaMask Connect that explains how developers can load agent skills from `MetaMask/connect-monorepo` via `npx skills add`, with a capabilities table (client setup, sessions, signing, Wagmi/migration, headless mode) and links to existing integration quickstarts.
> 
> Navigation is updated so **Use skills** appears in the overview sidebar and as cross-links from the multichain, EVM, and Solana doc sidebars.
> 
> Also whitelists `https://bwarelabs.com` in `.linkspector.yml` for link checking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a65a7db02c2456bdf88fc3775f254ad624fb50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->