### PR TITLE
[Agent Wallet] Update the docs for v5.4.0

### DIFF
--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -40,7 +40,7 @@ npx skills add MetaMask/agent-skills
 When prompted, install `metamask-agent-wallet`.
 
 Reinstall skills if you previously installed an older version.
-The current skills target CLI v5.3.0.
+The current skills target CLI v5.4.0.
 
 ## 3. Complete setup
 

--- a/agent-wallet/reference/commands.md
+++ b/agent-wallet/reference/commands.md
@@ -528,7 +528,8 @@ mm config set <key> <value>
 List recent transactions for the active wallet or specific addresses.
 Each row includes chain name, chain ID, explorer link, and protocol when Accounts API metadata is
 present. When a pending wallet job matches an indexed transaction hash, the local CLI intent is
-preserved on that row.
+preserved on that row. Pending jobs that never reached the chain are excluded;
+use `mm wallet requests list` to see stranded or expired requests.
 
 ```bash
 mm tx history [--addresses <addrs>] [--chain <chains>] [--type <filter>] [--limit <n>]
@@ -539,7 +540,7 @@ mm tx history [--addresses <addrs>] [--chain <chains>] [--type <filter>] [--limi
 Look up a specific transaction by hash.
 
 ```bash
-mm tx get <tx-hash>
+mm tx get --hash <tx-hash>
 ```
 
 Returns `TX_NOT_FOUND` for unknown hashes and `INVALID_TX_HASH` for malformed input.


### PR DESCRIPTION
# Description

- Update docs for the v5.4.0

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documentation is aligned with **Agent Wallet CLI v5.4.0** and a few command-reference corrections.
> 
> The quickstart now states that `metamask-agent-wallet` skills target **CLI v5.4.0** (was v5.3.0). In the commands reference, **`mm tx history`** is clarified: rows only cover activity that reached the chain; pending jobs that never did are omitted, and **`mm wallet requests list`** is the place to inspect stranded or expired requests. **`mm tx get`** is documented with the **`--hash`** flag instead of a positional hash argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45cb9df3ea713e3aff2300511804b2922da1d78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->