### PR TITLE
[Agent Wallet] Update docs for v5.3.0

### DIFF
--- a/agent-wallet/guides/trade-prediction-markets.md
+++ b/agent-wallet/guides/trade-prediction-markets.md
@@ -24,6 +24,10 @@ You (to your agent): "Show my open prediction market positions"
 You (to your agent): "Redeem my winning Polymarket positions"
 ```
 
+```text
+You (to your agent): "Show my Polymarket trade history"
+```
+
 Your agent runs one-time setup if needed, shows current odds, confirms your bet, then places the
 order.
 
@@ -103,6 +107,31 @@ order.
    mm predict positions
    mm predict portfolio
    ```
+
+## View trade history
+
+List your deposit-wallet trade activity:
+
+```bash
+mm predict history
+```
+
+Filter by type, paginate, and sort:
+
+```bash
+mm predict history --limit 20 --offset 20
+mm predict history --type redeem --sort-by cash --sort-direction desc
+mm predict history --start 1700000000 --end 1700600000
+```
+
+Inspect activity for a specific market condition:
+
+```bash
+mm predict history get <CONDITION_ID>
+mm predict history get <CONDITION_ID> --type redeem
+```
+
+Trade rows include outcome, win/lose status, redeemed status, and amount won.
 
 ## Redeem winnings
 

--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -40,7 +40,7 @@ npx skills add MetaMask/agent-skills
 When prompted, install `metamask-agent-wallet`.
 
 Reinstall skills if you previously installed an older version.
-The current skills target CLI v5.2.1.
+The current skills target CLI v5.3.0.
 
 ## 3. Complete setup
 

--- a/agent-wallet/reference/commands.md
+++ b/agent-wallet/reference/commands.md
@@ -90,6 +90,8 @@ Check authentication status. No additional flags beyond global flags.
 ## `mm logout`
 
 Sign out and revoke the CLI session.
+When no CLI auth session is stored, returns `reason: ALREADY_LOGGED_OUT` with a hint to run
+`mm login` instead of the same success payload as a real sign-out. Still exits with code 0.
 
 ## `mm reset`
 
@@ -291,8 +293,8 @@ signal produces a hard error (exit 1).
 ### `mm swap execute`
 
 ```bash
-mm swap execute --quote-id <id>
-mm swap execute --from <token> --to <token> --amount <amount> --from-chain <chain-id> [--to-chain <chain-id>] [--to-address <address>] [--slippage <percent>] [--refuel]
+mm swap execute --quote-id <id> [--wallet-timeout <seconds>]
+mm swap execute --from <token> --to <token> --amount <amount> --from-chain <chain-id> [--to-chain <chain-id>] [--to-address <address>] [--slippage <percent>] [--refuel] [--wallet-timeout <seconds>]
 ```
 
 When executing by `--quote-id`, the persisted quote retains `--to-address` and `--refuel` settings
@@ -307,6 +309,11 @@ EIP-7702 relay for gas-included quotes.
 
 The CLI runs an `INSUFFICIENT_FUNDS` preflight check before execution and returns actionable hints
 if the source token balance is insufficient.
+
+MFA poll timeouts on gasless relay and sequential server-wallet legs surface `RELAY_TIMEOUT` or
+`JOB_TIMEOUT` errors with a recovery hint to run `mm wallet requests watch --polling-id <id>` and
+a warning not to re-run execute while the job may still complete. Gasless relay polling honors
+`--wallet-timeout` and the CLI's 10-minute default.
 
 ### `mm swap status`
 
@@ -345,40 +352,75 @@ Hyperliquid perpetuals commands. Most commands require `--venue hyperliquid`.
 
 Polymarket prediction market commands.
 
-| Command                     | Description                                              |
-| --------------------------- | -------------------------------------------------------- |
-| `mm predict setup`          | One-time predict setup                                   |
-| `mm predict deposit`        | Fund predict deposit wallet                              |
-| `mm predict balance`        | Check predict balance                                    |
-| `mm predict mode`           | Set `mainnet` or `testnet`                               |
-| `mm predict auth`           | Refresh predict credentials                              |
-| `mm predict approve`        | Repair approvals                                         |
-| `mm predict status`         | Backend status                                           |
-| `mm predict portfolio`      | Snapshot of pUSD balance, positions, redeemable winnings |
-| `mm predict redeem list`    | List redeemable winning positions                        |
-| `mm predict redeem`         | Redeem one or all winning positions                      |
-| `mm predict markets search` | Search markets                                           |
-| `mm predict markets list`   | List markets with filters                                |
-| `mm predict markets get`    | Inspect a market (slug, ID, or condition ID)             |
-| `mm predict events list`    | List Polymarket events with filters                      |
-| `mm predict events get`     | Retrieve a single event by ID or slug                    |
-| `mm predict series list`    | List event series                                        |
-| `mm predict series get`     | Retrieve a single event series                           |
-| `mm predict tags list`      | List Polymarket tags                                     |
-| `mm predict tags get`       | Retrieve a tag by ID or slug                             |
-| `mm predict quote`          | Preview order cost (supports `--tick-size`)              |
-| `mm predict place`          | Place an order (supports `--tick-size`)                  |
-| `mm predict cancel`         | Cancel orders                                            |
-| `mm predict orders`         | List open orders                                         |
-| `mm predict positions`      | View positions                                           |
-| `mm predict withdraw`       | Withdraw pUSD from deposit wallet                        |
-| `mm predict book`           | Order book for a token                                   |
-| `mm predict watch`          | Watch a predict job                                      |
-| `mm predict geoblock`       | Check Polymarket geoblock for your IP                    |
+| Command                     | Description                                                        |
+| --------------------------- | ------------------------------------------------------------------ |
+| `mm predict setup`          | One-time predict setup                                             |
+| `mm predict deposit`        | Fund predict deposit wallet                                        |
+| `mm predict balance`        | Check predict balance                                              |
+| `mm predict mode`           | Set `mainnet` or `testnet`                                         |
+| `mm predict auth`           | Refresh predict credentials                                        |
+| `mm predict approve`        | Repair approvals                                                   |
+| `mm predict status`         | Backend status                                                     |
+| `mm predict portfolio`      | Snapshot of pUSD balance, positions, redeemable winnings           |
+| `mm predict redeem list`    | List redeemable winning positions                                  |
+| `mm predict redeem`         | Redeem one or all winning positions                                |
+| `mm predict markets search` | Search markets                                                     |
+| `mm predict markets list`   | List markets with filters                                          |
+| `mm predict markets get`    | Inspect a market (slug, ID, or condition ID)                       |
+| `mm predict events list`    | List Polymarket events with filters                                |
+| `mm predict events get`     | Retrieve a single event by ID or slug                              |
+| `mm predict series list`    | List event series                                                  |
+| `mm predict series get`     | Retrieve a single event series                                     |
+| `mm predict tags list`      | List Polymarket tags                                               |
+| `mm predict tags get`       | Retrieve a tag by ID or slug                                       |
+| `mm predict quote`          | Preview order cost (supports `--tick-size`)                        |
+| `mm predict place`          | Place an order (supports `--tick-size`)                            |
+| `mm predict cancel`         | Cancel orders                                                      |
+| `mm predict orders`         | List open orders                                                   |
+| `mm predict positions`      | View positions                                                     |
+| `mm predict withdraw`       | Withdraw pUSD from deposit wallet                                  |
+| `mm predict book`           | Order book for a token                                             |
+| `mm predict watch`          | Watch a predict job                                                |
+| `mm predict geoblock`       | Check Polymarket geoblock for your IP                              |
+| `mm predict history`        | List deposit-wallet trade history (use `--type redeem` for claims) |
+| `mm predict history get`    | Inspect activity for a specific market condition                   |
 
 `mm predict quote` and `mm predict place` accept an optional `--tick-size` flag to override the
 market's default tick size. Valid values: `0.1`, `0.01`, `0.005`, `0.0025`, `0.001`, `0.0001`.
 Defaults to the CLOB tick size for the token.
+
+### `mm predict history`
+
+List deposit-wallet activity. Shows trades by default; use `--type redeem` for past claims.
+Trade rows include outcome, win/lose status, redeemed status, amount won, market slug, and event
+slug. Results include a `hasMore` pagination hint when the page looks full.
+
+```bash
+mm predict history [--type trade|redeem] [--limit <n>] [--offset <n>] [--start <unix>] [--end <unix>] [--sort-by timestamp|tokens|cash] [--sort-direction asc|desc] [--side buy|sell]
+```
+
+| Flag               | Required | Description                                  |
+| ------------------ | -------- | -------------------------------------------- |
+| `--type`           | No       | `trade` (default) or `redeem`                |
+| `--limit`          | No       | Number of results to return                  |
+| `--offset`         | No       | Skip the first N results (pagination)        |
+| `--start`          | No       | Start timestamp in unix seconds              |
+| `--end`            | No       | End timestamp in unix seconds                |
+| `--sort-by`        | No       | Sort field: `timestamp`, `tokens`, or `cash` |
+| `--sort-direction` | No       | Sort direction: `asc` or `desc`              |
+| `--side`           | No       | Filter by side: `buy` or `sell`              |
+
+### `mm predict history get`
+
+Inspect deposit-wallet activity for a specific market condition.
+
+```bash
+mm predict history get <condition-id> [--type trade|redeem]
+```
+
+| Flag     | Required | Description                   |
+| -------- | -------- | ----------------------------- |
+| `--type` | No       | `trade` (default) or `redeem` |
 
 <!-- vale on -->
 
@@ -484,6 +526,9 @@ mm config set <key> <value>
 ### `mm tx history`
 
 List recent transactions for the active wallet or specific addresses.
+Each row includes chain name, chain ID, explorer link, and protocol when Accounts API metadata is
+present. When a pending wallet job matches an indexed transaction hash, the local CLI intent is
+preserved on that row.
 
 ```bash
 mm tx history [--addresses <addrs>] [--chain <chains>] [--type <filter>] [--limit <n>]

--- a/agent-wallet/reference/error-codes.md
+++ b/agent-wallet/reference/error-codes.md
@@ -25,6 +25,7 @@ Run `mm <command> --help` for command-specific validation rules.
 | `MWP_TIMEOUT`           | Mobile Wallet Protocol timeout                                   |
 | `MWP_CANCELLED`         | Mobile Wallet Protocol cancelled (pairing aborted)               |
 | `PAIRING_CANCELLED`     | Browser pairing cancelled by the user                            |
+| `ALREADY_LOGGED_OUT`    | No CLI auth session stored; run `mm login`                       |
 | `LOGOUT_FAILED`         | Sign-out operation failed (includes token revoke failures)       |
 
 ## Validation errors (`ValidationError`)
@@ -63,6 +64,10 @@ Run `mm <command> --help` for command-specific validation rules.
 | `NO_HISTORY_WALLETS`    | No EVM wallets found for `mm tx history`         |
 | `TX_NOT_FOUND`          | Transaction hash not found onchain               |
 | `INVALID_TX_HASH`       | Malformed transaction hash                       |
+| `INVALID_EVM_ADDRESS`   | Malformed EVM address input                      |
+| `UNSUPPORTED_CHAIN`     | Chain not supported for this operation           |
+| `INVALID_AMOUNT`        | Non-positive amount; value must be positive      |
+| `TX_REVERTED`           | Transaction reverted onchain                     |
 
 ## Swap errors (`SwapCommandError`)
 
@@ -95,6 +100,7 @@ Run `mm <command> --help` for command-specific validation rules.
 | `MINIMUM_WITHDRAW_AMOUNT` | Withdrawal below Hyperliquid minimum                   |
 | `MINIMUM_ORDER_NOTIONAL`  | Order notional below $10 floor                         |
 | `HYPERLIQUID_ERROR`       | Generic Hyperliquid error (often unfunded sub-account) |
+| `RATE_LIMITED`            | Hyperliquid HTTP 429 rate limit; retry after a delay   |
 
 The CLI provides actionable hints for common failures — for example, minimum amounts for deposits
 and withdrawals, the $10 notional floor for orders, funding shortfalls (including `--include-spot`),
@@ -139,10 +145,13 @@ All expected predict failures return actionable per-code hints. Inspect the `hin
 
 ## Server-wallet errors
 
-| Code                | Meaning                                             |
-| ------------------- | --------------------------------------------------- |
-| `JOB_TIMEOUT`       | Wallet job timed out (default 10 minutes, max 600s) |
-| `REQUEST_NOT_FOUND` | Server-wallet request not found                     |
+| Code                | Meaning                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `JOB_TIMEOUT`       | Wallet job timed out (default 10 minutes, max 600s)                       |
+| `RELAY_TIMEOUT`     | Gasless relay timed out; run `mm wallet requests watch --polling-id <id>` |
+| `RELAY_FAILED`      | Gasless relay failed                                                      |
+| `RELAY_ABORTED`     | Gasless relay aborted                                                     |
+| `REQUEST_NOT_FOUND` | Server-wallet request not found                                           |
 
 ## Network errors
 


### PR DESCRIPTION
# Description

- Update docs for v5.3.0

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security behavior changes in this repository.
> 
> **Overview**
> **Agent Wallet docs** are aligned with **CLI v5.3.0**: quickstart now says skills target v5.3.0 (was v5.2.1).
> 
> **Polymarket predict** adds **`mm predict history`** and **`mm predict history get`** for deposit-wallet trades and redeems, with filters, pagination, and per-condition lookups. The prediction-markets guide adds an agent prompt and a “View trade history” section; the commands reference documents flags and output fields.
> 
> **Swap execute** documents optional **`--wallet-timeout`**, plus **`RELAY_TIMEOUT`** / **`JOB_TIMEOUT`** behavior and recovery via **`mm wallet requests watch`** (with a warning not to re-run execute while a job may still complete).
> 
> **`mm logout`** when already signed out returns **`ALREADY_LOGGED_OUT`** (exit 0) instead of mirroring a successful sign-out. **`mm tx history`** rows can include richer chain/explorer/protocol metadata and preserve local CLI intent when a pending job matches a hash.
> 
> The **error codes** reference adds codes for auth, wallet validation, Hyperliquid **`RATE_LIMITED`**, and gasless relay (**`RELAY_TIMEOUT`**, **`RELAY_FAILED`**, **`RELAY_ABORTED`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2f19fa4a20ce98525f85fe3c6390fd67b4e7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->