### PR TITLE
Fix redirection to infura docs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -177,6 +177,11 @@
       "permanent": true
     },
     {
+      "source": "/services/",
+      "destination": "https://docs.infura.io/",
+      "permanent": true
+    },
+    {
       "source": "/services/:path*",
       "destination": "https://docs.infura.io/:path*",
       "permanent": true


### PR DESCRIPTION
Fix one missed redirection to infura docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single redirect rule in Vercel config; no application or auth logic changes.
> 
> **Overview**
> Adds a **permanent** redirect in `vercel.json` so **`/services/`** goes to **`https://docs.infura.io/`**, placed **before** the existing **`/services/:path*`** catch-all.
> 
> This closes a gap where the services index URL was not reliably sent to the Infura docs homepage like the rest of the `/services/*` migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfff663ffb53dad6dbd1010864c074decabb909d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->