### PR TITLE
fix: add missing await to signer.getAddress() in embedded-wallets examples

### DIFF
--- a/embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-account.mdx
+++ b/embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-account.mdx
@@ -8,6 +8,6 @@ const ethersProvider = new ethers.BrowserProvider(provider!)
 const signer = await ethersProvider.getSigner()
 
 // Get user's Ethereum public address
-const address = signer.getAddress()
+const address = await signer.getAddress()
 uiConsole(address)
 ```


### PR DESCRIPTION

## Description

The `signer.getAddress()` method in ethers v6 returns a `Promise<string>`, but examples in `embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-account.mdx` were missing `await`.

## Fix

Added: `await` before `signer.getAddress()`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an embedded-wallets code sample; no runtime or auth logic is modified.
> 
> **Overview**
> Updates the React Native **EVM get account** doc snippet so it matches **ethers v6**, where `signer.getAddress()` returns a `Promise<string>`.
> 
> The example now uses `await signer.getAddress()` (consistent with the existing `await ethersProvider.getSigner()` line) so copied code resolves the address instead of logging a Promise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc7ecfe580eb135634fbb6a434b6088ec33366f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->