### PR TITLE
fix: add missing await to signer.getAddress() in embedded-wallets get-balance example

### DIFF
--- a/embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-balance.mdx
+++ b/embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-balance.mdx
@@ -8,7 +8,7 @@ const ethersProvider = new ethers.BrowserProvider(provider!)
 const signer = await ethersProvider.getSigner()
 
 // Get user's Ethereum public address
-const address = signer.getAddress()
+const address = await signer.getAddress()
 
 // Get user's balance in ether
 // For ethers v5


### PR DESCRIPTION
# Description
Added `await` to `signer.getAddress()` in `embedded-wallets/connect-blockchain/_react-native-connect-blockchain/_evm-get-balance.mdx` to align with ethers v6 API.

Ref: Same issue as #3045 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a sample snippet; no runtime or product behavior is affected.
> 
> **Overview**
> Updates the React Native EVM **get balance** code sample so `signer.getAddress()` is called with **`await`**, matching ethers v6 (where it returns a Promise) and staying consistent with the other async calls in the same snippet (`getSigner`, `getBalance`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05dd262153cd26765470a00ca90d4d3663241321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->