### PR TITLE
docs: clarify deprecated Snap Functions API

### DIFF
--- a/snaps/get-started/quickstart.md
+++ b/snaps/get-started/quickstart.md
@@ -136,6 +136,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ origin, request }) => 
 </TabItem>
 <TabItem value="Functions" deprecated>
 
+:::warning
+The Functions API is deprecated. Use the JSX API above for new Snaps. This example is kept for
+legacy Snaps that still use the function-based custom UI library.
+:::
+
 ```ts title="index.ts"
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk'
 import { panel, text } from '@metamask/snaps-sdk'


### PR DESCRIPTION
Fixes #2894.

The Functions tab in the Snaps quickstart is marked deprecated, but the example did not explain what that means. Add a warning that JSX is recommended for new Snaps and that the function-based API is retained for legacy projects.

Verification: `npm run build` succeeds. The existing build emits unrelated dependency and Sass deprecation warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **warning** admonition at the top of the deprecated **Functions** tab in the Snaps quickstart so readers know the function-based custom UI API is deprecated, **JSX** is the path for new Snaps, and the tab remains for legacy examples only.
> 
> This aligns with issue **#2894**, where the tab was already marked deprecated but lacked an in-page explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7705d6dee65e45f41171a7f068c56a596ba317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->