### PR TITLE
[Agent Wallet] Update docs

### DIFF
--- a/agent-wallet/quickstart.md
+++ b/agent-wallet/quickstart.md
@@ -10,7 +10,7 @@ Each step tells you what you are doing, why it matters, and what to do next.
 
 ## Before you start
 
-- **Node.js** 22.x or later
+- **Node.js** 22.18 or later
 - An AI agent that supports skills (Claude Code, Codex, Cursor, OpenClaw, Hermes Agent, or similar)
 
 ## Step 1: Install the CLI

--- a/agent-wallet/reference/commands.md
+++ b/agent-wallet/reference/commands.md
@@ -679,7 +679,7 @@ preserved on that row. Pending jobs that never reached the chain are excluded;
 use `mm wallet requests list` to see stranded or expired requests.
 
 ```bash
-mm tx history [--addresses <addrs>] [--chain-ids <chains>] [--type <filter>] [--limit <n>]
+mm tx history [--addresses <addrs>] [--chain-ids <chains>] [--type <filter>] [--limit <n>] [--after <cursor>]
 ```
 
 | Flag          | Required | Description                                                                |
@@ -687,7 +687,12 @@ mm tx history [--addresses <addrs>] [--chain-ids <chains>] [--type <filter>] [--
 | `--addresses` | No       | Comma-separated EVM addresses. Defaults to all EVM wallets on your account |
 | `--chain-ids` | No       | Comma-separated chain filters, such as `1,137` or `eip155:1`               |
 | `--type`      | No       | Filter by direction (`in`, `out`, or `self`) or by transaction category    |
-| `--limit`     | No       | Number of transactions to return, 1–500. The default is 50                 |
+| `--limit`     | No       | Number of transactions to return, 1–50. The default is 50                  |
+| `--after`     | No       | Pagination cursor from a previous response (`endCursor` value)             |
+
+When more results are available, JSON and toon output include `hasNextPage: true` and an `endCursor`
+value. Pass that cursor as `--after <endCursor>` to fetch the next page. The REPL also displays a
+ready-to-run next-page command in a footer when `hasNextPage` is true.
 
 ### `mm tx`
 

--- a/agent-wallet/reference/error-codes.md
+++ b/agent-wallet/reference/error-codes.md
@@ -30,29 +30,30 @@ Run `mm <command> --help` for command-specific validation rules.
 
 ## Validation errors (`ValidationError`)
 
-| Code                          | Meaning                                                     |
-| ----------------------------- | ----------------------------------------------------------- |
-| `MISSING_FLAG`                | Required flag missing in headless mode                      |
-| `MISSING_INPUT`               | Required input is missing                                   |
-| `MISSING_CHAIN`               | Chain value is missing                                      |
-| `MISSING_CHAIN_ID`            | `--chain-id` is missing                                     |
-| `INVALID_CHAIN`               | Chain value is invalid                                      |
-| `INVALID_INPUT`               | Invalid user input                                          |
-| `INVALID_TO`                  | Recipient address is invalid                                |
-| `INVALID_TYPED_DATA`          | EIP-712 payload is invalid                                  |
-| `INVALID_TRANSACTION_PAYLOAD` | Transaction payload is invalid                              |
-| `CHAIN_ID_MISMATCH`           | Typed-data domain chain ID differs from `--chain-id`        |
-| `INVALID_MNEMONIC`            | Bring your own wallet mnemonic is invalid                   |
-| `NOT_INITIALIZED`             | Project not initialized; run `mm init`                      |
-| `INVALID_LIMIT`               | Invalid `--limit` value for `mm tx history` (must be 1–500) |
-| `INVALID_CONFIG_KEY`          | Unknown CLI config key                                      |
-| `INVALID_NETWORK`             | Unsupported or unknown network                              |
-| `UNKNOWN_FLAG`                | Unrecognized CLI flag                                       |
-| `MISSING_WALLET_REF`          | Missing wallet address for `mm wallet select`               |
-| `INVALID_EVM_ADDRESS`         | Malformed EVM address input                                 |
-| `INVALID_SORT_BY`             | Invalid `--sort-by` field                                   |
-| `INVALID_SORT_DIRECTION`      | Invalid `--sort-direction` value; use `asc` or `desc`       |
-| `INVALID_HISTORY_TYPE`        | Invalid `--type`; use `closed`, `trade`, or `redeem`        |
+| Code                          | Meaning                                                                                                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MISSING_FLAG`                | Required flag missing in headless mode                                                                                                                   |
+| `MISSING_INPUT`               | Required input is missing                                                                                                                                |
+| `MISSING_CHAIN`               | Chain value is missing                                                                                                                                   |
+| `MISSING_CHAIN_ID`            | `--chain-id` is missing                                                                                                                                  |
+| `INVALID_CHAIN`               | Chain value is invalid                                                                                                                                   |
+| `INVALID_INPUT`               | Invalid user input                                                                                                                                       |
+| `INVALID_TO`                  | Recipient address is invalid                                                                                                                             |
+| `INVALID_TYPED_DATA`          | EIP-712 payload is invalid                                                                                                                               |
+| `INVALID_TRANSACTION_PAYLOAD` | Transaction payload is invalid                                                                                                                           |
+| `CHAIN_ID_MISMATCH`           | Typed-data domain chain ID differs from `--chain-id`                                                                                                     |
+| `INVALID_MNEMONIC`            | Bring your own wallet mnemonic is invalid                                                                                                                |
+| `NOT_INITIALIZED`             | Project not initialized; run `mm init`                                                                                                                   |
+| `INVALID_LIMIT`               | Invalid `--limit` value for `mm tx history` (must be 1–50)                                                                                               |
+| `INVALID_POLICY_YAML`         | Policy YAML passed to `mm wallet policy set` is not a valid policy object; use `mm wallet policy get` or `mm wallet policy template` as a starting point |
+| `INVALID_CONFIG_KEY`          | Unknown CLI config key                                                                                                                                   |
+| `INVALID_NETWORK`             | Unsupported or unknown network                                                                                                                           |
+| `UNKNOWN_FLAG`                | Unrecognized CLI flag                                                                                                                                    |
+| `MISSING_WALLET_REF`          | Missing wallet address for `mm wallet select`                                                                                                            |
+| `INVALID_EVM_ADDRESS`         | Malformed EVM address input                                                                                                                              |
+| `INVALID_SORT_BY`             | Invalid `--sort-by` field                                                                                                                                |
+| `INVALID_SORT_DIRECTION`      | Invalid `--sort-direction` value; use `asc` or `desc`                                                                                                    |
+| `INVALID_HISTORY_TYPE`        | Invalid `--type`; use `closed`, `trade`, or `redeem`                                                                                                     |
 
 ## Wallet errors (`WalletError`)
 
@@ -164,6 +165,12 @@ All expected predict failures return actionable per-code hints. Inspect the `hin
 | `RELAY_FAILED`      | Gasless relay failed, usually because the wallet cannot cover the amount plus the relay fee. Retry with a lower `--amount` |
 | `RELAY_ABORTED`     | Gasless relay aborted                                                                                                      |
 | `REQUEST_NOT_FOUND` | Server-wallet request not found                                                                                            |
+
+## Runtime errors
+
+| Code               | Meaning                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `UNSUPPORTED_NODE` | Node.js version is below the minimum required (22.18). Upgrade Node.js from https://nodejs.org/ or use nvm/fnm/volta |
 
 ## Network errors
 

--- a/agent-wallet/troubleshooting.md
+++ b/agent-wallet/troubleshooting.md
@@ -7,6 +7,29 @@ keywords: [MetaMask, Agent Wallet, troubleshooting, mm doctor, mm]
 
 Symptom-first fixes for common `mm` CLI issues.
 
+## `UNSUPPORTED_NODE` at startup
+
+The CLI checks the Node.js version before loading. If the active runtime is below Node.js 22.18, it
+exits immediately:
+
+```
+Error: Node.js <current> is not supported. MetaMask Agent Wallet (mm) requires Node.js 22.18 or later.
+Upgrade Node.js from https://nodejs.org/ or use a version manager (nvm, fnm, volta).
+```
+
+With `--json`, the exit payload is:
+
+```json
+{ "ok": false, "error": { "code": "UNSUPPORTED_NODE", "message": "...", "hint": "..." } }
+```
+
+Upgrade Node.js to 22.18 or later, then verify:
+
+```bash
+node --version
+mm doctor
+```
+
 ## Start with `mm doctor`
 
 Run `mm doctor` first to inspect CLI version, skill compatibility, authentication, and
@@ -130,6 +153,25 @@ Run setup before wallet commands:
 ```bash
 mm init
 mm doctor
+```
+
+### `INVALID_POLICY_YAML` on `mm wallet policy set`
+
+The YAML you passed is not a valid policy object (for example, it is an empty document, a plain
+string, or a list). Start from a known-good baseline:
+
+```bash
+# Start from your current live policy:
+mm wallet policy get
+
+# Or start from the project template:
+mm wallet policy template
+```
+
+Edit the output, then pass it back:
+
+```bash
+mm wallet policy set --policy "$(mm wallet policy get)"
 ```
 
 ### Reset local session


### PR DESCRIPTION
# Description

Update docs for the version 6.1

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code; risk is limited to doc accuracy if it diverges from the shipped CLI.
> 
> **Overview**
> Updates **Agent Wallet** documentation for **v6.1** across quickstart, command reference, error codes, and troubleshooting.
> 
> **Runtime requirement:** Minimum Node.js is now **22.18** (was 22.x). Docs add **`UNSUPPORTED_NODE`** startup behavior, including `--json` error shape and upgrade steps via `mm doctor`.
> 
> **`mm tx history`:** **`--limit`** is capped at **1–50** (was 1–500). **`--after`** cursor pagination is documented, along with `hasNextPage` / `endCursor` in JSON/toon output and REPL next-page hints.
> 
> **Policy YAML:** **`INVALID_POLICY_YAML`** is documented for `mm wallet policy set`, with troubleshooting that points users to `mm wallet policy get` or `mm wallet policy template` as baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c2371b71d6795b46e0814b7807faeb6a74110b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->