### PR TITLE
[Agent Wallet] Update docs

### DIFF
--- a/agent-wallet/guides/swap-and-bridge.md
+++ b/agent-wallet/guides/swap-and-bridge.md
@@ -101,12 +101,25 @@ Available strategies: `cost`, `speed`, `impact`, `output`. The default is `cost,
 When your wallet's native balance cannot cover gas, the CLI automatically uses gasless execution
 via the EIP-7702 relay for eligible quotes. No additional flags are required.
 
+## Unavailable quotes
+
+When the bridge returns zero routes for actionable reasons, `mm swap quote` returns a soft
+unavailable result (exit 0) instead of a hard error. The response includes:
+
+- `kind: "unavailable"` — no quote was generated.
+- `reason` — one of `AMOUNT_TOO_LOW`, `SLIPPAGE_TOO_HIGH`, `NO_QUOTES`, or other actionable codes.
+- `message` — a human-readable explanation.
+- `hint` — guidance on how to adjust and retry.
+
+Your agent can inspect the reason and adjust amount, slippage, or token before retrying.
+Only the transient `QUOTE_RETRY` bridge signal produces a hard error (exit 1).
+
 ## Common pitfalls
 
 :::caution Verify the quote step succeeded
-If `mm swap quote` returns an error or no quote ID, do not call `mm swap execute` with a fabricated
-or expired quote ID. The execute step fails and no transaction is submitted, even when partial
-output is printed.
+If `mm swap quote` returns an unavailable result or no quote ID, do not call `mm swap execute` with
+a fabricated or expired quote ID. The execute step fails and no transaction is submitted, even when
+partial output is printed.
 :::
 
 ## Related commands

--- a/agent-wallet/guides/trade-prediction-markets.md
+++ b/agent-wallet/guides/trade-prediction-markets.md
@@ -75,7 +75,7 @@ order.
 2. Preview a quote:
 
    ```bash
-   mm predict quote --token-id <TOKEN_ID> --side buy --size <SIZE> [--limit-price <PRICE>]
+   mm predict quote --token-id <TOKEN_ID> --side buy --size <SIZE> [--limit-price <PRICE>] [--tick-size <TICK>]
    ```
 
 3. Inspect a market to get outcome token IDs:
@@ -87,11 +87,14 @@ order.
 4. Place the order:
 
    ```bash
-   mm predict place --token-id <TOKEN_ID> --side buy --size <SIZE> --price <PRICE> [--order-type GTC|GTD|FOK|FAK]
+   mm predict place --token-id <TOKEN_ID> --side buy --size <SIZE> --price <PRICE> [--order-type GTC|GTD|FOK|FAK] [--tick-size <TICK>]
    ```
 
    `--limit-price` applies to `mm predict quote` only. `mm predict place` requires `--price`
    (worst fill price per share, between 0 and 1).
+
+   Use `--tick-size` to override the market's default tick size. Valid values: `0.1`, `0.01`,
+   `0.005`, `0.0025`, `0.001`, `0.0001`. Defaults to the CLOB tick size for the token when omitted.
 
 5. View open orders and positions:
 

--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -40,7 +40,7 @@ npx skills add MetaMask/agent-skills
 When prompted, install `metamask-agent-wallet`.
 
 Reinstall skills if you previously installed an older version.
-The current skills target CLI v5.1.0.
+The current skills target CLI v5.2.0.
 
 ## 3. Complete setup
 

--- a/agent-wallet/reference/commands.md
+++ b/agent-wallet/reference/commands.md
@@ -283,6 +283,11 @@ The CLI streams quotes via SSE for faster response times.
 Use `--all-quotes` to compare routes, then execute a specific one with `--quote-id`.
 Old quote artifacts are automatically pruned after 24 hours.
 
+When the bridge returns zero routes for actionable reasons, `mm swap quote` returns a soft
+unavailable result (exit 0) with `kind: "unavailable"`, a `reason` (such as `AMOUNT_TOO_LOW`,
+`SLIPPAGE_TOO_HIGH`, or `NO_QUOTES`), a `message`, and a `hint`. Only the transient `QUOTE_RETRY`
+signal produces a hard error (exit 1).
+
 ### `mm swap execute`
 
 ```bash
@@ -361,8 +366,8 @@ Polymarket prediction market commands.
 | `mm predict series get`     | Retrieve a single event series                           |
 | `mm predict tags list`      | List Polymarket tags                                     |
 | `mm predict tags get`       | Retrieve a tag by ID or slug                             |
-| `mm predict quote`          | Preview order cost                                       |
-| `mm predict place`          | Place an order                                           |
+| `mm predict quote`          | Preview order cost (supports `--tick-size`)              |
+| `mm predict place`          | Place an order (supports `--tick-size`)                  |
 | `mm predict cancel`         | Cancel orders                                            |
 | `mm predict orders`         | List open orders                                         |
 | `mm predict positions`      | View positions                                           |
@@ -370,6 +375,10 @@ Polymarket prediction market commands.
 | `mm predict book`           | Order book for a token                                   |
 | `mm predict watch`          | Watch a predict job                                      |
 | `mm predict geoblock`       | Check Polymarket geoblock for your IP                    |
+
+`mm predict quote` and `mm predict place` accept an optional `--tick-size` flag to override the
+market's default tick size. Valid values: `0.1`, `0.01`, `0.005`, `0.0025`, `0.001`, `0.0001`.
+Defaults to the CLOB tick size for the token.
 
 <!-- vale on -->
 

--- a/agent-wallet/reference/error-codes.md
+++ b/agent-wallet/reference/error-codes.md
@@ -50,35 +50,37 @@ Run `mm <command> --help` for command-specific validation rules.
 
 ## Wallet errors (`WalletError`)
 
-| Code                 | Meaning                                          |
-| -------------------- | ------------------------------------------------ |
-| `MISSING_MNEMONIC`   | Bring your own wallet mode is missing a mnemonic |
-| `MNEMONIC_LOCKED`    | Mnemonic is password-protected                   |
-| `WRONG_PASSWORD`     | Mnemonic password is incorrect                   |
-| `WALLET_NOT_FOUND`   | Wallet not found                                 |
-| `WALLET_ERROR`       | Wallet operation failed                          |
-| `NO_AUTH_TOKEN`      | Missing authentication token                     |
-| `NO_PROJECT_ID`      | Project ID not configured                        |
-| `NO_HISTORY_WALLETS` | No EVM wallets found for `mm tx history`         |
-| `TX_NOT_FOUND`       | Transaction hash not found onchain               |
-| `INVALID_TX_HASH`    | Malformed transaction hash                       |
+| Code                    | Meaning                                          |
+| ----------------------- | ------------------------------------------------ |
+| `MISSING_MNEMONIC`      | Bring your own wallet mode is missing a mnemonic |
+| `MNEMONIC_LOCKED`       | Mnemonic is password-protected                   |
+| `WRONG_PASSWORD`        | Mnemonic password is incorrect                   |
+| `WALLET_NOT_FOUND`      | Wallet not found                                 |
+| `WALLET_NOT_REGISTERED` | BYOK wallet registration failed during `mm init` |
+| `WALLET_ERROR`          | Wallet operation failed                          |
+| `NO_AUTH_TOKEN`         | Missing authentication token                     |
+| `NO_PROJECT_ID`         | Project ID not configured                        |
+| `NO_HISTORY_WALLETS`    | No EVM wallets found for `mm tx history`         |
+| `TX_NOT_FOUND`          | Transaction hash not found onchain               |
+| `INVALID_TX_HASH`       | Malformed transaction hash                       |
 
 ## Swap errors (`SwapCommandError`)
 
-| Code                  | Meaning                                 |
-| --------------------- | --------------------------------------- |
-| `NO_QUOTES`           | No swap quotes returned for the request |
-| `INVALID_SWAP_PARAMS` | Missing or invalid swap parameters      |
-| `TOKEN_NOT_FOUND`     | Token not found for the selected chain  |
-| `QUOTE_NOT_FOUND`     | Quote ID not found                      |
-| `NO_TRADE_DATA`       | Selected quote has no trade transaction |
-| `EXECUTE_FAILED`      | Swap execution failed                   |
-| `STATUS_UNAVAILABLE`  | Swap status unavailable                 |
-| `INSUFFICIENT_FUNDS`  | Source token balance insufficient       |
-| `INSUFFICIENT_GAS`    | Native balance cannot cover gas fees    |
-| `AMOUNT_TOO_LOW`      | Swap amount below minimum threshold     |
-| `SLIPPAGE_TOO_HIGH`   | Slippage exceeds acceptable range       |
-| `SWAP_ERROR`          | Generic swap error                      |
+| Code                  | Meaning                                                |
+| --------------------- | ------------------------------------------------------ |
+| `NO_QUOTES`           | No swap quotes returned for the request                |
+| `INVALID_SWAP_PARAMS` | Missing or invalid swap parameters                     |
+| `TOKEN_NOT_FOUND`     | Token not found for the selected chain                 |
+| `QUOTE_NOT_FOUND`     | Quote ID not found                                     |
+| `NO_TRADE_DATA`       | Selected quote has no trade transaction                |
+| `EXECUTE_FAILED`      | Swap execution failed                                  |
+| `STATUS_UNAVAILABLE`  | Swap status unavailable                                |
+| `INSUFFICIENT_FUNDS`  | Source token balance insufficient                      |
+| `INSUFFICIENT_GAS`    | Native balance cannot cover gas fees                   |
+| `AMOUNT_TOO_LOW`      | Swap amount below minimum threshold                    |
+| `SLIPPAGE_TOO_HIGH`   | Slippage exceeds acceptable range                      |
+| `QUOTE_RETRY`         | Transient bridge quote-stream retry signal (retryable) |
+| `SWAP_ERROR`          | Generic swap error                                     |
 
 ## Perpetuals errors
 
@@ -104,13 +106,15 @@ See [Trade perpetuals](../guides/trade-perpetuals.md).
 
 ## Predict errors
 
-| Code                                   | Meaning                                      |
-| -------------------------------------- | -------------------------------------------- |
-| `PREDICT_SETUP_REQUIRED`               | Run `mm predict setup` before this operation |
-| `PREDICT_AUTH_REQUIRED`                | Predict credentials missing or expired       |
-| `PREDICT_INSUFFICIENT_BALANCE`         | Insufficient pUSD in the deposit wallet      |
-| `PREDICT_INSUFFICIENT_FUNDING_BALANCE` | Insufficient USDC.e for `mm predict deposit` |
-| `PREDICT_ERROR`                        | Generic predict error                        |
+| Code                                   | Meaning                                                    |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `PREDICT_SETUP_REQUIRED`               | Run `mm predict setup` before this operation               |
+| `PREDICT_AUTH_REQUIRED`                | Predict credentials missing or expired                     |
+| `PREDICT_INSUFFICIENT_BALANCE`         | Insufficient pUSD in the deposit wallet                    |
+| `PREDICT_INSUFFICIENT_FUNDING_BALANCE` | Insufficient USDC.e for `mm predict deposit`               |
+| `PREDICT_INSUFFICIENT_GAS`             | Insufficient native POL for gas on predict deposit         |
+| `INVALID_TICK_SIZE`                    | Invalid `--tick-size` value for `mm predict quote`/`place` |
+| `PREDICT_ERROR`                        | Generic predict error                                      |
 
 ## Earn errors
 

--- a/agent-wallet/troubleshooting.md
+++ b/agent-wallet/troubleshooting.md
@@ -115,12 +115,19 @@ mm predict deposit --amount <AMOUNT> --wait
 
 See [Trade prediction markets](guides/trade-prediction-markets.md).
 
+### `PREDICT_INSUFFICIENT_GAS` on predict deposit
+
+You need native POL on Polygon to cover gas for the predict deposit transaction. Fund your wallet
+with POL before retrying.
+
 ## Swaps
 
-### `NO_QUOTES` or no quote ID from `mm swap quote`
+### `NO_QUOTES` or unavailable quote from `mm swap quote`
 
-Liquidity may be unavailable for the token pair or chain. Do not call `mm swap execute` without a
-valid `quoteId` from a successful quote step.
+When the bridge returns zero routes for actionable reasons, `mm swap quote` returns a soft
+unavailable result (exit 0) with a `reason`, `message`, and `hint`. Common reasons include
+`AMOUNT_TOO_LOW`, `SLIPPAGE_TOO_HIGH`, and `NO_QUOTES`. Adjust the amount, slippage, or token and
+retry. Do not call `mm swap execute` without a valid `quoteId` from a successful quote step.
 
 When bridging with `--refuel`, do not use the flag if the destination token is the destination
 chain's native gas asset (for example, bridging ETH to Arbitrum ETH).


### PR DESCRIPTION
# Description
- Updates for v5.2.0 release of AW.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates Agent Wallet documentation for **CLI v5.2.0**, including the skills compatibility note in the quickstart (v5.1.0 → v5.2.0).
> 
> **Swaps:** Documents that `mm swap quote` can return a **soft unavailable** result (exit 0) with `kind: "unavailable"`, `reason`, `message`, and `hint` when the bridge has no routes for actionable reasons (`AMOUNT_TOO_LOW`, `SLIPPAGE_TOO_HIGH`, `NO_QUOTES`, etc.). Only **`QUOTE_RETRY`** is documented as a hard error (exit 1). Guides, command reference, troubleshooting, and swap pitfalls are aligned with this behavior.
> 
> **Prediction markets:** Documents optional **`--tick-size`** on `mm predict quote` and `mm predict place`, including allowed values and default-to-CLOB behavior.
> 
> **Error codes & troubleshooting:** Adds **`WALLET_NOT_REGISTERED`**, **`QUOTE_RETRY`**, **`PREDICT_INSUFFICIENT_GAS`**, and **`INVALID_TICK_SIZE`**, plus guidance to fund **POL** on Polygon when predict deposit fails for gas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99777accdcd4251323626f569bdc760eb0333588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->