### PR TITLE
Add CSP guidance to MetaMask Connect troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,11 @@ Follow these guides when writing or editing documentation:
 - [Consensys documentation style guide](https://docs-template.consensys.net/contribute/style-guide)
 - [Consensys Markdown formatting guide](https://docs-template.consensys.net/contribute/format-markdown)
 - [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
+
 <!-- vale off -->
+
 - [Diataxis framework](https://diataxis.fr/) for content structure
+
 <!-- vale on -->
 
 The rules under `.cursor/rules/` cover the most actionable parts of these references.

--- a/gator_versioned_docs/version-1.2.0/reference/delegation/caveats.md
+++ b/gator_versioned_docs/version-1.2.0/reference/delegation/caveats.md
@@ -577,9 +577,9 @@ Specifies an ID for multiple delegations. Once one of them is redeemed, the othe
 
 ### Parameters
 
-| Name | Type     | Required | Description |
+| Name | Type | Required | Description |
 | ---- | -------- | -------- | ----------- | -------------------------------------------------------------------------------- |
-| `id` | `bigint` | `number` | Yes         | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
+| `id` | `bigint` | `number` | Yes | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
 
 ### Example
 

--- a/gator_versioned_docs/version-1.5.0/reference/delegation/caveats.md
+++ b/gator_versioned_docs/version-1.5.0/reference/delegation/caveats.md
@@ -579,9 +579,9 @@ Specifies an ID for multiple delegations. Once one of them is redeemed, the othe
 
 ### Parameters
 
-| Name | Type     | Required | Description |
+| Name | Type | Required | Description |
 | ---- | -------- | -------- | ----------- | -------------------------------------------------------------------------------- |
-| `id` | `bigint` | `number` | Yes         | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
+| `id` | `bigint` | `number` | Yes | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
 
 ### Example
 

--- a/gator_versioned_docs/version-1.6.0/reference/delegation/caveats.md
+++ b/gator_versioned_docs/version-1.6.0/reference/delegation/caveats.md
@@ -615,9 +615,9 @@ Specifies an ID for multiple delegations. Once one of them is redeemed, the othe
 
 ### Parameters
 
-| Name | Type     | Required | Description |
+| Name | Type | Required | Description |
 | ---- | -------- | -------- | ----------- | -------------------------------------------------------------------------------- |
-| `id` | `bigint` | `number` | Yes         | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
+| `id` | `bigint` | `number` | Yes | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
 
 ### Example
 

--- a/gator_versioned_docs/version-1.6.0/reference/types.md
+++ b/gator_versioned_docs/version-1.6.0/reference/types.md
@@ -245,8 +245,7 @@ Represents a value that can be provided directly or derived at runtime from [`Pa
 
 ```ts
 type MaybeDeferred<TResult> =
-  | TResult
-  | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
+  TResult | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
 ```
 
 ### `PaymentRequirements`

--- a/gator_versioned_docs/version-1.7.0/reference/delegation/caveats.md
+++ b/gator_versioned_docs/version-1.7.0/reference/delegation/caveats.md
@@ -615,9 +615,9 @@ Specifies an ID for multiple delegations. Once one of them is redeemed, the othe
 
 ### Parameters
 
-| Name | Type     | Required | Description |
+| Name | Type | Required | Description |
 | ---- | -------- | -------- | ----------- | -------------------------------------------------------------------------------- |
-| `id` | `bigint` | `number` | Yes         | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
+| `id` | `bigint` | `number` | Yes | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
 
 ### Example
 

--- a/gator_versioned_docs/version-1.7.0/reference/types.md
+++ b/gator_versioned_docs/version-1.7.0/reference/types.md
@@ -260,8 +260,7 @@ Represents a value that can be provided directly or derived at runtime from [`Pa
 
 ```ts
 type MaybeDeferred<TResult> =
-  | TResult
-  | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
+  TResult | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
 ```
 
 ### `PaymentRequirements`

--- a/metamask-connect/evm/guides/migrate-from-sdk.md
+++ b/metamask-connect/evm/guides/migrate-from-sdk.md
@@ -138,21 +138,22 @@ the `dapp` object from the first call is never overwritten. Do not recreate it o
 Use the following table to map `MetaMaskSDK` configuration options to their equivalents in `createEVMClient`.
 The table includes renamed options, options that moved into grouped objects (for example, `ui` and `mobile`), and
 options that MetaMask Connect EVM no longer exposes.
-| Old (`MetaMaskSDK`) | New (`createEVMClient`) | Notes |
-| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------- |
-| `dappMetadata` | `dapp` | Same shape: `{ name, url, iconUrl }` |
-| `dappMetadata.name` | `dapp.name` | Required |
-| `dappMetadata.url` | `dapp.url` | Auto-set in browsers; required in Node.js and React Native |
-| `infuraAPIKey` | `api.supportedNetworks` via [`getInfuraRpcUrls({ infuraApiKey })`](../reference/methods.md#getinfurarpcurls) | Helper generates RPC URLs for all Infura-supported chains |
-| `readonlyRPCMap` | `api.supportedNetworks` | Merge into the same object |
-| `headless` | `ui.headless` | Same behavior |
-| `extensionOnly` | `ui.preferExtension` | `true` prefers extension (default); not the same as "only" |
-| `openDeeplink` | `mobile.preferredOpenLink` | Same signature: `(deeplink: string) => void` |
-| `useDeeplink` | `mobile.useDeeplink` | Same behavior |
-| `timer` | Removed | No longer configurable |
-| `enableAnalytics` | `analytics.enabled` | Replaced by `analytics: { enabled: false }` to opt out |
-| `communicationServerUrl` | Removed | Managed internally |
-| `storage` | Removed | Managed internally |
+
+| Old (`MetaMaskSDK`)      | New (`createEVMClient`)                                                                                      | Notes                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `dappMetadata`           | `dapp`                                                                                                       | Same shape: `{ name, url, iconUrl }`                       |
+| `dappMetadata.name`      | `dapp.name`                                                                                                  | Required                                                   |
+| `dappMetadata.url`       | `dapp.url`                                                                                                   | Auto-set in browsers; required in Node.js and React Native |
+| `infuraAPIKey`           | `api.supportedNetworks` via [`getInfuraRpcUrls({ infuraApiKey })`](../reference/methods.md#getinfurarpcurls) | Helper generates RPC URLs for all Infura-supported chains  |
+| `readonlyRPCMap`         | `api.supportedNetworks`                                                                                      | Merge into the same object                                 |
+| `headless`               | `ui.headless`                                                                                                | Same behavior                                              |
+| `extensionOnly`          | `ui.preferExtension`                                                                                         | `true` prefers extension (default); not the same as "only" |
+| `openDeeplink`           | `mobile.preferredOpenLink`                                                                                   | Same signature: `(deeplink: string) => void`               |
+| `useDeeplink`            | `mobile.useDeeplink`                                                                                         | Same behavior                                              |
+| `timer`                  | Removed                                                                                                      | No longer configurable                                     |
+| `enableAnalytics`        | `analytics.enabled`                                                                                          | Replaced by `analytics: { enabled: false }` to opt out     |
+| `communicationServerUrl` | Removed                                                                                                      | Managed internally                                         |
+| `storage`                | Removed                                                                                                      | Managed internally                                         |
 
 ### 4. Update connection flow
 

--- a/metamask-connect/troubleshooting/index.md
+++ b/metamask-connect/troubleshooting/index.md
@@ -14,6 +14,9 @@ keywords:
     QR code,
     headless,
     session,
+    Content Security Policy,
+    CSP,
+    Flask,
   ]
 ---
 
@@ -74,6 +77,103 @@ try {
 The core also exports `RPCHttpErr`, `RPCReadonlyResponseErr`, and `RPCReadonlyRequestErr` for
 read-only RPC failures.
 
+Since `@metamask/connect-evm` 2.1.0, `provider.request` also preserves the wallet's JSON-RPC
+`error.data`, so you can read revert reasons, custom-error bytes, and other wallet-provided metadata
+alongside `error.code` and `error.message`.
+On the multichain client, the same metadata is available as `err.rpcData` on `RPCInvokeMethodErr`.
+
+## Content Security Policy
+
+MetaMask Connect needs a few origins allowed in your dapp's Content Security Policy (CSP).
+This applies to every integration (`@metamask/connect-evm`, `@metamask/connect-solana`, and
+`@metamask/connect-multichain`) on all current package versions, not only to the QR code flow.
+A strict policy that omits these directives breaks remote connections, the install and QR modal, or
+both.
+
+### Required directives
+
+```text
+connect-src wss://mm-sdk-relay.api.cx.metamask.io;
+img-src data:;
+```
+
+- `connect-src wss://mm-sdk-relay.api.cx.metamask.io` allows the WebSocket connection to the
+  MetaMask relay, which carries every remote connection, including mobile deeplinks and desktop
+  browsers without the extension installed.
+  The relay can't be proxied or deferred from within the library, so remote connections fail
+  without it.
+- `img-src data:` allows the MetaMask fox SVG that the install and QR modal in
+  `@metamask/multichain-ui` embeds as a `data:` URI inside the generated QR code.
+  Without it, the QR code doesn't render.
+
+### Also consider
+
+- `connect-src https://mm-sdk-analytics.api.cx.metamask.io` for the telemetry endpoint used by
+  `@metamask/analytics`.
+  Analytics are enabled by default.
+  Set `analytics.enabled: false` when creating the client to disable the events and omit this
+  origin.
+- `style-src 'unsafe-inline'` for the modal styles.
+  `@metamask/multichain-ui` is built with Stencil, which injects component styles at runtime inside
+  the Shadow DOM.
+  Strict policies without `'unsafe-inline'`, or an equivalent nonce or hash strategy, can break the
+  modal styling.
+- `connect-src` entries for the RPC endpoints your dapp supplies through `api.supportedNetworks`,
+  `api.infuraProjectId`, or `api.readonlyRPCMap`.
+  For example, `https://*.infura.io`, your own node provider, or a public RPC.
+- `https://metamask.app.link` and `metamask://` for mobile deeplinks and universal links.
+  These are top-level navigations that `connect-src` doesn't normally govern, but policies that set
+  `navigate-to` or `form-action` may need to allow them.
+
+### Example policy
+
+For a dapp that uses the default analytics endpoint, Infura RPC URLs, and the install modal, set the
+policy as a response header at your server or CDN:
+
+```text
+Content-Security-Policy: connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io https://*.infura.io; img-src 'self' data:; style-src 'self' 'unsafe-inline';
+```
+
+The equivalent `<meta>` tag, which is useful for local development and static pages:
+
+```html
+<meta
+  http-equiv="Content-Security-Policy"
+  content="
+    connect-src 'self' wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io https://*.infura.io;
+    img-src 'self' data:;
+    style-src 'self' 'unsafe-inline';
+  " />
+```
+
+### Symptoms of a missing directive
+
+The exact wording varies by browser.
+In Chromium-based browsers, the console reports messages similar to the following.
+
+| Console message                                                                                     | Missing directive                                         |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `Refused to connect to 'wss://mm-sdk-relay.api.cx.metamask.io/...'`                                 | `connect-src wss://mm-sdk-relay.api.cx.metamask.io`       |
+| `Refused to load the image 'data:image/svg+xml;base64,...'`                                         | `img-src data:`                                           |
+| `Refused to connect to 'https://mm-sdk-analytics.api.cx.metamask.io/...'`                           | `connect-src https://mm-sdk-analytics.api.cx.metamask.io` |
+| `Refused to apply inline style because it violates the following Content Security Policy directive` | `style-src 'unsafe-inline'`                               |
+
+:::note Older versions
+Before `@metamask/connect-multichain` 0.12.1 (which pulls in `@metamask/multichain-ui` 0.4.1), the
+QR code modal fetched the fox icon through an `XMLHttpRequest` on a `data:` URI, so it also needed
+`data:` (and in some setups `blob:`) in `connect-src`. The symptom looked like:
+
+`Refused to connect to 'data:image/svg+xml;base64,...' because it violates the following Content Security Policy directive: "connect-src 'self' https: wss:".`
+
+Upgrading removes only that extra `connect-src` entry.
+The required directives above still apply on the latest packages.
+If you can't upgrade, add `data: blob:` to `connect-src` as a fallback.
+:::
+
+For the full reference, see
+[Content Security Policy](https://github.com/MetaMask/connect-monorepo#content-security-policy) in
+the `connect-monorepo` repository.
+
 ## Common issues
 
 ### Connection hangs after `connect()`
@@ -126,6 +226,10 @@ Rejections from [`connect`](../evm/reference/methods.md#connect),
 `err.rpcCode` (for example, `4001`). Requests made through
 [`provider.request`](../evm/reference/provider-api.md#request) are normalized to `err.code = rpcCode`,
 but `connect` rejections are not.
+
+Closing the QR code or install modal is also a cancellation.
+Since `@metamask/connect-multichain` 1.2.0, that rejects with the canonical EIP-1193 `4001` error.
+Earlier versions rejected with a plain `Error('User closed modal')` that carried no code.
 
 Normalize defensively before branching on the error. This mirrors the SDK's own rejection heuristic,
 which checks `code === 4001` or a message containing `reject`, `denied`, or `cancel`:
@@ -256,45 +360,25 @@ const client = await createEVMClient({
 ```
 
 **Cause C:** A strict Content Security Policy (CSP) is blocking the QR code from rendering.
-The QR code embeds the MetaMask fox SVG as a `data:` URI.
+The QR code embeds the MetaMask fox SVG as a `data:` URI, so the console reports a message like
+`Refused to load the image 'data:image/svg+xml;base64,...'`.
 
-**Fix:** Allow the `data:` scheme in `img-src` and the MetaMask relay and analytics origins in
-`connect-src`.
-A minimal working policy looks like:
+**Fix:** Allow `data:` in `img-src` and the MetaMask relay origin in `connect-src`.
+See [Content Security Policy](#content-security-policy) for the full set of directives.
 
-```html
-<meta
-  http-equiv="Content-Security-Policy"
-  content="
-    connect-src 'self' https://*.infura.io wss://mm-sdk-relay.api.cx.metamask.io https://mm-sdk-analytics.api.cx.metamask.io;
-    img-src 'self' data:;
-    style-src 'self' 'unsafe-inline';
-  " />
-```
+### MetaMask Flask shows the QR code instead of using the extension
 
-- `img-src 'self' data:` - Required for the fox SVG embedded in the QR code.
-- `wss://mm-sdk-relay.api.cx.metamask.io` - The relay used for remote (no-extension and mobile)
-  connections.
-- `https://mm-sdk-analytics.api.cx.metamask.io` - The default analytics endpoint emitted during the
-  connection lifecycle.
-- `style-src 'unsafe-inline'` - `@metamask/multichain-ui` injects component styles at runtime
-  inside Shadow DOM (Stencil).
+A browser with only MetaMask Flask installed gets the QR code flow instead of connecting directly
+through the extension.
 
-:::note Older versions
-In earlier package versions, the QR-code modal materialized the fox icon via an `XMLHttpRequest` on
-a `blob:` / `data:` URI, requiring `blob:` (and in some setups `data:`) in `connect-src`.
-Upgrade to `@metamask/connect-evm` 1.0.0, `@metamask/connect-solana` 1.0.0, or
-`@metamask/connect-multichain` 0.12.1 or later to remove this requirement — the fox SVG is now
-embedded directly as a `data:` URI without an extra request.
-A symptom on older versions looked like:
+**Cause:** Before `@metamask/connect-multichain` 1.2.0, EIP-6963 extension detection didn't
+recognize the Flask RDNS value (`io.metamask.flask`), so `hasExtension` returned `false` and
+`connect` fell back to the MetaMask Wallet Protocol (MWP) transport.
+On `@metamask/connect-evm`, this also produced a duplicate MetaMask entry in wallet pickers, because
+the client announced its own provider alongside the one Flask had already announced.
 
-`Refused to connect to 'data:image/svg+xml;base64,...' because it violates the following Content Security Policy directive: "connect-src 'self' https: wss:".`
-
-If you cannot upgrade, add `data: blob:` to `connect-src` as a fallback.
-:::
-
-For the full reference, see
-[Content Security Policy](https://github.com/MetaMask/connect-monorepo#content-security-policy) in `metamask/connect-monorepo`.
+**Fix:** Upgrade to `@metamask/connect-multichain` 1.2.0, `@metamask/connect-evm` 2.1.1, or
+`@metamask/connect-solana` 2.1.1 or later.
 
 ### Mobile shows the QR modal instead of deeplinking to the app
 
@@ -440,6 +524,8 @@ When any MetaMask Connect integration is misbehaving, ensure the following are t
 
 - `supportedNetworks` has valid RPC URLs for every chain the dapp uses.
 - Chain IDs are hex strings for EVM (`'0x1'`, not `1` or `'1'`).
+- The [Content Security Policy](#content-security-policy) allows
+  `wss://mm-sdk-relay.api.cx.metamask.io` in `connect-src` and `data:` in `img-src`.
 - In React Native dapps:
   - Polyfills are loaded: `react-native-get-random-values` is the first entry-file
     import; `window` shim is present; `Event`/`CustomEvent` shims are present **only if using Wagmi**;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9231,9 +9231,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9253,9 +9250,6 @@
       "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9277,9 +9271,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9299,9 +9290,6 @@
       "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9323,9 +9311,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9345,9 +9330,6 @@
       "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/smart-accounts-kit/reference/delegation/caveats.md
+++ b/smart-accounts-kit/reference/delegation/caveats.md
@@ -615,9 +615,9 @@ Specifies an ID for multiple delegations. Once one of them is redeemed, the othe
 
 ### Parameters
 
-| Name | Type     | Required | Description |
+| Name | Type | Required | Description |
 | ---- | -------- | -------- | ----------- | -------------------------------------------------------------------------------- |
-| `id` | `bigint` | `number` | Yes         | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
+| `id` | `bigint` | `number` | Yes | An ID for the delegation. Only one delegation may be redeemed with any given ID. |
 
 ### Example
 

--- a/smart-accounts-kit/reference/types.md
+++ b/smart-accounts-kit/reference/types.md
@@ -260,8 +260,7 @@ Represents a value that can be provided directly or derived at runtime from [`Pa
 
 ```ts
 type MaybeDeferred<TResult> =
-  | TResult
-  | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
+  TResult | ((requirements: PaymentRequirements) => Promise<TResult> | TResult)
 ```
 
 ### `PaymentRequirements`

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -19,14 +19,7 @@ import styles from './Card.module.scss'
 
 /** Optional lead icon for product cards (defaults to star). */
 export type CardLeadIcon =
-  | 'wallet'
-  | 'user'
-  | 'shield'
-  | 'globe'
-  | 'controls'
-  | 'community'
-  | 'multichain'
-  | 'star'
+  'wallet' | 'user' | 'shield' | 'globe' | 'controls' | 'community' | 'multichain' | 'star'
 
 const LEAD_ICON_COMPONENTS: Record<
   CardLeadIcon,

--- a/src/components/NavDropdown/Products.html
+++ b/src/components/NavDropdown/Products.html
@@ -6,28 +6,30 @@
           href="/metamask-connect"
           id="metamask-sdk-menu-button"
           class="selected"
-          onfocus='
-                    document.getElementById("metamask-sdk-menu-button").classList.add("selected");
-                    document.getElementById("metamask-sdk-menu").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'
-          onmouseover='
-                    document.getElementById("metamask-sdk-menu-button").classList.add("selected");
-                    document.getElementById("metamask-sdk-menu").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'>
+          onfocus="
+            document.getElementById('metamask-sdk-menu-button').classList.add('selected')
+            document.getElementById('metamask-sdk-menu').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          "
+          onmouseover="
+            document.getElementById('metamask-sdk-menu-button').classList.add('selected')
+            document.getElementById('metamask-sdk-menu').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          ">
           <div>
             <h2>Connect to MetaMask</h2>
           </div>
@@ -37,28 +39,30 @@
         <a
           href="/embedded-wallets"
           id="embedded-wallets-button"
-          onfocus='
-                    document.getElementById("embedded-wallets-button").classList.add("selected");
-                    document.getElementById("embedded-wallets").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'
-          onmouseover='
-                    document.getElementById("embedded-wallets-button").classList.add("selected");
-                    document.getElementById("embedded-wallets").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'>
+          onfocus="
+            document.getElementById('embedded-wallets-button').classList.add('selected')
+            document.getElementById('embedded-wallets').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          "
+          onmouseover="
+            document.getElementById('embedded-wallets-button').classList.add('selected')
+            document.getElementById('embedded-wallets').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          ">
           <div>
             <h2>Create embedded wallets</h2>
           </div>
@@ -68,28 +72,30 @@
         <a
           href="/smart-accounts-kit"
           id="smart-accounts-kit-menu-button"
-          onfocus='
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.add("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.add("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'
-          onmouseover='
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.add("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.add("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'>
+          onfocus="
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.add('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.add('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          "
+          onmouseover="
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.add('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.add('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          ">
           <div>
             <h2>Create smart accounts</h2>
           </div>
@@ -99,28 +105,30 @@
         <a
           href="/agent-wallet"
           id="agent-wallet-menu-button"
-          onfocus='
-                    document.getElementById("agent-wallet-menu-button").classList.add("selected");
-                    document.getElementById("agent-wallet-menu").classList.add("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");'
-          onmouseover='
-                    document.getElementById("agent-wallet-menu-button").classList.add("selected");
-                    document.getElementById("agent-wallet-menu").classList.add("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("infura-menu-button").classList.remove("selected");
-                    document.getElementById("infura-menu").classList.remove("selected-menu");'>
+          onfocus="
+            document.getElementById('agent-wallet-menu-button').classList.add('selected')
+            document.getElementById('agent-wallet-menu').classList.add('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+          "
+          onmouseover="
+            document.getElementById('agent-wallet-menu-button').classList.add('selected')
+            document.getElementById('agent-wallet-menu').classList.add('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('infura-menu-button').classList.remove('selected')
+            document.getElementById('infura-menu').classList.remove('selected-menu')
+          ">
           <div>
             <h2>Create agent wallets</h2>
           </div>
@@ -130,28 +138,30 @@
         <a
           href="https://docs.infura.io/"
           id="infura-menu-button"
-          onfocus='
-                    document.getElementById("infura-menu-button").classList.add("selected");
-                    document.getElementById("infura-menu").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'
-          onmouseover='
-                    document.getElementById("infura-menu-button").classList.add("selected");
-                    document.getElementById("infura-menu").classList.add("selected-menu");
-                    document.getElementById("smart-accounts-kit-menu-button").classList.remove("selected");
-                    document.getElementById("smart-accounts-kit-menu").classList.remove("selected-menu");
-                    document.getElementById("metamask-sdk-menu-button").classList.remove("selected");
-                    document.getElementById("metamask-sdk-menu").classList.remove("selected-menu");
-                    document.getElementById("embedded-wallets-button").classList.remove("selected");
-                    document.getElementById("embedded-wallets").classList.remove("selected-menu");
-                    document.getElementById("agent-wallet-menu-button").classList.remove("selected");
-                    document.getElementById("agent-wallet-menu").classList.remove("selected-menu");'>
+          onfocus="
+            document.getElementById('infura-menu-button').classList.add('selected')
+            document.getElementById('infura-menu').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          "
+          onmouseover="
+            document.getElementById('infura-menu-button').classList.add('selected')
+            document.getElementById('infura-menu').classList.add('selected-menu')
+            document.getElementById('smart-accounts-kit-menu-button').classList.remove('selected')
+            document.getElementById('smart-accounts-kit-menu').classList.remove('selected-menu')
+            document.getElementById('metamask-sdk-menu-button').classList.remove('selected')
+            document.getElementById('metamask-sdk-menu').classList.remove('selected-menu')
+            document.getElementById('embedded-wallets-button').classList.remove('selected')
+            document.getElementById('embedded-wallets').classList.remove('selected-menu')
+            document.getElementById('agent-wallet-menu-button').classList.remove('selected')
+            document.getElementById('agent-wallet-menu').classList.remove('selected-menu')
+          ">
           <div>
             <h2>Extend and scale</h2>
           </div>

--- a/src/components/SnapsAPIReference/Parameters/Parameter/types.ts
+++ b/src/components/SnapsAPIReference/Parameters/Parameter/types.ts
@@ -25,7 +25,4 @@ export type UnionMethodParameter = CommonMethodParameter & {
 }
 
 export type MethodParameter =
-  | ObjectMethodParameter
-  | PrimitiveMethodParameter
-  | ArrayMethodParameter
-  | UnionMethodParameter
+  ObjectMethodParameter | PrimitiveMethodParameter | ArrayMethodParameter | UnionMethodParameter

--- a/src/pages/quickstart/index.jsx
+++ b/src/pages/quickstart/index.jsx
@@ -112,9 +112,8 @@ const StepNavigationMenu = ({ steps, currentStepIndex, onStepChange, scrollToSte
 async function loadFilesDirectly() {
   try {
     // Use dynamic import to load build-time generated files
-    const filesModule = await import(
-      '../../../.docusaurus/docusaurus-plugin-virtual-files/default/files.json'
-    )
+    const filesModule =
+      await import('../../../.docusaurus/docusaurus-plugin-virtual-files/default/files.json')
     return filesModule.default || filesModule
   } catch (e) {
     console.error('Could not load files directly:', e)

--- a/src/pages/tutorials/pnp-no-modal-multichain.mdx
+++ b/src/pages/tutorials/pnp-no-modal-multichain.mdx
@@ -458,9 +458,8 @@ export async function sendSolanaTransaction(ethProvider: IProvider): Promise<str
     const connection = new Connection('https://api.devnet.solana.com')
 
     // Import required modules for transaction
-    const { SystemProgram, Transaction, PublicKey, sendAndConfirmTransaction } = await import(
-      '@solana/web3.js'
-    )
+    const { SystemProgram, Transaction, PublicKey, sendAndConfirmTransaction } =
+      await import('@solana/web3.js')
 
     // Create a test recipient address
     const toAccount = new PublicKey('7C4jsPZpht1JHMWmwDF5ZEVfGSBViXCKbQEcm2GKHtKQ')


### PR DESCRIPTION
# Description

* Add a Content Security Policy section to the MetaMask Connect troubleshooting page explaining required directives (wss://mm-sdk-relay.api.cx.metamask.io in connect-src, img-src data:, etc.), example policies, symptoms, and compatibility notes for older packages. Also document provider.request preserving wallet JSON-RPC error.data since @metamask/connect-evm 2.1.0 (and err.rpcData on multichain), note that closing the modal rejects with EIP-1193 4001 since @metamask/connect-multichain 1.2.0, and update Flask/QR-flow troubleshooting and recommended upgrades.
* Standardizes formatting across Markdown, TypeScript, JSX, and HTML files to match repo linting and readability rules. It updates several doc tables and code snippets for consistency, tweaks product dropdown event handlers to use double-quoted attribute strings, and removes stale lockfile libc entries generated by dependency resolution.

## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and cosmetic formatting; no runtime application logic beyond HTML attribute quoting in the nav dropdown.
> 
> **Overview**
> **MetaMask Connect troubleshooting** gets a dedicated **Content Security Policy** section: required `connect-src` / `img-src` (and optional analytics, RPC, modal styling), example header and meta policies, a symptom-to-directive table, and notes for older packages that needed extra `connect-src` for QR fox icons. The QR-code CSP subsection is shortened to point at that guide, and the diagnostic checklist now calls out relay + `data:` CSP.
> 
> The same page documents **`error.data` / `err.rpcData`** on failed wallet calls (EVM 2.1.0+), **modal close as EIP-1193 `4001`** (multichain 1.2.0+), and a new **MetaMask Flask** entry (Flask RDNS detection and recommended package upgrades). Front matter keywords were updated for CSP and Flask.
> 
> Elsewhere the PR is mostly **formatting**: editorial spacing in `AGENTS.md`, table/type layout in Smart Accounts Kit reference (including versioned copies), column alignment in the SDK migration option table, Prettier-style tweaks in `Card.tsx`, Snaps types, quickstart/tutorial imports, and product nav `onfocus`/`onmouseover` handlers (double-quoted attributes). **`package-lock.json`** drops stale `libc` fields on optional `@parcel/watcher` Linux packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27177fcf714b86e14105334162c0e2014415ad85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->