### PR TITLE
Update Agent Wallet docs

### DIFF
--- a/agent-wallet/guides/earn-yield-vaults.md
+++ b/agent-wallet/guides/earn-yield-vaults.md
@@ -52,15 +52,16 @@ mm earn positions
 Supply tokens to a yield vault:
 
 ```bash
-mm earn supply --token <TOKEN> --amount <AMOUNT> [--chain <chain-id>] [--from-chain <chain-id>]
+mm earn supply --token <TOKEN> --amount <AMOUNT> [--chain <chain-id>] [--from-chain <chain-id>] [--wait]
 ```
 
-| Flag           | Required | Description                           |
-| -------------- | -------- | ------------------------------------- |
-| `--token`      | Yes      | Token symbol or contract address      |
-| `--amount`     | Yes      | Human-readable amount to supply       |
-| `--chain`      | No       | Destination chain for the vault       |
-| `--from-chain` | No       | Source chain if supplying cross-chain |
+| Flag           | Required | Description                                                       |
+| -------------- | -------- | ----------------------------------------------------------------- |
+| `--token`      | Yes      | Token symbol or contract address                                  |
+| `--amount`     | Yes      | Human-readable amount to supply                                   |
+| `--chain`      | No       | Destination chain for the vault                                   |
+| `--from-chain` | No       | Source chain if supplying cross-chain                             |
+| `--wait`       | No       | Poll until the position reflects (up to ~45s) and confirm balance |
 
 The CLI automatically handles ERC-20 approval when the vault's allowance is insufficient.
 

--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -40,7 +40,7 @@ npx skills add MetaMask/agent-skills
 When prompted, install `metamask-agent-wallet`.
 
 Reinstall skills if you previously installed an older version.
-The current skills target CLI v5.0.0.
+The current skills target CLI v5.1.0.
 
 ## 3. Complete setup
 

--- a/agent-wallet/reference/commands.md
+++ b/agent-wallet/reference/commands.md
@@ -413,12 +413,12 @@ mm decode <0x-calldata>
 
 Yield vault operations. Supply and withdraw from vaults across supported chains and protocols.
 
-| Command             | Usage summary                                                                |
-| ------------------- | ---------------------------------------------------------------------------- |
-| `mm earn markets`   | `[--chain <chain>] [--protocol <protocol>] [--min-tvl <amount>]`             |
-| `mm earn positions` | View current yield positions                                                 |
-| `mm earn supply`    | `--token <token> --amount <amount> [--chain <chain>] [--from-chain <chain>]` |
-| `mm earn withdraw`  | `--token <token> --amount <amount> [--chain <chain>]`                        |
+| Command             | Usage summary                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| `mm earn markets`   | `[--chain <chain>] [--protocol <protocol>] [--min-tvl <amount>]`                      |
+| `mm earn positions` | View current yield positions                                                          |
+| `mm earn supply`    | `--token <token> --amount <amount> [--chain <chain>] [--from-chain <chain>] [--wait]` |
+| `mm earn withdraw`  | `--token <token> --amount <amount> [--chain <chain>]`                                 |
 
 ### `mm earn markets`
 
@@ -442,10 +442,13 @@ Supply tokens to a yield vault. The CLI handles ERC-20 approval automatically wh
 allowance is insufficient.
 
 ```bash
-mm earn supply --token <token> --amount <amount> [--chain <chain-id>] [--from-chain <chain-id>]
+mm earn supply --token <token> --amount <amount> [--chain <chain-id>] [--from-chain <chain-id>] [--wait]
 ```
 
 Use `--from-chain` for cross-chain supply operations that bridge and supply in one step.
+Use `--wait` to poll until the position reflects in the portfolio (up to ~45 seconds) and display
+an inline balance confirmation. Without `--wait`, the CLI prints a hint that positions may lag
+15–30 seconds.
 
 ### `mm earn withdraw`
 

--- a/agent-wallet/reference/error-codes.md
+++ b/agent-wallet/reference/error-codes.md
@@ -84,9 +84,21 @@ Run `mm <command> --help` for command-specific validation rules.
 
 <!-- vale off -->
 
-Common Hyperliquid failures include `ORDER_REJECTED`, `DEPOSIT_FAILED`, `INSUFFICIENT_BALANCE`, and
-`HYPERLIQUID_ERROR` when the venue sub-account has not been funded. See
-[Trade perpetuals](../guides/trade-perpetuals.md).
+| Code                      | Meaning                                                |
+| ------------------------- | ------------------------------------------------------ |
+| `ORDER_REJECTED`          | Order rejected by Hyperliquid                          |
+| `DEPOSIT_FAILED`          | Deposit to venue failed                                |
+| `INSUFFICIENT_BALANCE`    | Venue sub-account has insufficient balance             |
+| `MINIMUM_DEPOSIT_AMOUNT`  | Deposit below Hyperliquid minimum                      |
+| `MINIMUM_WITHDRAW_AMOUNT` | Withdrawal below Hyperliquid minimum                   |
+| `MINIMUM_ORDER_NOTIONAL`  | Order notional below $10 floor                         |
+| `HYPERLIQUID_ERROR`       | Generic Hyperliquid error (often unfunded sub-account) |
+
+The CLI provides actionable hints for common failures — for example, minimum amounts for deposits
+and withdrawals, the $10 notional floor for orders, funding shortfalls (including `--include-spot`),
+and source-chain mismatches. Operational errors surface a retry hint instead of raw provider text.
+
+See [Trade perpetuals](../guides/trade-perpetuals.md).
 
 <!-- vale on -->
 
@@ -108,6 +120,13 @@ Common Hyperliquid failures include `ORDER_REJECTED`, `DEPOSIT_FAILED`, `INSUFFI
 | `EARN_INSUFFICIENT_BALANCE` | Insufficient balance for earn supply                  |
 | `EARN_WITHDRAW_REVERTED`    | Withdraw transaction reverted (retried automatically) |
 | `EARN_ERROR`                | Generic earn error                                    |
+
+## Server-wallet errors
+
+| Code                | Meaning                                             |
+| ------------------- | --------------------------------------------------- |
+| `JOB_TIMEOUT`       | Wallet job timed out (default 10 minutes, max 600s) |
+| `REQUEST_NOT_FOUND` | Server-wallet request not found                     |
 
 ## Network errors
 

--- a/agent-wallet/troubleshooting.md
+++ b/agent-wallet/troubleshooting.md
@@ -91,6 +91,17 @@ mm perps balance --venue hyperliquid
 
 See [Trade perpetuals](guides/trade-perpetuals.md).
 
+### Minimum deposit, withdraw, or order notional errors
+
+The CLI provides actionable hints for Hyperliquid minimum-amount failures:
+
+- **`MINIMUM_DEPOSIT_AMOUNT`** / **`MINIMUM_WITHDRAW_AMOUNT`**: the error shows the required minimum
+  and your actual amount. Increase the amount and retry.
+- **`MINIMUM_ORDER_NOTIONAL`**: orders below $10 notional are rejected. Increase your position size
+  or leverage.
+- **Funding shortfall**: if your venue balance can't cover the order, deposit more USDC or use
+  `--include-spot` to include spot balance.
+
 ## Prediction markets
 
 ### `JsonRpcError: execution reverted` on predict deposit
@@ -137,6 +148,15 @@ execution. The CLI applies a small dust buffer for `--amount all` withdrawals, b
 reverts, it automatically retries up to 3 times. If retries fail, try withdrawing a slightly smaller
 amount.
 
+### Position not showing after supply
+
+Earn positions can lag 15–30 seconds after deposit. Use `--wait` on `mm earn supply` to
+poll until the position reflects (up to ~45 seconds), or check manually:
+
+```bash
+mm earn positions --chain <CHAIN_ID>
+```
+
 ### Approval required for supply
 
 When supplying for the first time, the CLI sends an ERC-20 approval transaction before the supply.
@@ -162,6 +182,9 @@ Use `--wait` on signing and transfer commands, or watch the job:
 ```bash
 mm wallet requests watch --polling-id <POLLING_ID>
 ```
+
+The default wallet job poll timeout is 10 minutes. You can override it with `--wallet-timeout`
+(max 600 seconds).
 
 See [Architecture](reference/architecture.md).
 


### PR DESCRIPTION
# Description

Update Agent Wallet docs to v5.1.0

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documentation is bumped to **CLI v5.1.0** (skills compatibility in quickstart) and reflects new earn, perps, server-wallet, and troubleshooting behavior.
> 
> **Earn:** `mm earn supply` documents optional **`--wait`** to poll until positions show (~45s) and confirm balance; guides and commands reference explain the default 15–30s lag without `--wait`.
> 
> **Errors & troubleshooting:** Perpetuals errors are expanded into a table (minimum deposit/withdraw, $10 notional, etc.) with notes on CLI hints and `--include-spot`. **Server-wallet** codes `JOB_TIMEOUT` and `REQUEST_NOT_FOUND` are added. Troubleshooting covers Hyperliquid minimums, earn position lag, and **`--wallet-timeout`** (default 10 min, max 600s) for wallet job polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e13b0e2ea3dc482e36919e50b382c5e806d225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->