### PR TITLE
Fix Ask AI by pointing DocSearch at the Agent Studio agent

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -649,8 +649,22 @@ const config = {
             buttonAriaLabel: 'Search or Ask AI',
           },
         },
+        // Ask AI is backed by the "MetaMask Documentation Help" agent in Algolia
+        // Agent Studio, not the retired standalone Ask AI service.
+        //
+        // NOTE: the `agentStudio: true` flag that switches @docsearch/react over
+        // to the Agent Studio completions endpoint deliberately does NOT live
+        // here. Docusaurus' theme-search-algolia Joi schema for `algolia.askAi`
+        // is a closed object and fails the build on unknown keys. It is injected
+        // by the SearchBar wrapper in src/theme/SearchBar/index.tsx instead
+        // (SearchBar lets props override themeConfig), and passed explicitly to
+        // DocSearchSidepanel in src/theme/Root.tsx.
+        //
+        // Without that flag, requests go to the legacy askai.algolia.com/chat
+        // backend, which cannot resolve an Agent Studio agent ID and returns
+        // "AI-201 Bad input".
         askAi: {
-          assistantId: 'REak1eiP5wfp',
+          assistantId: '10444a67-6975-454f-811c-95a9087f0474',
         },
         // Disable the standalone `/search/` results page. The Algolia DocSearch
         // modal still works; the dedicated page was being indexed as an orphan

--- a/src/scss/theme/_doc-search.scss
+++ b/src/scss/theme/_doc-search.scss
@@ -591,3 +591,162 @@ div[class*='DocSearch-Sidepanel'] {
     background-color: rgb(34, 93, 195) !important;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Ask AI code snippets
+
+   DocSearch renders fenced code blocks in Ask AI answers through its own marked
+   renderer, as:
+
+     <div class="DocSearch-CodeSnippet">
+       <button class="DocSearch-CodeSnippet-CopyButton">…</button>
+       <pre><code class="language-tsx">…</code></pre>
+     </div>
+
+   @docsearch/css ships no styling for that <pre>/<code> at all (only
+   `position: relative` on the wrapper and the copy button chrome), so answers
+   render as unstyled, low-contrast text with the copy button overlapping the
+   first line and long lines wrapping mid-token. These rules give snippets the
+   same treatment as the site's own code blocks (see theme/_prism-code.scss).
+
+   Note: DocSearch does not syntax highlight — the marked renderer only emits a
+   `language-*` class, with no Prism/highlight.js pass — so this is contrast,
+   typography and layout only, not token colors.
+
+   Targeted globally (not scoped to a container) so it applies to both the
+   search modal and the Ask AI sidepanel.
+   ───────────────────────────────────────────────────────────────────────────── */
+.DocSearch-CodeSnippet {
+  margin: 1.2rem 0;
+  border: 1px solid var(--general-gray-dark);
+  border-radius: 0.8rem;
+  background-color: var(--general-black-light);
+  overflow: hidden;
+  /* Keep long lines from forcing the modal/sidepanel wider. */
+  max-width: 100%;
+  min-width: 0;
+
+  pre {
+    /* Top padding reserves room for the absolutely positioned copy button. */
+    padding: 3.2rem 1.6rem 1.6rem !important;
+    margin: 0 !important;
+    background: none !important;
+    border: 0 !important;
+    /* Scroll long lines instead of wrapping mid-URL/mid-identifier. */
+    overflow-x: auto;
+    white-space: pre;
+  }
+
+  /* `color` needs the extra specificity + !important to beat the sidepanel
+     rules above, which force a near-black `code` colour in light mode — that
+     would be unreadable on this dark snippet background. */
+  pre code,
+  [data-theme='light'] div[class*='DocSearch-Sidepanel'] & pre code,
+  [data-theme='dark'] div[class*='DocSearch-Sidepanel'] & pre code {
+    display: block;
+    padding: 0 !important;
+    background: none !important;
+    border: 0 !important;
+    font-family: var(--inline-code-font) !important;
+    font-size: 1.3rem !important;
+    line-height: 1.6 !important;
+    color: var(--general-gray) !important;
+    tab-size: 2;
+  }
+
+  /* Copy button: sit on the snippet surface rather than over the code. */
+  .DocSearch-CodeSnippet-CopyButton {
+    inset-block-start: 0.6rem;
+    inset-inline-end: 0.6rem;
+    padding: 0.3rem 0.7rem;
+    gap: 0.3rem;
+    border: 1px solid var(--general-gray-dark);
+    border-radius: 0.5rem;
+    background-color: var(--general-black);
+    color: var(--general-gray);
+    font-family: var(--ifm-font-family-base);
+    font-size: 1.1rem;
+    line-height: 1.4;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+      color: var(--general-white);
+      border-color: var(--general-gray);
+    }
+
+    svg {
+      height: 1.3rem;
+      width: 1.3rem;
+      margin-inline-end: 0;
+    }
+  }
+
+  /* Thin scrollbar so the horizontal scroller is unobtrusive. */
+  pre::-webkit-scrollbar {
+    height: 0.6rem;
+  }
+
+  pre::-webkit-scrollbar-thumb {
+    border-radius: 0.6rem;
+    background-color: var(--general-gray-dark);
+  }
+
+  pre::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+}
+
+/* Inline `code` in Ask AI answers (outside a snippet block) — keep it legible
+   in both themes rather than inheriting the washed-out default. */
+.DocSearch-AskAiScreen-Response,
+.DocSearch-AskAiScreen-MessageContent {
+  code {
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.4rem;
+    background-color: var(--ifm-code-background);
+    font-family: var(--inline-code-font);
+    font-size: 0.92em;
+  }
+
+  /* Block code is handled by .DocSearch-CodeSnippet above; undo the inline
+     treatment rather than using `:not(pre code)`, which needs a Selectors L4
+     complex `:not()` (Safari 16.4+). */
+  pre code {
+    padding: 0;
+    border-radius: 0;
+    background-color: transparent;
+    font-size: 1.3rem;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   From PR #3053's sibling PR (#3052, branch `ai-fixes`): DocSearch button
+   spacing and modal stacking. Kept here rather than in a separate
+   src/theme/SearchBar/styles.css so all DocSearch styling stays in one file.
+
+   #3052 also set `--docsearch-primary-color` / `--docsearch-text-color` on
+   `:root`. Deliberately not copied: this file already overrides both, scoped
+   per colour mode (see the top of this file, where those exact two lines are
+   commented out on purpose). Re-adding them at `:root` would leak a purple
+   primary to DocSearch surfaces rendered outside `.DocSearch`.
+   ───────────────────────────────────────────────────────────────────────────── */
+.DocSearch-Button {
+  margin: 0;
+  transition: all var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+}
+
+/* Lift the modal above the fixed navbar. */
+.DocSearch-Container {
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+}
+
+/* Note: `.DocSearch-Button-Key:first-child` in custom.scss sets
+   `padding: 0 0.35rem !important` (it also appends the "K" label), so #3052's
+   blanket `padding: 0` only affects any non-first key. */
+.DocSearch-Button-Key {
+  padding: 0;
+}

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -73,6 +73,16 @@ interface AlgoliaThemeConfig {
   }
 }
 
+/**
+ * The Ask AI assistant is an Algolia Agent Studio agent, so DocSearch must be
+ * pointed at the Agent Studio completions endpoint rather than the legacy
+ * askai.algolia.com/chat backend (which returns "AI-201 Bad input" for an Agent
+ * Studio agent ID). The equivalent flag for the search modal is injected by the
+ * SearchBar wrapper in src/theme/SearchBar/index.tsx — it can't live in
+ * themeConfig.algolia.askAi, which Docusaurus validates with a closed schema.
+ */
+const ASK_AI_USES_AGENT_STUDIO = true
+
 export const MetamaskProviderContext = createContext<IMetamaskProviderContext>({
   token: undefined,
   projects: {},
@@ -312,6 +322,7 @@ export default function Root({ children }: { children: ReactElement }) {
             apiKey={algolia.apiKey}
             assistantId={algolia.assistantId || algolia.askAi?.assistantId}
             indexName={algolia.indexName}
+            agentStudio={ASK_AI_USES_AGENT_STUDIO}
             panel={{
               translations: {
                 newConversationScreen: {

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import SearchBar from '@theme-original/SearchBar'
+import type SearchBarType from '@theme/SearchBar'
+import type { WrapperProps } from '@docusaurus/types'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+
+type Props = WrapperProps<typeof SearchBarType>
+
+/**
+ * Ask AI in the DocSearch modal is served by the "MetaMask Documentation Help"
+ * agent in Algolia Agent Studio, which sits behind a different endpoint from the
+ * retired standalone Ask AI service:
+ *
+ *   agentStudio: false -> https://askai.algolia.com/chat (+ /chat/token)          [legacy]
+ *   agentStudio: true  -> https://{appId}.algolia.net/agent-studio/1/agents/{id}/completions
+ *
+ * `agentStudio` cannot be set in `themeConfig.algolia.askAi` because
+ * theme-search-algolia validates that object with a closed Joi schema and fails the
+ * build on unknown keys ("algolia.askAi.agentStudio is not allowed"). SearchBar lets
+ * props override themeConfig, so the flag is injected here instead. Sending an Agent
+ * Studio agent ID to the legacy endpoint fails with "AI-201 Bad input".
+ *
+ * Note: `askAi` is read from themeConfig rather than from props. Navbar/Content
+ * renders <SearchBar /> with no props — the themeConfig merge happens *inside* the
+ * original SearchBar, i.e. downstream of this wrapper — so `props.askAi` is
+ * undefined here. Anything a caller does pass still wins, matching upstream.
+ *
+ * Once Docusaurus' schema accepts `agentStudio` (or DocSearch v5 defaults to Agent
+ * Studio), this wrapper can be deleted and the flag moved into docusaurus.config.js.
+ *
+ * KNOWN UPSTREAM BUG (reported to Algolia): a correct answer streams and renders, then
+ * a spurious second request fails with 422 "Conversation must end with a user message
+ * or resolved tool results" and DocSearch paints a "Chat error" banner above the
+ * answer. Agent Studio does not set `providerExecuted: true` on tool events in its
+ * ai-sdk-5 stream, so `lastAssistantMessageIsCompleteWithToolCalls` — which DocSearch
+ * passes to the AI SDK unconditionally — thinks the client owns the tool call and
+ * auto-resubmits a conversation ending in an assistant message. Not caused by this
+ * config; there is no supported way to disable the auto-resubmit. Fixed upstream by
+ * either Agent Studio emitting the flag or DocSearch gating `sendAutomaticallyWhen`.
+ */
+export default function SearchBarWrapper(props: Props): JSX.Element {
+  const { siteConfig } = useDocusaurusContext()
+  const themeConfigAskAi = (siteConfig?.themeConfig?.algolia as { askAi?: object } | undefined)
+    ?.askAi
+  const askAi = (props as { askAi?: object }).askAi ?? themeConfigAskAi
+
+  if (!askAi) {
+    return <SearchBar {...props} />
+  }
+
+  return <SearchBar {...props} askAi={{ ...askAi, agentStudio: true }} />
+}


### PR DESCRIPTION
# Description

Ask AI was failing on every question with "AI-201 Bad input".

Root cause: @docsearch/react v4 has two Ask AI transports, selected by an `agentStudio` flag:

  agentStudio: false (default) -> https://askai.algolia.com/chat
                                 (legacy standalone Ask AI)
  agentStudio: true            -> https://{appId}.algolia.net/agent-studio/1
                                 /agents/{id}/completions (Agent Studio)

Our assistant lives in Algolia Agent Studio (the published "MetaMask Documentation Help" agent), but the flag was never set, so the site was posting to the retired legacy backend. That backend cannot resolve an Agent Studio agent ID and returns AI-201. The configured assistantId (REak1eiP5wfp) was also a stale legacy Ask AI ID rather than the Agent Studio agent ID.

This is why Ask AI worked when tested from the Algolia dashboard but not on the docs site - the dashboard was exercising Agent Studio directly.

Changes:

1. docusaurus.config.js - askAi.assistantId updated to the Agent Studio agent ID.
2. src/theme/SearchBar/index.tsx (new) - swizzled wrapper that injects `agentStudio: true` into askAi for the search modal.
3. src/theme/Root.tsx - passes `agentStudio` to DocSearchSidepanel.

Why the flag isn't just in docusaurus.config.js:
@docusaurus/theme-search-algolia@3.10.2 validates themeConfig.algolia.askAi with a closed Joi schema (assistantId, indexName, apiKey, appId, searchParameters.facetFilters, suggestedQuestions). Adding `agentStudio` there fails the build with `"algolia.askAi.agentStudio" is not allowed`. SearchBar lets props override themeConfig and forwards the whole askAi object to DocSearchModal untouched, so the wrapper is the supported way to get the flag through. Both files carry comments explaining this and noting the wrapper can be deleted once Docusaurus' schema accepts `agentStudio` (or DocSearch v5 makes Agent Studio the default).

Note the wrapper reads askAi from themeConfig rather than from props: Navbar/Content renders <SearchBar /> with no props, and the themeConfig merge happens inside the original SearchBar, downstream of the wrapper.

Known upstream bug, not introduced here: after this fix answers stream and render correctly, but a spurious second request fires and fails with "422 Conversation must end with a user message or resolved tool results", which DocSearch paints as a red "Chat error" banner above the correct answer. Agent Studio does not set `providerExecuted: true` on tool events in its ai-sdk-5 compatibility stream (verified - tool-input-start, tool-input-available and tool-output-available all omit it), so DocSearch's unconditional `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` concludes the client owns the server-side search tool call and auto-resubmits a conversation ending in an assistant message, which the API correctly rejects. There is no supported option to disable that auto-resubmit and @docsearch/react@5.0.5 still sets it unconditionally, so a version bump does not help. Reported to Algolia; tracking separately rather than patching node_modules.

Verification: `POST {appId}.algolia.net/agent-studio/1/agents/{agentId} /completions?stream=true&compatibilityMode=ai-sdk-5` with no request to askai.algolia.com/chat/token.


## Issue(s) fixed

<!-- Include the issue number that this PR fixes. -->

Fixes #

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

## Checklist

<!-- Complete the following checklist before merging your PR. -->

- [ ] If this PR updates or adds documentation content that changes or adds technical meaning, it has received an approval from an engineer or DevRel from the relevant team.
- [ ] If this PR updates or adds documentation content, it has received an approval from a technical writer.

## External contributor checklist

<!-- If you are an external contributor (outside of the MetaMask organization), complete the following checklist. -->

- [ ] I've read the [contribution guidelines](https://github.com/MetaMask/metamask-docs/blob/main/CONTRIBUTING.md).
- [ ] I've created a new issue (or assigned myself to an existing issue) describing what this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site Algolia/Ask AI configuration and theme CSS only; no auth, data, or payment paths.
> 
> **Overview**
> Fixes Ask AI failing with **AI-201 Bad input** by targeting the **MetaMask Documentation Help** Agent Studio agent instead of the retired `askai.algolia.com` backend.
> 
> **Config:** `themeConfig.algolia.askAi.assistantId` is updated to the Agent Studio agent UUID, with comments noting why `agentStudio` cannot live in `docusaurus.config.js` (Docusaurus’ closed Joi schema rejects unknown `askAi` keys).
> 
> **Runtime wiring:** A new swizzled **`SearchBar`** wrapper merges `agentStudio: true` into `askAi` for the search modal, and **`Root.tsx`** passes the same flag to **`DocSearchSidepanel`**, so both entry points hit `{appId}.algolia.net/agent-studio/.../completions`.
> 
> **UI:** **`_doc-search.scss`** adds styling for Ask AI fenced code (`.DocSearch-CodeSnippet`), inline `code` in answers, DocSearch button spacing, and a higher modal `z-index` above the navbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a956174196772ad7452590d792c5bb52956c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->