### PR TITLE
docs: update Mermaid diagram styles

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -1370,3 +1370,71 @@ html {
   font-weight: 400;
   line-height: 1.4;
 }
+
+/* Mermaid diagrams */
+.mermaid {
+  text-align: center;
+
+  svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .node rect,
+  .node circle,
+  .node polygon {
+    fill: var(--ifm-background-surface-color);
+    stroke: var(--ifm-color-primary);
+    stroke-width: 2px;
+  }
+
+  .edgePath path {
+    stroke: var(--ifm-color-primary);
+    stroke-width: 1.5px;
+  }
+
+  .arrowheadPath {
+    fill: var(--ifm-color-primary);
+  }
+
+  .nodeLabel,
+  .edgeLabel,
+  .label {
+    color: var(--ifm-font-color-base);
+    fill: var(--ifm-font-color-base);
+  }
+
+  .cluster rect {
+    fill: var(--ifm-color-emphasis-100);
+    stroke: var(--ifm-color-primary-light);
+  }
+}
+
+/* Dark mode Mermaid adjustments */
+[data-theme='dark'] .mermaid {
+  .node rect,
+  .node circle,
+  .node polygon {
+    fill: var(--general-black-light);
+    stroke: var(--developer-green);
+  }
+
+  .edgePath path,
+  .arrowheadPath {
+    stroke: var(--developer-green);
+    fill: var(--developer-green);
+  }
+
+  .nodeLabel,
+  .edgeLabel,
+  .label {
+    color: var(--general-white);
+    fill: var(--general-white);
+  }
+
+  .cluster rect {
+    fill: var(--general-black);
+    stroke: var(--developer-green-light);
+  }
+}
+


### PR DESCRIPTION
## Summary

- Update Mermaid diagram styles to match MetaMask branding
- Add light and dark mode support
- Improve node, edge, label, and cluster styling

## Related issue

Closes #2906

## Notes

- Pan/zoom was evaluated but not included in this change because it requires additional Mermaid/Docusaurus integration work.
- This PR focuses on improving Mermaid diagram readability and theme consistency.